### PR TITLE
Alpha 3: add existing-project adoption guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The next steps are:
 - keep converting pilot learnings into framework improvements
 - keep using AletheIA to improve AletheIA itself
 - begin the first Alpha 3 adoption artifacts without losing the core/pilot discipline
-- define the future Alpha 4 direction for orchestrated handoffs between agents
+- define the future Alpha 4 direction for orchestrated, model-agnostic handoffs between agents
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,9 @@ If this is your first time here, start with:
 9. `docs/pilot-crisis-monitor.md`
 10. `docs/pilot-conversion.md`
 11. `docs/project-extension-pattern.md`
-12. `examples/`
-13. `starter-pack/`
+12. `docs/apply-to-existing-project.md`
+13. `examples/`
+14. `starter-pack/`
 
 ---
 
@@ -173,7 +174,7 @@ The next steps are:
 - keep validating the Crisis Monitor pilot and adjacent real slices
 - keep converting pilot learnings into framework improvements
 - keep using AletheIA to improve AletheIA itself
-- strengthen adoption only after the core and pilots are solid
+- begin the first Alpha 3 adoption artifacts without losing the core/pilot discipline
 
 ---
 
@@ -185,8 +186,13 @@ The first explicit bridge into Alpha 2 is:
 - `docs/pilot-crisis-monitor.md`
 - `docs/pilot-conversion.md`
 - `docs/project-extension-pattern.md`
+- `docs/apply-to-existing-project.md`
 
 Together, these documents explain how AletheIA should evolve itself, learn from pilots, and preserve a clear boundary between framework core and local project extensions.
+
+The first adoption-facing guide after this bridge is:
+
+- `docs/apply-to-existing-project.md`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ The next steps are:
 - keep converting pilot learnings into framework improvements
 - keep using AletheIA to improve AletheIA itself
 - begin the first Alpha 3 adoption artifacts without losing the core/pilot discipline
+- define the future Alpha 4 direction for orchestrated handoffs between agents
 
 ---
 
@@ -186,7 +187,6 @@ The first explicit bridge into Alpha 2 is:
 - `docs/pilot-crisis-monitor.md`
 - `docs/pilot-conversion.md`
 - `docs/project-extension-pattern.md`
-- `docs/apply-to-existing-project.md`
 
 Together, these documents explain how AletheIA should evolve itself, learn from pilots, and preserve a clear boundary between framework core and local project extensions.
 

--- a/docs/apply-to-existing-project.md
+++ b/docs/apply-to-existing-project.md
@@ -1,0 +1,188 @@
+# Applying AletheIA to an Existing Project
+
+## Goal
+
+This guide explains how to introduce AletheIA into a project that already exists.
+
+In simple terms:
+
+You do not need to rebuild your project around the framework.
+You only need to add enough structure to make AI-assisted work more explicit, reviewable, and reusable.
+
+---
+
+## Why start this way
+
+Most teams will not adopt AletheIA on a blank repository.
+
+They will adopt it inside a project that already has:
+
+- a product in flight
+- existing docs
+- local conventions
+- technical debt
+- mixed human and AI workflows
+
+That means adoption should begin with the smallest useful layer, not with a full rewrite.
+
+---
+
+## Recommended adoption order
+
+### 1. Choose one real slice
+
+Start with one flow, one feature area, or one repeated kind of work.
+
+Good first candidates usually are:
+
+- a small AI-assisted feature flow
+- a review or approval flow
+- a task type that suffers from context sprawl
+- a part of the project where decisions are not clearly recorded
+
+Avoid starting with the biggest or riskiest part of the system.
+
+### 2. Define the local extension boundary
+
+Before changing anything, make explicit:
+
+- what is framework core
+- what is project-local
+- what language belongs only to this project
+
+See also:
+
+- `docs/project-extension-pattern.md`
+
+### 3. Add the minimum operating layer
+
+For a first adoption pass, this usually means:
+
+- a small work-item discipline
+- explicit scope boundaries
+- a validation expectation
+- a place to preserve durable learnings
+
+You do not need full ceremony for everything.
+You need enough ceremony to stop important work from becoming invisible.
+
+### 4. Add the minimum governance baseline
+
+Use the smallest checks that make the work safer and more reviewable.
+
+Examples:
+
+- a governance checklist
+- a decision template
+- a validation rule
+- a small executable baseline if the repo is ready for it
+
+### 5. Pilot first, then generalize
+
+Do not generalize from theory alone.
+
+Run the framework in one real slice.
+Then ask:
+
+- what helped?
+- what was too heavy?
+- what remained local?
+- what should become reusable?
+
+That is the start of the conversion loop.
+
+See also:
+
+- `docs/pilot-conversion.md`
+
+---
+
+## The minimum adoption set
+
+If a team wants the smallest practical AletheIA starting point, begin with:
+
+1. `docs/00-overview.md`
+2. `docs/governance.md`
+3. `docs/token-policy.md`
+4. `docs/durable-decisions.md`
+5. `docs/project-extension-pattern.md`
+6. one starter-pack guide or template that matches the first pilot
+
+This is often enough to begin without pretending the whole framework is already fully installed.
+
+---
+
+## What to keep local at first
+
+At the beginning, keep these things local unless there is a strong reason to generalize them:
+
+- product vocabulary
+- file ownership rules
+- branch conventions
+- provider-specific rules
+- local assistant behavior
+- team-specific rituals
+
+AletheIA should help make those things explicit.
+It should not force them to become public framework rules too early.
+
+---
+
+## What to extract first
+
+The first things worth extracting into reusable framework artifacts are usually:
+
+- recurring decision patterns
+- validation patterns
+- governance boundaries
+- small learnings that reduce repeated mistakes
+- starter-pack templates that help future work start cleaner
+
+---
+
+## Good first-adoption signs
+
+A first adoption is going well when:
+
+- one real slice is clearer than before
+- decisions are easier to review
+- the team knows what stayed local and what became reusable
+- AI-assisted work feels more explicit, not more theatrical
+
+---
+
+## What not to do
+
+Do not start by:
+
+- rewriting the whole repo around AletheIA
+- turning every small edit into ceremony
+- universalizing product-specific rules too early
+- promising adoption before one real slice has worked
+
+The framework should enter the project proportionally.
+
+---
+
+## Relationship to Alpha 3
+
+Alpha 3 is about making AletheIA easier to adopt.
+
+This guide is one of the first adoption-facing artifacts because it answers a practical question:
+
+**How do I start if my project already exists?**
+
+That question matters more than abstract completeness.
+
+---
+
+## Suggested next reading
+
+After this guide, continue with:
+
+1. `docs/project-extension-pattern.md`
+2. `docs/self-application.md`
+3. `docs/pilot-conversion.md`
+4. `starter-pack/README.md`
+
+If you already know the slice you want to pilot, go directly into the matching starter-pack guide or template.

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -103,6 +103,7 @@ Includes:
 - better onboarding
 - stronger contributor guidance
 - stronger starter-pack
