### PR TITLE
Alpha 2: add pilot-to-framework conversion loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The first explicit bridge into Alpha 2 is:
 
 - `docs/self-application.md`
 - `docs/pilot-crisis-monitor.md`
+- `docs/pilot-conversion.md`
 
 This document explains how AletheIA should increasingly use its own operating logic to guide changes in the AletheIA repository itself.
 

--- a/docs/pilot-conversion.md
+++ b/docs/pilot-conversion.md
@@ -1,0 +1,223 @@
+# AletheIA Pilot-to-Framework Conversion
+
+## Goal
+
+This document explains how a real pilot learning should become a concrete improvement in the framework.
+
+In simple terms:
+
+the pilot should not end as an anecdote.
+It should create a path from field evidence to reusable framework change.
+
+---
+
+## Why this matters
+
+Real pilots generate useful signals, but those signals can be lost in three ways:
+
+- they stay trapped in product-specific language
+- they stay trapped in retrospective notes
+- they never become an explicit framework artifact
+
+Alpha 2 should prove that AletheIA can do better than that.
+
+It should show a repeatable path from:
+
+`pilot observation -> learning -> framework improvement`
+
+---
+
+## The conversion question
+
+When a pilot teaches something useful, the key question is:
+
+**what kind of framework change does this learning justify?**
+
+Not every pilot learning should become the same kind of change.
+
+Sometimes it should become:
+
+- a doc
+- a starter-pack guide
+- a template
+- a governance clarification
+- a policy pack refinement
+- a test or executable baseline improvement
+
+The job of conversion is to choose the smallest reusable form that preserves the learning.
+
+---
+
+## The minimum conversion loop
+
+### 1. Observe a real friction or useful pattern
+
+Something happened in the pilot that matters.
+
+Examples:
+
+- users did not understand why approval was needed
+- audit and chat were telling different stories
+- a pilot slice proved a smaller-first strategy works better
+
+### 2. Write the learning explicitly
+
+Do not jump straight from observation to repo change.
+
+First capture:
+
+- what happened
+- why it mattered
+- what seems reusable
+
+### 3. Classify the learning
+
+Ask which kind of reusable change it really is.
+
+### 4. Apply the smallest justified framework change
+
+Prefer:
+
+- the smallest artifact
+- the clearest scope
+- the least speculative generalization
+
+### 5. Validate and merge
+
+The change should be visible, reviewable, and justified.
+
+---
+
+## Conversion targets
+
+### 1. Documentation artifact
+
+Use when the learning clarifies:
+
+- a principle
+- a boundary
+- a pattern
+- a distinction
+
+Examples:
+
+- token discipline
+- enforcement boundaries
+- durable decision discipline
+
+### 2. Starter-pack artifact
+
+Use when the learning should help future adopters operate better.
+
+Examples:
+
+- a guide
+- a checklist
+- a template
+
+### 3. Governance refinement
+
+Use when the learning changes:
+
+- policy interpretation
+- governance wording
+- expectations about review/block/escalation
+
+### 4. Technical baseline refinement
+
+Use when the learning justifies:
+
+- a check
+- a warning
+- a test
+- a small executable baseline
+
+### 5. Pilot write-up refinement
+
+Use when the learning mostly improves:
+
+- how the field result is explained
+- what the pilot proved
+- what remains product-specific vs reusable
+
+---
+
+## What not to do
+
+### Do not overgeneralize from one product detail
+
+A product-specific behavior is not automatically a framework principle.
+
+### Do not leave the learning untyped
+
+If the learning is useful, decide what kind of artifact it should become.
+
+### Do not jump to heavy mechanism first
+
+A lightweight doc or template may be the right first conversion.
+
+---
+
+## Good Alpha 2 signs
+
+Alpha 2 is going well when:
+
+- a real pilot learning can be traced to a merged framework change
+- the framework change is smaller than the pilot itself
+- the reusable part is separated from the product residue
+- the repo shows a growing chain of pilot -> learning -> improvement
+
+---
+
+## Crisis Monitor example
+
+The Crisis Monitor pilot already produced reusable lessons such as:
+
+- start with low-risk explicability improvements
+- validate decision and audit together
+- prefer controlled reversible actions in early proof
+
+Those lessons already influenced framework artifacts like:
+
+- governance clarity
+- durable decision discipline
+- enforcement-boundary clarification
+
+This is exactly the kind of loop Alpha 2 is trying to make explicit.
+
+---
+
+## Relationship to self-application
+
+Self-application explains how the framework should govern its own evolution.
+
+Pilot conversion explains how field learnings should enter that evolution.
+
+Together, they make the Alpha 2 loop concrete:
+
+`pilot -> learning -> conversion -> framework improvement`
+
+---
+
+## What Alpha 2 should prove with this
+
+By adding the pilot conversion loop, AletheIA should show that:
+
+- real pilots do not remain isolated stories
+- framework maturity can be fed by disciplined field evidence
+- repo evolution can stay small, explicit, and traceable
+
+---
+
+## Future evolution
+
+Later versions may add:
+
+- explicit pilot-to-artifact mapping tables
+- scorecards for conversion quality
+- links between learnings and merged PRs
+- domain-specific conversion patterns
+
+Alpha 2 does not need that yet.
+
+It only needs a visible and repeatable conversion path.

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -87,6 +87,7 @@ Current Alpha 2 bridge artifacts now include:
 
 - `docs/self-application.md`
 - `docs/pilot-crisis-monitor.md`
+- `docs/pilot-conversion.md`
 
 ---
 

--- a/docs/self-application.md
+++ b/docs/self-application.md
@@ -167,6 +167,10 @@ Later versions may connect self-application more directly to:
 - pilot-to-framework scorecards
 - project extension patterns
 
+See also:
+
+- `docs/pilot-conversion.md`
+
 Alpha 2 does not need all of that on day one.
 
 It only needs to make the loop visible and repeatable.


### PR DESCRIPTION
## Summary
- add `docs/pilot-conversion.md`
- make the conversion path from pilot learning to framework artifact explicit
- connect the conversion loop to the README, roadmap, and self-application doc

## Why
After making the real pilot and self-application loop explicit, Alpha 2 still needed the conversion step itself to be visible. This PR makes the core Alpha 2 loop concrete: `pilot -> learning -> conversion -> framework improvement`.

## Validation
- `bash scripts/check-governance.sh`

## Notes
- lightweight by design
- no new engine behavior
- strengthens the internal logic of Alpha 2 without over-expanding the framework
