### PR TITLE
Alpha 2: align bridge narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Today, this public draft already contains:
 - a quality baseline
 - a first learnings path
 - a reusable starter-pack slice
+- an explicit Alpha 2 bridge for self-application, pilot conversion, and project extension
 
 ---
 
@@ -155,8 +156,12 @@ If this is your first time here, start with:
 5. `docs/durable-decisions.md`
 6. `docs/enforcement-boundaries.md`
 7. `docs/quality.md`
-8. `examples/`
-9. `starter-pack/`
+8. `docs/self-application.md`
+9. `docs/pilot-crisis-monitor.md`
+10. `docs/pilot-conversion.md`
+11. `docs/project-extension-pattern.md`
+12. `examples/`
+13. `starter-pack/`
 
 ---
 
@@ -164,10 +169,10 @@ If this is your first time here, start with:
 
 The next steps are:
 
-- consolidate the Alpha 1 governance baseline
-- keep validating the Crisis Monitor pilot
-- convert pilot learnings into framework improvements
-- start using AletheIA to improve AletheIA itself
+- consolidate the Alpha 2 bridge now that its four pillars are explicit
+- keep validating the Crisis Monitor pilot and adjacent real slices
+- keep converting pilot learnings into framework improvements
+- keep using AletheIA to improve AletheIA itself
 - strengthen adoption only after the core and pilots are solid
 
 ---

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -25,6 +25,7 @@ The public repository is organized around three blocks:
    - how it was extracted from Crisis Monitor
    - what was learned in the real test field
    - how pilot learnings return into framework evolution
+   - how self-application, pilot conversion, and project extension stay connected
 
 The Crisis Monitor pilot is the first concrete example of this bridge.
 
@@ -33,3 +34,11 @@ The key idea is simple:
 AletheIA should be reusable outside the original pilot while still preserving the lessons learned from that pilot.
 
 That reuse depends on an explicit boundary between the framework core and each project's local extension layer.
+
+
+At this point, Alpha 2 is organized around four explicit bridge artifacts:
+
+- `docs/self-application.md`
+- `docs/pilot-crisis-monitor.md`
+- `docs/pilot-conversion.md`
+- `docs/project-extension-pattern.md`

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -90,6 +90,8 @@ Current Alpha 2 bridge artifacts now include:
 - `docs/pilot-conversion.md`
 - `docs/project-extension-pattern.md`
 
+Together, these four artifacts define how AletheIA learns from pilots, improves itself, and preserves the boundary between reusable core and local project context.
+
 ---
 
 ## Alpha 3 — Adoption + Ecosystem
@@ -144,12 +146,11 @@ Across all three alphas, AletheIA should preserve a few boundaries:
 
 ## Near-term priority order
 
-1. finish strengthening Alpha 1 baseline
-   - token policy
-   - technical governance baseline
-   - durable decision discipline
-   - enforcement boundary clarity
-2. continue validating the Crisis Monitor pilot
+1. consolidate the Alpha 2 bridge
+   - self-application
+   - Crisis Monitor pilot
+   - pilot conversion
+   - project extension pattern
+2. continue validating the Crisis Monitor pilot and nearby real slices
 3. convert pilot learnings into framework updates
-4. start the self-application loop
-5. improve adoption and ecosystem only after the core and pilots are solid
+4. strengthen adoption and ecosystem only after the core and pilots are solid


### PR DESCRIPTION
## Summary
- align README, overview, and roadmap with the current Alpha 2 bridge
- promote the four explicit Alpha 2 artifacts into reading order and near-term framing
- make the public narrative reflect the real maturity already present on main

## Validation
- bash scripts/check-governance.sh