+- clearer guidance for applying AletheIA in an existing project
 - cleaner release structure
 - reusable domain governance packs
 - tighter release hygiene
@@ -146,11 +147,9 @@ Across all three alphas, AletheIA should preserve a few boundaries:
 
 ## Near-term priority order
 
-1. consolidate the Alpha 2 bridge
-   - self-application
-   - Crisis Monitor pilot
-   - pilot conversion
-   - project extension pattern
-2. continue validating the Crisis Monitor pilot and nearby real slices
-3. convert pilot learnings into framework updates
-4. strengthen adoption and ecosystem only after the core and pilots are solid
+1. open the first Alpha 3 adoption artifacts
+   - applying AletheIA to an existing project
+   - stronger onboarding path
+2. keep the Alpha 2 bridge coherent while adoption grows
+3. continue validating the Crisis Monitor pilot and nearby real slices
+4. convert pilot learnings into framework updates

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -135,13 +135,13 @@ AletheIA should become easier to:
 ## Alpha 4 — Orchestrated Handoffs & Multi-Agent Continuity
 
 Focus:
-- make handoffs between agents explicit, reusable, and increasingly automatable
+- make handoffs between agents explicit, reusable, model-agnostic, and increasingly automatable
 
 Includes:
 - structured inter-agent handoff contracts
 - handoff generation patterns from real work items
 - clearer separation between human-facing summaries and agent-facing restart packages
-- stronger continuity between Codex, Claude Code, and other agent contexts
+- model-agnostic continuity patterns that do not depend on one LLM or coding tool
 - starter-pack guidance for cross-agent execution flows
 - reusable patterns for passing scope, validation, risks, and next action across agents
 
@@ -153,6 +153,7 @@ By the end of Alpha 4, AletheIA should already show that:
 - one agent can stop at its boundary and prepare the next agent's work clearly
 - cross-agent continuity can happen without relying on hidden thread memory
 - handoff artifacts can be generated in a repeatable way from real project work
+- the handoff structure can work across different LLMs and agent shells without changing its core meaning
 
 ### Notes
 
@@ -171,6 +172,7 @@ Potential first artifacts for this phase may include:
 - agent-facing handoff templates
 - project-level handoff conventions
 - automated or semi-automated handoff creation from completed work items
+- execution-scope fields such as allowed files, forbidden files, allowed data, semantic guardrails, acceptance criteria, and expected response format
 
 ---
 

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -132,6 +132,48 @@ AletheIA should become easier to:
 
 ---
 
