### PR TITLE
Alpha 3: add getting started onboarding path

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,20 +149,21 @@ Today, this public draft already contains:
 
 If this is your first time here, start with:
 
-1. `docs/00-overview.md`
-2. `docs/architecture.md`
-3. `docs/governance.md`
-4. `docs/token-policy.md`
-5. `docs/durable-decisions.md`
-6. `docs/enforcement-boundaries.md`
-7. `docs/quality.md`
-8. `docs/self-application.md`
-9. `docs/pilot-crisis-monitor.md`
-10. `docs/pilot-conversion.md`
-11. `docs/project-extension-pattern.md`
-12. `docs/apply-to-existing-project.md`
-13. `examples/`
-14. `starter-pack/`
+1. `docs/getting-started.md`
+2. `docs/00-overview.md`
+3. `docs/architecture.md`
+4. `docs/governance.md`
+5. `docs/token-policy.md`
+6. `docs/durable-decisions.md`
+7. `docs/enforcement-boundaries.md`
+8. `docs/quality.md`
+9. `docs/self-application.md`
+10. `docs/pilot-crisis-monitor.md`
+11. `docs/pilot-conversion.md`
+12. `docs/project-extension-pattern.md`
+13. `docs/apply-to-existing-project.md`
+14. `examples/`
+15. `starter-pack/`
 
 ---
 
@@ -174,7 +175,7 @@ The next steps are:
 - keep validating the Crisis Monitor pilot and adjacent real slices
 - keep converting pilot learnings into framework improvements
 - keep using AletheIA to improve AletheIA itself
-- begin the first Alpha 3 adoption artifacts without losing the core/pilot discipline
+- keep opening Alpha 3 adoption artifacts without losing the core/pilot discipline
 - define the future Alpha 4 direction for orchestrated, model-agnostic handoffs between agents
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,120 @@
+# Getting Started with AletheIA
+
+## Goal
+
+This guide is the shortest practical path to start using AletheIA.
+
+It is meant for readers who do not want to read the whole repository first.
+
+---
+
+## Choose your starting mode
+
+Most readers should start in one of these modes:
+
+### 1. I want to understand the framework
+
+Read in this order:
+
+1. `docs/00-overview.md`
+2. `docs/governance.md`
+3. `docs/token-policy.md`
+4. `docs/durable-decisions.md`
+5. `docs/enforcement-boundaries.md`
+
+### 2. I want to try the framework quickly
+
+Read and run in this order:
+
+1. `README.md`
+2. `examples/`
+3. `tests/`
+4. `bash scripts/check-governance.sh`
+
+### 3. I want to apply it to an existing project
+
+Read in this order:
+
+1. `docs/apply-to-existing-project.md`
+2. `docs/project-extension-pattern.md`
+3. `docs/pilot-conversion.md`
+4. `starter-pack/README.md`
+
+---
+
+## The smallest useful mental model
+
+AletheIA helps turn this:
+
+`prompt -> output -> execution`
+
+into this:
+
+`intent -> context -> decision -> execution -> validation -> learning`
+
+If you understand that shift, you already understand the core idea of the framework.
+
+---
+
+## What to look at first in the repository
+
+If you only have a few minutes, look at:
+
+- `README.md`
+- `docs/00-overview.md`
+- `docs/governance.md`
+- `examples/hello-world/`
+- `scripts/check-governance.sh`
+
+That gives you a compact sense of:
+
+- the problem AletheIA solves
+- the operating model
+- the governance baseline
+- the smallest runnable proof
+
+---
+
+## First practical moves
+
+If you want to test AletheIA in practice, start with one of these:
+
+### Option A — inspect the public alpha
+
+- read the overview and roadmap
+- inspect the starter-pack
+- run the lightweight examples and tests
+
+### Option B — pilot one real slice in your own project
+
+- choose one bounded slice
+- define the local extension boundary
+- apply the minimum operating layer
+- validate what helped and what remained local
+
+See also:
+
+- `docs/apply-to-existing-project.md`
+
+---
+
+## What not to do first
+
+Do not start by:
+
+- trying to automate the entire framework at once
+- copying every artifact into your repo before one real pilot exists
+- assuming your local rules are already reusable framework rules
+
+AletheIA works best when adoption starts small and becomes more explicit through use.
+
+---
+
+## Suggested next step after this guide
+
+After `getting-started.md`, choose one of these paths:
+
+- **understand the core** -> `docs/00-overview.md`
+- **pilot in an existing project** -> `docs/apply-to-existing-project.md`
+- **inspect the operating method** -> `starter-pack/README.md`
+- **understand the roadmap** -> `docs/roadmap-alpha.md`

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -101,6 +101,7 @@ Focus:
 
 Includes:
 - better onboarding
+- a clearer getting-started path
 - stronger contributor guidance
 - stronger starter-pack
 - clearer guidance for applying AletheIA in an existing project
@@ -194,6 +195,7 @@ Across all three alphas, AletheIA should preserve a few boundaries:
 1. open the first Alpha 3 adoption artifacts
    - applying AletheIA to an existing project
    - stronger onboarding path
+   - explicit getting-started guide
 2. keep the Alpha 2 bridge coherent while adoption grows
 3. continue validating the Crisis Monitor pilot and nearby real slices
 4. convert pilot learnings into framework updates

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -20,4 +20,5 @@ Start here if you want the operating method around the framework, not only the t
 
 If you are starting from an existing repository rather than a blank setup, read:
 
+- `docs/getting-started.md`
 - `docs/apply-to-existing-project.md`


### PR DESCRIPTION
## Summary
- add a getting-started guide for the shortest onboarding path into AletheIA
- wire the new guide into the README reading order and starter-pack adoption note
- reflect the stronger onboarding path in the Alpha 3 roadmap

## Validation
- bash scripts/check-governance.sh