### PR TITLE
Alpha 4: add agent handoff template

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ That future direction should stay evidence-oriented and conditional, rather than
 See also:
 
 - `docs/agent-handoffs.md`
+- `starter-pack/templates/agent-handoff-template.md`
 - `docs/structured-risk-inference.md`
 
 ---

--- a/docs/agent-handoffs.md
+++ b/docs/agent-handoffs.md
@@ -177,4 +177,5 @@ AletheIA should preserve the handoff as a reusable operating pattern.
 
 - `starter-pack/guides/handoff-guide.md`
 - `starter-pack/templates/handoff-template.md`
+- `starter-pack/templates/agent-handoff-template.md`
 - `docs/project-extension-pattern.md`

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -37,3 +37,10 @@ If you are adopting AletheIA inside a real project and need to make the local la
 If you are thinking about cross-agent continuity and operational restart packages, read:
 
 - `docs/agent-handoffs.md`
+
+
+## Alpha 4 template
+
+For operational handoffs between agents, use:
+
+- `starter-pack/templates/agent-handoff-template.md`

--- a/starter-pack/templates/agent-handoff-template.md
+++ b/starter-pack/templates/agent-handoff-template.md
@@ -1,0 +1,115 @@
+# Agent Handoff Template
+
+## Goal
+
+Use this template when one agent is stopping at its boundary and another agent is expected to continue execution.
+
+This is not a transcript.
+It is a compact restart package.
+
+---
+
+## Handoff type
+
+### Receiving agent role
+
+### Dominant frontier
+
+### Cross-boundary reason
+
+Explain why this work is moving to another agent instead of continuing in the current one.
+
+---
+
+## Current status
+
+### Status
+
+Examples:
+- ready for continuation
+- blocked on validation
+- blocked on decision
+- partial implementation ready for next agent
+
+### What was completed
+
+### What remains pending
+
+---
+
+## Execution boundary
+
+### Allowed files
+
+List the files the next agent may change.
+
+### Forbidden files
+
+List the files or layers that are out of scope.
+
+### Explicitly out of scope
+
+List expansions or reinterpretations the next agent should avoid.
+
+---
+
+## Available context
+
+### Allowed data or contracts
+
+List the data, APIs, contracts, or assumptions the next agent may safely rely on.
+
+### Relevant files
+
+List the files that matter most for resuming work.
+
+---
+
+## Semantic guardrails
+
+Describe what meaning, behavior, or product intent must be preserved.
+
+---
+
+## Acceptance criteria
+
+Describe what must be true for the handoff target to count as complete.
+
+---
+
+## Validation expectation
+
+Describe the minimum proof expected before closure.
+
+Examples:
+- lint
+- smoke
+- targeted tests
+- human review
+- audit check
+
+---
+
+## Risks and unknowns
+
+### Main risks
+
+### Unknowns still open
+
+---
+
+## Expected response format
+
+Describe how the receiving agent should report back.
+
+Examples:
+- changed files
+- what was validated
+- what remains blocked
+- recommended next action
+
+---
+
+## Next action
+
+State the next action the receiving agent should take first.


### PR DESCRIPTION
## Summary
- add the operational agent-handoff template to the starter-pack
- wire the template into the new Alpha 4 agent-handoffs doc
- expose the template through README and starter-pack entrypoints

## Validation
- bash scripts/check-governance.sh