+## Alpha 4 — Orchestrated Handoffs & Multi-Agent Continuity
+
+Focus:
+- make handoffs between agents explicit, reusable, and increasingly automatable
+
+Includes:
+- structured inter-agent handoff contracts
+- handoff generation patterns from real work items
+- clearer separation between human-facing summaries and agent-facing restart packages
+- stronger continuity between Codex, Claude Code, and other agent contexts
+- starter-pack guidance for cross-agent execution flows
+- reusable patterns for passing scope, validation, risks, and next action across agents
+
+### What Alpha 4 must prove
+
+By the end of Alpha 4, AletheIA should already show that:
+
+- handoffs can be produced as compact restart packages instead of ad-hoc prompts
+- one agent can stop at its boundary and prepare the next agent's work clearly
+- cross-agent continuity can happen without relying on hidden thread memory
+- handoff artifacts can be generated in a repeatable way from real project work
+
+### Notes
+
+Alpha 4 is not about adding more agents for their own sake.
+It is about making agent boundaries safer and more productive.
+
+The key move in Alpha 4 is turning:
+
+`work in one agent -> explicit handoff artifact -> reliable continuation in another agent`
+
+into a reusable operating pattern.
+
+Potential first artifacts for this phase may include:
+
+- handoff generation guidance
+- agent-facing handoff templates
+- project-level handoff conventions
+- automated or semi-automated handoff creation from completed work items
+
+---
+
 ## Cross-Alpha principles
 
 Across all three alphas, AletheIA should preserve a few boundaries:
@@ -153,3 +195,4 @@ Across all three alphas, AletheIA should preserve a few boundaries:
 2. keep the Alpha 2 bridge coherent while adoption grows
 3. continue validating the Crisis Monitor pilot and nearby real slices
 4. convert pilot learnings into framework updates
+5. shape Alpha 4 around orchestrated handoffs and cross-agent continuity

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -14,3 +14,10 @@ The goal is to provide a practical baseline for:
 - durable decisions
 
 Start here if you want the operating method around the framework, not only the technical core.
+
+
+## Adoption note
+
+If you are starting from an existing repository rather than a blank setup, read:
+
+- `docs/apply-to-existing-project.md`

--- a/starter-pack/guides/handoff-guide.md
+++ b/starter-pack/guides/handoff-guide.md
@@ -32,3 +32,51 @@ AletheIA should eventually distinguish more clearly between:
 - an agent-facing restart package
 
 That distinction becomes important when work moves from one agent to another and the next agent needs a compact, structured continuation artifact rather than a long narrative recap.
+
+
+## Narrative handoff vs operational handoff
+
+Not every handoff has the same job.
+
+### Narrative handoff
+
+Useful when the next reader is mainly trying to understand:
+
+- what happened
+- what remains open
+- what risks exist
+
+This is often enough for humans.
+
+### Operational handoff
+
+Useful when the next reader is another agent expected to continue execution with low ambiguity.
+
+In that case, the handoff should behave more like a restart contract than a recap.
+
+It should ideally make explicit:
+
+- dominant frontier
+- reason for the cross-boundary handoff
+- allowed files
+- forbidden files
+- allowed data or contracts already available
+- semantic guardrails
+- acceptance criteria
+- expected response format
+- what is explicitly out of scope
+
+This reduces drift when one agent stops at its boundary and another takes over.
+
+## Model-agnostic requirement
+
+AletheIA should not define handoffs that only work for one tool, one shell, or one LLM family.
+
+A good inter-agent handoff should preserve its meaning even if the next executor is:
+
+- Codex
+- Claude Code
+- another coding agent
+- a future workflow built on a different provider
+
+The artifact may reference local project conventions, but its structure should stay provider-agnostic.

--- a/starter-pack/guides/handoff-guide.md
+++ b/starter-pack/guides/handoff-guide.md
@@ -22,3 +22,13 @@ It is a compact restart package.
 - blocked decisions
 - missing approvals
 - learnings that change the next step
+
+
+## Future evolution
+
+AletheIA should eventually distinguish more clearly between:
+
+- a human-facing summary
+- an agent-facing restart package
+
+That distinction becomes important when work moves from one agent to another and the next agent needs a compact, structured continuation artifact rather than a long narrative recap.


### PR DESCRIPTION
## Summary
- add the first Alpha 3 adoption-facing guide for applying AletheIA to an existing project
- wire the new guide into the README, roadmap, and starter-pack
- define the future Alpha 4 direction for orchestrated, model-agnostic agent handoffs
- clarify in the handoff guide the difference between narrative handoffs and operational inter-agent restart packages

## Validation
- bash scripts/check-governance.sh