### PR TITLE
Alpha 5: add structured risk inference proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ The next steps are:
 - keep using AletheIA to improve AletheIA itself
 - keep opening Alpha 3 adoption artifacts without losing the core/pilot discipline
 - define the future Alpha 4 direction for orchestrated, model-agnostic handoffs between agents
+- keep future Alpha 5 work framed as evidence-oriented inference for higher-risk tasks
 
 ---
 
@@ -194,6 +195,18 @@ Together, these documents explain how AletheIA should evolve itself, learn from 
 The first adoption-facing guide after this bridge is:
 
 - `docs/apply-to-existing-project.md`
+
+---
+
+## Future direction after Alpha 4
+
+AletheIA may eventually need a further phase focused on structured risk inference before execution in higher-risk tasks.
+
+That future direction should stay evidence-oriented and conditional, rather than claiming strong formal verification that the framework does not yet provide.
+
+See also:
+
+- `docs/structured-risk-inference.md`
 
 ---
 

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -177,6 +177,48 @@ Potential first artifacts for this phase may include:
 
 ---
 
+## Alpha 5 — Structured Risk Inference & Evidence-Oriented Validation
+
+Focus:
+- make higher-risk decisions more reviewable before execution through structured, evidence-oriented inference
+
+Includes:
+- a conditional inference step for higher-risk work
+- compact inference artifacts with premises, assumptions, invariants, risks, unknowns, and test gaps
+- better connection between semantic risk and validation design
+- stronger rationale preservation across high-stakes handoffs
+- experimental use in code and semantic-risk scenarios before broader expansion
+
+### What Alpha 5 must prove
+
+By the end of Alpha 5, AletheIA should already show that:
+
+- higher-risk changes can be reasoned about more explicitly before execution
+- semantic risks can be surfaced without pretending to prove formal correctness
+- evidence, assumptions, and unknowns can be captured in a reusable artifact
+- risk-oriented suggested tests can improve validation quality
+- the capability can remain selective instead of becoming universal ceremony
+
+### Notes
+
+Alpha 5 should not be framed as formal verification.
+It should be framed as structured, reviewable inference for cases where raw confidence is not enough.
+
+The key move in Alpha 5 is inserting a conditional step such as:
+
+`intent -> context -> decision -> [if triggered: inference] -> execution -> validation -> learning`
+
+This phase should begin as an experimental capability, not a mandatory step for every workflow.
+
+Potential first artifacts for this phase may include:
+
+- `docs/structured-risk-inference.md`
+- a starter-pack template for inference artifacts
+- trigger guidance for when the capability should run
+- pilot scenarios focused on refactors, patch review, or semantic regression risk
+
+---
+
 ## Cross-Alpha principles
 
 Across all three alphas, AletheIA should preserve a few boundaries:
@@ -200,3 +242,4 @@ Across all three alphas, AletheIA should preserve a few boundaries:
 3. continue validating the Crisis Monitor pilot and nearby real slices
 4. convert pilot learnings into framework updates
 5. shape Alpha 4 around orchestrated handoffs and cross-agent continuity
+6. frame Alpha 5 as experimental structured risk inference rather than strong formal verification

