### PR TITLE
Alpha 1: add token policy and executable governance baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Today, this public draft already contains:
 - core contracts
 - a minimal kernel
 - a governance pack
+- an explicit token policy
 - a quality baseline
 - a first learnings path
 - a reusable starter-pack slice
@@ -147,9 +148,10 @@ If this is your first time here, start with:
 1. `docs/00-overview.md`
 2. `docs/architecture.md`
 3. `docs/governance.md`
-4. `docs/quality.md`
-5. `examples/`
-6. `starter-pack/`
+4. `docs/token-policy.md`
+5. `docs/quality.md`
+6. `examples/`
+7. `starter-pack/`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Today, this public draft already contains:
 - a minimal kernel
 - a governance pack
 - an explicit token policy
+- a small executable governance baseline
 - a quality baseline
 - a first learnings path
 - a reusable starter-pack slice
@@ -164,3 +165,16 @@ The next steps are:
 - convert pilot learnings into framework improvements
 - start using AletheIA to improve AletheIA itself
 - strengthen adoption only after the core and pilots are solid
+
+---
+
+## Minimal governance baseline
+
+Alpha 1 now includes a small executable governance check:
+
+- `bash scripts/check-governance.sh`
+
+This is intentionally modest.
+
+It does not try to be a heavy enforcement layer yet.
+It only proves that AletheIA can move from governance prose into a small technical baseline.

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -8,6 +8,7 @@ The public repository is organized around three blocks:
    - contracts
    - engine
    - policies
+   - token discipline
    - examples
    - tests
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -40,6 +40,22 @@ Ele é um **policy pack específico para software development**, dentro do guard
 
 ---
 
+## Relação com token discipline
+
+O `Governance Pack` diz quando o trabalho pode ou não pode seguir.
+
+A `Token Policy` complementa isso dizendo:
+
+- quanto contexto deve entrar
+- em que momento ele deve entrar
+- quando expansão de contexto é justificável
+
+Leitura recomendada em conjunto:
+
+- `docs/token-policy.md`
+
+---
+
 ## Por que isso importa
 
 Sem governança explícita, a IA pode:

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -41,6 +41,11 @@ This phase is not the moment for:
 
 The goal is to make the framework inspectable, teachable, and minimally enforceable.
 
+Current Alpha 1 baseline artifacts now include:
+
+- `docs/token-policy.md`
+- `scripts/check-governance.sh`
+
 ---
 
 ## Alpha 2 — Real Pilots + Self-Application

