### PR TITLE
Alpha 4: add project handoff conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,10 @@ If this is your first time here, start with:
 15. `starter-pack/`
 16. `starter-pack/templates/project-extension-template.md`
 17. `docs/agent-handoffs.md`
-18. `starter-pack/templates/agent-handoff-template.md`
-19. `examples/`
+18. `starter-pack/guides/agent-handoff-generation.md`
+19. `starter-pack/templates/agent-handoff-template.md`
+20. `docs/project-handoff-conventions.md`
+21. `examples/`
 
 ---
 
@@ -220,7 +222,9 @@ The current Alpha 3 adoption baseline after this bridge is:
 The first Alpha 4 handoff baseline now adds:
 
 - `docs/agent-handoffs.md`
+- `starter-pack/guides/agent-handoff-generation.md`
 - `starter-pack/templates/agent-handoff-template.md`
+- `docs/project-handoff-conventions.md`
 
 ---
 

--- a/docs/agent-handoffs.md
+++ b/docs/agent-handoffs.md
@@ -179,4 +179,5 @@ AletheIA should preserve the handoff as a reusable operating pattern.
 - `starter-pack/guides/agent-handoff-generation.md`
 - `starter-pack/templates/handoff-template.md`
 - `starter-pack/templates/agent-handoff-template.md`
+- `docs/project-handoff-conventions.md`
 - `docs/project-extension-pattern.md`

--- a/docs/project-handoff-conventions.md
+++ b/docs/project-handoff-conventions.md
@@ -1,0 +1,195 @@
+# Project-Level Handoff Conventions
+
+## Goal
+
+This document explains how a project can define local handoff conventions on top of AletheIA without breaking the framework's model-agnostic handoff structure.
+
+In simple terms:
+
+AletheIA defines the handoff shape.
+A project may define local conventions for how that shape is filled.
+
+---
+
+## Why this matters
+
+Alpha 4 should not stop at a generic handoff template.
+
+Real projects often need local conventions such as:
+
+- ownership boundaries between agents
+- preferred handoff folder locations
+- local frontier labels
+- repo-specific file scope rules
+- project-specific validation expectations
+- local wording for response formats
+
+Those conventions are useful.
+
+But if they replace the framework structure itself, handoffs become tied to one product or one toolchain.
+
+The point of project-level conventions is to keep the local layer explicit.
+
+---
+
+## Core rule
+
+A project may customize:
+
+- vocabulary
+- local ownership rules
+- storage location
+- naming patterns
+- validation expectations
+- handoff cadence
+
+A project should not silently replace:
+
+- the restart-package concept
+- the distinction between narrative and operational handoffs
+- the need for explicit execution boundaries
+- the model-agnostic meaning of the artifact
+
+---
+
+## What a project may define locally
+
+### 1. Frontier taxonomy
+
+A project may define its own dominant frontier labels.
+
+Examples:
+
+- integration
+- UX writing
+- visual polish
+- security
+- observability
+- internal platform
+
+The exact labels may vary by project.
+
+### 2. Ownership map
+
+A project may define which agent or team usually owns which layer.
+
+Examples:
+
+- backend owned by one agent
+- visual refinement owned by another
+- copy allowed to cross the visual surface under specific rules
+
+### 3. Handoff storage convention
+
+A project may define where handoffs live.
+
+Examples:
+
+- `docs/handoffs/`
+- `ops/handoffs/`
+- issue-linked artifacts
+- task-linked artifacts in a work log
+
+### 4. Naming convention
+
+A project may define how handoff artifacts are named.
+
+Examples:
+
+- date + target + scope
+- task id + target agent + frontier
+- feature slice + handoff type
+
+### 5. Validation expectation defaults
+
+A project may define recurring proof expectations.
+
+Examples:
+
+- lint for UI changes
+- smoke for route behavior
+- domain-specific audit checks
+- human review for sensitive flows
+
+### 6. Response format preference
+
+A project may define the preferred return format from the receiving agent.
+
+Examples:
+
+- changed files + validation + next step
+- execution summary + blockers + suggested follow-up
+- implementation status + out-of-scope notes
+
+---
+
+## What should remain framework-stable
+
+The following should remain stable even when the project layer changes:
+
+- handoff as restart package
+- allowed files vs forbidden files distinction
+- semantic guardrails
+- acceptance criteria
+- validation expectation
+- explicit next action
+- provider-agnostic meaning of the artifact
+
+These are part of the framework logic, not only local preference.
+
+---
+
+## Recommended project convention checklist
+
+If a project wants handoffs to be consistent, it should make explicit:
+
+1. where handoffs are stored
+2. how they are named
+3. which frontier labels are valid locally
+4. which ownership boundaries matter most
+5. what proof is expected by default for each major frontier
+6. what response format the receiving agent should use
+7. when a handoff should be narrative vs operational
+
+---
+
+## Relationship to project extension pattern
+
+This document is a direct extension of:
+
+- `docs/project-extension-pattern.md`
+
+The project extension pattern explains the boundary between framework core and local project rules.
+
+This document applies that same discipline specifically to inter-agent handoffs.
+
+---
+
+## Good signs
+
+Project-level handoff conventions are healthy when:
+
+- local conventions reduce ambiguity without changing the framework meaning
+- handoffs are easier to generate and easier to review
+- multiple agents can work in the same project without relying on hidden memory
+- the project can evolve local rules without forking the framework logic
+
+---
+
+## What not to do
+
+Do not let project conventions turn into:
+
+- provider-specific framework rules
+- hidden assumptions not written anywhere
+- one team's habits masquerading as universal structure
+- prompts that only make sense in one agent shell
+
+---
+
+## Suggested next reading
+
+- `docs/agent-handoffs.md`
+- `starter-pack/guides/agent-handoff-generation.md`
+- `starter-pack/templates/agent-handoff-template.md`
+- `docs/project-extension-pattern.md`

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -176,7 +176,7 @@ Current Alpha 4 baseline artifacts now include:
 
 Next artifacts for this phase may include:
 
-- project-level handoff conventions
+- `docs/project-handoff-conventions.md`
 - automated or semi-automated handoff creation from completed work items
 - execution-scope fields such as allowed files, forbidden files, allowed data, semantic guardrails, acceptance criteria, and expected response format
 

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -48,3 +48,7 @@ The first practical Alpha 4 handoff baseline now includes:
 - `starter-pack/templates/agent-handoff-template.md`
 
 Use these when you need model-agnostic continuity between agents without relying on hidden thread memory.
+
+For local repo conventions that sit on top of the shared handoff structure, also read:
+
+- `docs/project-handoff-conventions.md`


### PR DESCRIPTION
## Summary
- add project-level handoff conventions for local ownership, naming, storage, and validation defaults
- connect Alpha 4 handoffs to the project-extension boundary explicitly
- wire the new conventions doc into the README, roadmap, agent-handoffs doc, and starter-pack

## Validation
- bash scripts/check-governance.sh