### PR TITLE
Alpha 4: consolidate handoff baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Today, this public draft already contains:
 - a reusable starter-pack slice
 - an explicit Alpha 2 bridge for self-application, pilot conversion, and project extension
 - initial Alpha 3 adoption artifacts for getting started, existing-project application, contribution guidance, and starter-pack reuse
+- the first concrete Alpha 4 handoff assets for model-agnostic restart packages between agents
 
 ---
 
@@ -166,7 +167,9 @@ If this is your first time here, start with:
 14. `CONTRIBUTING.md`
 15. `starter-pack/`
 16. `starter-pack/templates/project-extension-template.md`
-17. `examples/`
+17. `docs/agent-handoffs.md`
+18. `starter-pack/templates/agent-handoff-template.md`
+19. `examples/`
 
 ---
 
@@ -174,11 +177,11 @@ If this is your first time here, start with:
 
 The next steps are:
 
-- keep expanding Alpha 3 adoption artifacts without losing the core/pilot discipline
+- consolidate the first Alpha 4 handoff baseline without losing the Alpha 3 adoption gains
 - keep validating the Crisis Monitor pilot and adjacent real slices
 - keep converting pilot learnings into framework improvements
 - keep using AletheIA to improve AletheIA itself
-- shape Alpha 4 around orchestrated, model-agnostic handoffs between agents
+- extend Alpha 4 from concept + template into more repeatable handoff operating patterns
 - keep Alpha 5 framed as evidence-oriented inference for higher-risk tasks
 
 ---
@@ -194,12 +197,17 @@ The first explicit bridge into Alpha 2 is:
 
 Together, these documents explain how AletheIA should evolve itself, learn from pilots, and preserve a clear boundary between framework core and local project extensions.
 
-The first adoption-facing assets after this bridge are:
+The current Alpha 3 adoption baseline after this bridge is:
 
 - `docs/getting-started.md`
 - `docs/apply-to-existing-project.md`
 - `CONTRIBUTING.md`
 - `starter-pack/templates/project-extension-template.md`
+
+The first Alpha 4 handoff baseline now adds:
+
+- `docs/agent-handoffs.md`
+- `starter-pack/templates/agent-handoff-template.md`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ It was born from real operational work inside the `Crisis Monitor` project and t
 
 Today, this public draft already contains:
 
+- an Alpha 1 baseline for governance, token discipline, durable decisions, enforcement clarity, quality, and learnings
+- an explicit Alpha 2 bridge for self-application, pilot conversion, and project extension
+- an Alpha 3 adoption baseline for getting started, existing-project application, contribution guidance, and starter-pack reuse
+- the first concrete Alpha 4 handoff assets for model-agnostic restart packages between agents
+
+In practical terms, that currently includes:
+
 - core contracts
 - a minimal kernel
 - a governance pack
@@ -141,9 +148,6 @@ Today, this public draft already contains:
 - a quality baseline
 - a first learnings path
 - a reusable starter-pack slice
-- an explicit Alpha 2 bridge for self-application, pilot conversion, and project extension
-- initial Alpha 3 adoption artifacts for getting started, existing-project application, contribution guidance, and starter-pack reuse
-- the first concrete Alpha 4 handoff assets for model-agnostic restart packages between agents
 
 ---
 
@@ -183,6 +187,15 @@ The next steps are:
 - keep using AletheIA to improve AletheIA itself
 - extend Alpha 4 from concept + template into more repeatable handoff operating patterns
 - keep Alpha 5 framed as evidence-oriented inference for higher-risk tasks
+
+---
+
+## Current phase map
+
+- Alpha 1 established the governance and validation baseline.
+- Alpha 2 established the pilot, self-application, and conversion bridge.
+- Alpha 3 is making the framework easier to adopt and contribute to.
+- Alpha 4 is starting to make inter-agent continuity explicit and reusable.
 
 ---
 

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -168,11 +168,14 @@ The key move in Alpha 4 is turning:
 
 into a reusable operating pattern.
 
-Potential first artifacts for this phase may include:
+Current Alpha 4 baseline artifacts now include:
 
 - `docs/agent-handoffs.md`
+- `starter-pack/templates/agent-handoff-template.md`
+
+Next artifacts for this phase may include:
+
 - handoff generation guidance
-- agent-facing handoff templates
 - project-level handoff conventions
 - automated or semi-automated handoff creation from completed work items
 - execution-scope fields such as allowed files, forbidden files, allowed data, semantic guardrails, acceptance criteria, and expected response format
@@ -236,13 +239,16 @@ Across all three alphas, AletheIA should preserve a few boundaries:
 
 ## Near-term priority order
 
-1. consolidate the current Alpha 3 adoption baseline
+1. consolidate the current Alpha 4 handoff baseline
+   - agent handoff concept doc
+   - agent handoff template
+   - alignment with Alpha 3 adoption assets
+2. keep the current Alpha 3 adoption baseline coherent
    - getting started
    - existing-project application
    - contributor guidance
    - project extension template
-2. keep the Alpha 2 bridge coherent while adoption grows
-3. continue validating the Crisis Monitor pilot and nearby real slices
-4. convert pilot learnings into framework updates
-5. shape Alpha 4 around orchestrated handoffs and cross-agent continuity
+3. keep the Alpha 2 bridge coherent while adoption grows
+4. continue validating the Crisis Monitor pilot and nearby real slices
+5. convert pilot learnings into framework updates
 6. keep Alpha 5 framed as experimental structured risk inference rather than strong formal verification

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -39,8 +39,11 @@ If you are thinking about cross-agent continuity and operational restart package
 - `docs/agent-handoffs.md`
 
 
-## Alpha 4 template
+## Alpha 4 baseline
 
-For operational handoffs between agents, use:
+The first practical Alpha 4 handoff baseline now includes:
 
+- `docs/agent-handoffs.md`
 - `starter-pack/templates/agent-handoff-template.md`
+
+Use these when you need model-agnostic continuity between agents without relying on hidden thread memory.


### PR DESCRIPTION
## Summary
- align README, roadmap, and starter-pack docs with the first concrete Alpha 4 handoff assets
- make the Alpha 4 baseline explicit now that the concept doc and operational template are both in main
- rebalance near-term priorities so Alpha 4 consolidation sits ahead of further expansion

## Validation
- bash scripts/check-governance.sh