--- a/docs/token-policy.md
+++ b/docs/token-policy.md
@@ -1,0 +1,274 @@
+# AletheIA Token Policy
+
+## Goal
+
+This document makes token discipline explicit inside AletheIA.
+
+In simple terms:
+
+the framework should not read everything by default.
+It should read only what is needed for the current step, with a visible budget and a reason.
+
+---
+
+## Why token policy exists
+
+Without explicit token discipline, AI-assisted workflows tend to drift into:
+
+- oversized cold boots
+- unnecessary file reads
+- repeated context expansion
+- expensive handoffs
+- weak explainability about why so much context was pulled in
+
+That creates three kinds of waste:
+
+1. **cost waste**
+2. **attention waste**
+3. **decision waste**
+
+AletheIA treats token usage as an operating concern, not only a pricing concern.
+
+---
+
+## Principle
+
+> Context should be pulled in proportion to the decision being made.
+
+This means:
+
+- simple tasks should stay small
+- ambiguity should justify expansion
+- handoffs should carry only the minimum durable context
+- large context should be an explicit choice, not the default behavior
+
+---
+
+## The five token moments
+
+### 1. Cold boot
+
+The first context load for a task or session.
+
+Goal:
+- understand the task
+- identify the dominant front
+- decide whether deeper exploration is necessary
+
+Rule:
+- start with the smallest context that can still support a safe first decision
+
+Typical contents:
+- task brief
+- one source-of-truth artifact
+- the most relevant file or contract
+
+---
+
+### 2. Exploration
+
+Additional context loaded to reduce ambiguity before execution.
+
+Goal:
+- understand dependencies
+- inspect neighboring files
+- check existing patterns
+
+Rule:
+- exploration must be justified by a concrete uncertainty
+
+Good reasons:
+- contract is unclear
+- routing depends on another module
+- prior decision may constrain the change
+
+Bad reasons:
+- “maybe it will be useful”
+- “read everything just in case”
+
+---
+
+### 3. Expansion
+
+Context added because the task crosses a boundary or becomes structurally more complex.
+
+Goal:
+- support a bigger decision without losing control
+
+Rule:
+- expansion should happen only when the task clearly stopped being local
+
+Typical triggers:
+- contract change
+- multi-front impact
+- governance-sensitive change
+- decision that requires triad-style arbitration
+
+---
+
+### 4. Delegation
+
+Context prepared for a subagent, worker, or parallel lane.
+
+Goal:
+- give enough context for execution
+- avoid sending the whole parent thread by reflex
+
+Rule:
+- delegated context must be narrower than the main thread whenever possible
+
+Good delegation pack:
+- objective
+- scope
+- files owned
+- constraints
+- expected output
+
+---
+
+### 5. Handoff
+
+Context preserved for future continuation.
+
+Goal:
+- make resumption possible without replaying the full history
+
+Rule:
+- handoff should preserve decisions, boundaries, and next steps — not transcript bulk
+
+Good handoff content:
+- what changed
+- why it changed
+- what remains open
+- risks or caveats
+- relevant files
+
+---
+
+## Budget model
+
+This first alpha does not enforce token counting at runtime.
+
+Instead, it defines a **policy budget model** that future implementations can interpret.
+
+### Budget levels
+
+#### Minimal
+
+Use when:
+- task is local
+- scope is clear
+- decision is low risk
+
+Expected behavior:
+- read only the core artifact(s)
+- avoid large neighboring exploration
+
+#### Moderate
+
+Use when:
+- task is still bounded, but ambiguity exists
+- one or two adjacent modules matter
+
+Expected behavior:
+- allow targeted exploration
+- keep expansion local
+
+#### Extended
+
+Use when:
+- task crosses fronts
+- contract or governance impact is real
+- more structured arbitration is needed
+
+Expected behavior:
+- allow broader context packs
+- document why expansion happened
+
+---
+
+## Policy expectations by moment
+
+| Moment | Default budget | Escalation trigger |
+|---|---|---|
+| Cold boot | Minimal | task unclear or source-of-truth insufficient |
+| Exploration | Minimal -> Moderate | unresolved ambiguity after first read |
+| Expansion | Moderate | cross-boundary or structural change |
+| Delegation | Minimal per worker | subtask cannot be executed safely without extra context |
+| Handoff | Minimal | only expand if future resumption would otherwise be unsafe |
+
+---
+
+## Practical rules
+
+### Rule 1 — Do not front-load context
+
+Do not read a large set of files before knowing whether they matter.
+
+### Rule 2 — Expansion needs a reason
+
+Every meaningful context expansion should be explainable in one sentence.
+
+### Rule 3 — Handoff is not transcript replay
+
+Preserve decisions and next steps, not the full narrative.
+
+### Rule 4 — Delegation should reduce, not duplicate, context
+
+Subagents should not receive the full parent scope unless absolutely necessary.
+
+### Rule 5 — Token discipline supports governance
+
+Oversized context is not only inefficient; it also makes decision quality harder to audit.
+
+---
+
+## Relationship to the rest of AletheIA
+
+This policy connects directly to:
+
+- `Context Pack`
+- `Decision Record`
+- `Execution Scope`
+- `Handoff Record`
+- `Learning Record`
+
+In future iterations, token policy can become:
+
+- a governance check
+- a warning surface
+- a technical enforcement baseline
+
+But in Alpha 1, its main role is to make context discipline explicit and reusable.
+
+---
+
+## What Alpha 1 should prove with this policy
+
+By adding token policy, AletheIA should show that:
+
+- context discipline is intentional
+- large context is not the silent default
+- handoffs can stay small and durable
+- delegation can be scoped instead of copied wholesale
+- governance and token usage can reinforce each other
+
+---
+
+## Future evolution
+
+Later versions may add:
+
+- executable budget checks
+- context-pack size warnings
+- policy trace for expansion reasons
+- project-specific token extensions
+
+Alpha 1 does not need all of that.
+
+It only needs to prove that token discipline can be:
+
+- explicit
+- teachable
+- reusable
+- aligned with the operating loop

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "check:governance": "bash scripts/check-governance.sh",
     "test:contracts": "tsx tests/contracts/test-contracts.ts",
     "test:goldens": "tsx tests/goldens/test-goldens.ts",
     "test:e2e": "tsx tests/e2e/test-e2e.ts",