--- a/docs/structured-risk-inference.md
+++ b/docs/structured-risk-inference.md
@@ -1,0 +1,284 @@
+# Structured Risk Inference (Experimental)
+
+## Status
+
+Proposed
+
+## Goal
+
+This document describes a possible future AletheIA capability for improving decision quality before execution.
+
+In simple terms:
+
+it adds a structured, evidence-oriented inference step for cases where the decision itself needs more semantic scrutiny before code or workflow execution proceeds.
+
+---
+
+## Why this matters
+
+AletheIA already helps structure:
+
+- intent
+- context
+- decision
+- execution
+- validation
+- learning
+
+It is also growing stronger in:
+
+- adoption
+- inter-agent continuity
+- project extension boundaries
+
+But one gap still remains in higher-risk work:
+
+**how do we make the reasoning behind a decision more explicit before execution starts?**
+
+Today, many AI-assisted systems can answer:
+
+- what to do
+- how to execute
+
+But they still struggle to answer in a structured, reviewable way:
+
+- why this change is likely correct
+- where it may fail
+- what evidence supports the claim
+- which unknowns still remain
+- what tests would reduce the main risk
+
+---
+
+## Problem
+
+LLMs can propose changes and partially validate them, but several failure modes remain common:
+
+- semantic inferences stay implicit
+- reasoning may sound correct while still being incomplete
+- test suites may not cover the real risk surface
+- handoffs may preserve the instruction but lose the rationale
+- confidence may look stronger than the underlying evidence justifies
+
+The result is often:
+
+- fragile confidence
+- reactive validation
+- hidden risk in apparently safe changes
+
+---
+
+## Non-goals
+
+This capability should **not** try to:
+
+- replace automated tests
+- prove formal correctness
+- eliminate empirical validation
+- act as an oracle of truth
+- run on every small task by default
+
+This is not formal verification.
+
+It is a structured way of making risk-bearing inference more reviewable.
+
+---
+
+## Core concept
+
+The proposed capability is:
+
+**structured risk inference**
+
+This is a conditional step between `decision` and `execution` that produces a compact artifact describing:
+
+- the hypothesis being made
+- the evidence or premises supporting that hypothesis
+- the assumptions not yet demonstrated
+- impacted paths
+- invariants that must continue to hold
+- major risks
+- unknowns
+- test gaps
+- suggested tests
+- confidence level and basis
+
+---
+
+## Updated flow
+
+The flow should remain proportional.
+
+This means inference is **not** universal.
+
+### Default flow
+
+`intent -> context -> decision -> execution -> validation -> learning`
+
+### Triggered flow
+
+`intent -> context -> decision -> [if triggered: inference] -> execution -> validation -> learning`
+
+---
+
+## Trigger conditions
+
+Structured risk inference should be triggered only when the work justifies it.
+
+Typical triggers include:
+
+- changes that cross multiple modules or layers
+- sensitive business or domain rules
+- security or governance impact
+- refactors with invisible regression risk
+- tests that appear insufficient for the semantic risk
+- low confidence from the executing agent
+- high-stakes inter-agent handoff
+
+---
+
+## Artifact contract (v1)
+
+```json
+{
+  "hypothesis": "Expected behavior after the change",
+  "premises": [
+    "Observed evidence from file or contract X"
+  ],
+  "assumptions": [
+    "Assumption not fully demonstrated"
+  ],
+  "impacted_paths": [
+    "Flow A -> function X -> effect Y"
+  ],
+  "invariants": [
+    "Rule that must remain true"
+  ],
+  "risks": [
+    {
+      "description": "Potential semantic regression",
+      "likelihood": "low | medium | high",
+      "impact": "low | medium | high"
+    }
+  ],
+  "unknowns": [
+    "What could not be verified"
+  ],
+  "test_gaps": [
+    "Scenario not covered today"
+  ],
+  "suggested_tests": [
+    "Test that would validate the critical path"
+  ],
+  "confidence_level": "low | medium | high",
+  "confidence_basis": "Why this confidence level was assigned"
+}
+```
+
+---
+
+## Relationship to Alpha 4 handoffs
+
+Alpha 4 improves inter-agent continuity.
+
+Alpha 5 would strengthen that continuity by making the rationale more portable.
+
+Before:
+
+- context
+- instruction
+- scope
+
+After:
+
+- context
+- instruction
+- scope
+- structured risk inference artifact
+
+That makes it easier for the next agent to:
+
+- understand the rationale
+- challenge assumptions
+- refine the validation plan
+- avoid redoing the same uncertainty blindly
+
+---
+
+## Use cases
+
+### 1. Patch review
+
+Compare likely before/after behavior without relying only on raw intuition.
+
+### 2. Refactoring risk analysis
+
+Surface likely regressions that tests may miss.
+
+### 3. Test generation guidance
+
+Suggest tests based on risk concentration rather than coverage alone.
+
+### 4. Multi-agent continuity
+
+Preserve semantic rationale across handoffs, not only execution instructions.
+
+---
+
+## Risks
+
+This capability also carries risks of its own:
+
+- false sense of rigor
+- increased token and latency cost
+- overuse in simple tasks
+- artifacts that become verbose without adding clarity
+- confidence labels that appear more precise than they really are
+
+---
+
+## Mitigations
+
+To keep the capability proportional:
+
+- use explicit triggers
+- limit the depth of analysis
+- keep the prompt question bounded
+- always expose unknowns and assumptions
+- never treat the artifact as a substitute for empirical validation
+- avoid numeric confidence unless it is truly grounded
+
+---
+
+## Success criteria
+
+Alpha 5 would be successful if it:
+
+- improves risk identification before execution
+- improves the quality of suggested tests in risky changes
+- reduces unexpected regressions in pilot scenarios
+- improves handoff clarity in high-stakes cases
+- is used selectively rather than becoming universal ceremony
+
+---
+
+## Open questions
+
+- how should inference quality be evaluated?
+- how can verbosity stay bounded without losing value?
+- what trigger threshold is practical?
+- how should this connect to observability and post-execution signals?
+- when should a risk inference become durable learning?
+
+---
+
+## Recommended starting position
+
+If this enters the roadmap, it should start as:
+
+- experimental
+- selective
+- evidence-oriented
+- scoped primarily to code and semantic-risk tasks
+
+It should not start as a mandatory core phase for every workflow.


### PR DESCRIPTION
## Summary
- add Alpha 5 to the roadmap with a more precise framing than 'verifiable inference'
- position the phase as structured, evidence-oriented inference for higher-risk tasks
- add an experimental doc describing triggers, artifact contract, risks, and mitigations

## Validation
- bash scripts/check-governance.sh