### PR TITLE
Alpha 3: strengthen starter-pack with project extension template

### DIFF
--- a/docs/apply-to-existing-project.md
+++ b/docs/apply-to-existing-project.md
@@ -53,6 +53,7 @@ Before changing anything, make explicit:
 See also:
 
 - `docs/project-extension-pattern.md`
+- `starter-pack/templates/project-extension-template.md`
 
 ### 3. Add the minimum operating layer
 
@@ -107,6 +108,7 @@ If a team wants the smallest practical AletheIA starting point, begin with:
 4. `docs/durable-decisions.md`
 5. `docs/project-extension-pattern.md`
 6. one starter-pack guide or template that matches the first pilot
+7. `starter-pack/templates/project-extension-template.md` if the local extension boundary needs to be documented explicitly
 
 This is often enough to begin without pretending the whole framework is already fully installed.
 

--- a/docs/project-extension-pattern.md
+++ b/docs/project-extension-pattern.md
@@ -227,7 +227,6 @@ By adding the project extension pattern, AletheIA should show that:
 
 Later versions may add:
 
-- a starter-pack template for project extensions
 - explicit project-extension examples
 - mapping between local rules and reusable core rules
 - more than one pilot to compare extension patterns across projects

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -22,3 +22,10 @@ If you are starting from an existing repository rather than a blank setup, read:
 
 - `docs/getting-started.md`
 - `docs/apply-to-existing-project.md`
+
+
+## New template
+
+If you are adopting AletheIA inside a real project and need to make the local layer explicit, use:
+
+- `starter-pack/templates/project-extension-template.md`

--- a/starter-pack/templates/project-extension-template.md
+++ b/starter-pack/templates/project-extension-template.md
@@ -1,0 +1,139 @@
+# Project Extension Template
+
+## Goal
+
+Use this template when applying AletheIA to a specific project that needs local rules on top of the reusable framework core.
+
+This template helps keep one thing explicit:
+
+**what is framework core, and what is project-local?**
+
+---
+
+## Project identity
+
+### Project name
+
+### Short description
+
+### Current stage
+
+Examples:
+- pilot
+- production
+- migration
+- internal tool
+
+---
+
+## Local context
+
+Describe the local context that matters for operation.
+
+### Product or domain context
+
+### Team context
+
+### Repo context
+
+### Relevant constraints
+
+Examples:
+- compliance
+- provider lock-in already present in the project
+- multi-team ownership
+- legacy architecture
+
+---
+
+## Local operating layer
+
+Describe the local rules that sit on top of AletheIA core.
+
+### Thread or workstream taxonomy
+
+### Ownership boundaries
+
+### Branch conventions
+
+### Local escalation rules
+
+### Local handoff expectations
+
+---
+
+## What remains framework core
+
+List the AletheIA pieces that should remain reusable and unchanged in spirit.
+
+Examples:
+- governance concepts
+- token discipline
+- durable decision discipline
+- validation expectations
+- pilot conversion logic
+
+---
+
+## What is explicitly project-local
+
+List the rules, terms, and patterns that should stay local unless they later prove reusable.
+
+Examples:
+- product vocabulary
+- assistant behavior
+- repo-specific ownership maps
+- provider-specific rules
+- domain-specific risk policies
+
+---
+
+## Initial pilot slice
+
+### Candidate slice
+
+### Why this slice first
+
+### What success looks like
+
+### What stays out of scope
+
+---
+
+## Reuse checkpoint
+
+After the first pilot or iteration, answer:
+
+### What generalized well?
+
+### What stayed local?
+
+### What should become a framework artifact?
+
+### What should remain a project extension?
+
+---
+
+## Validation baseline
+
+Describe the minimum proof expected for work in this project extension.
+
+Examples:
+- governance baseline
+- lint
+- smoke
+- targeted tests
+- human review
+
+---
+
+## Next recommended artifact
+
+Choose the next artifact this project most likely needs.
+
+Examples:
+- task brief template usage
+- handoff template usage
+- quality gate checklist
+- project-specific handoff convention
+- durable decision record


### PR DESCRIPTION
## Summary
- add a reusable project-extension template to the starter-pack
- wire the template into the existing-project adoption guide
- update the project-extension doc now that a concrete starter-pack artifact exists

## Validation
- bash scripts/check-governance.sh