--- a/scripts/check-governance.sh
+++ b/scripts/check-governance.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+failures=0
+
+pass() {
+  printf 'PASS: %s\n' "$1"
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+check_file() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    pass "required file present -> $path"
+  else
+    fail "required file missing -> $path"
+  fi
+}
+
+check_dir() {
+  local path="$1"
+  if [[ -d "$path" ]]; then
+    pass "required directory present -> $path"
+  else
+    fail "required directory missing -> $path"
+  fi
+}
+
+check_text() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+  if grep -q "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail "$label"
+  fi
+}
+
+echo "== AletheIA governance baseline check =="
+
+for dir in engine schemas policies examples tests starter-pack docs scripts; do
+  check_dir "$dir"
+done
+
+for file in \
+  README.md \
+  docs/00-overview.md \
+  docs/governance.md \
+  docs/quality.md \
+  docs/roadmap-alpha.md \
+  docs/token-policy.md \
+  policies/aletheia-development-governance.v1.json \
+  scripts/check-governance.sh \
+  package.json
+do
+  check_file "$file"
+done
+
+check_text "README.md" "docs/token-policy.md" "README links token policy in reading order"
+check_text "docs/governance.md" "docs/token-policy.md" "governance doc references token policy"
+check_text "docs/roadmap-alpha.md" "token policy" "roadmap includes token policy"
+check_text "package.json" "test:contracts" "package exposes contract tests"
+check_text "package.json" "test:goldens" "package exposes golden tests"
+check_text "package.json" "test:e2e" "package exposes e2e tests"
+check_text "package.json" "test:learnings" "package exposes learning tests"
+
+if grep -R -n -E "__PLACEHOLDER__|YOUR_PROJECT|TODO_RELEASE" \
+  README.md docs policies starter-pack 2>/dev/null >/tmp/aletheia-governance-placeholders.txt; then
+  fail "unexpected release placeholders found (see /tmp/aletheia-governance-placeholders.txt)"
+else
+  pass "no release placeholder markers found in key public surfaces"
+fi
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+  printf 'Governance baseline failed with %s issue(s).\n' "$failures" >&2
+  exit 1
+fi
+
+echo "Governance baseline passed."


### PR DESCRIPTION
## Summary
- add `docs/token-policy.md` as the first explicit Alpha 1 token discipline artifact
- add `scripts/check-governance.sh` as a small executable governance baseline
- wire the new Alpha 1 baseline into `README.md`, `docs/governance.md`, `docs/00-overview.md`, `docs/roadmap-alpha.md`, and `package.json`

## Why
This PR closes the first small Alpha 1 governance-hardening package while also validating that the branch structure is working in practice for real framework evolution.

## Validation
- `git diff --check`
- `bash scripts/check-governance.sh`

## Notes
- intentionally small baseline
- does not introduce a heavy policy engine
- keeps Alpha 1 proportional to the current implementation
