### PR TITLE
Alpha 1: align baseline narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Today, this public draft already contains:
 - a governance pack
 - an explicit token policy
 - a small executable governance baseline
+- a lightweight durable decision discipline
+- an explicit boundary between behavioral and technical enforcement
 - a quality baseline
 - a first learnings path
 - a reusable starter-pack slice
@@ -162,7 +164,7 @@ If this is your first time here, start with:
 
 The next steps are:
 
-- harden the Alpha 1 governance baseline
+- consolidate the Alpha 1 governance baseline
 - keep validating the Crisis Monitor pilot
 - convert pilot learnings into framework improvements
 - start using AletheIA to improve AletheIA itself

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -9,6 +9,8 @@ The public repository is organized around three blocks:
    - engine
    - policies
    - token discipline
+   - durable reasoning
+   - enforcement clarity
    - examples
    - tests
 
@@ -16,7 +18,7 @@ The public repository is organized around three blocks:
    - reusable operating guides
    - checklists
    - templates
-   - branch, context, and quality discipline
+   - branch, context, quality, and decision discipline
 
 3. **pilot materials**
    - why the framework emerged

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -140,6 +140,7 @@ Across all three alphas, AletheIA should preserve a few boundaries:
    - token policy
    - technical governance baseline
    - durable decision discipline
+   - enforcement boundary clarity
 2. continue validating the Crisis Monitor pilot
 3. convert pilot learnings into framework updates
 4. start the self-application loop


### PR DESCRIPTION
## Summary
- align `README.md`, `docs/00-overview.md`, and `docs/roadmap-alpha.md` with the actual Alpha 1 baseline already present on `main`
- make the public narrative explicitly reflect durable decision discipline and enforcement-boundary clarity
- tighten the near-term framing so Alpha 1 reads as a consolidation step instead of an unfinished vague baseline

## Why
After several small Alpha 1 increments were merged successfully, the public docs needed a short consolidation pass so the repository narrative would match the real state of the framework.

## Validation
- `bash scripts/check-governance.sh`

## Notes
- editorial/structural pass only
- no new engine behavior
- intended to keep Alpha 1 coherent before leaning harder into Alpha 2
