### PR TITLE
Alpha 4: consolidate handoff baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Today, this public draft already contains:
 - an Alpha 1 baseline for governance, token discipline, durable decisions, enforcement clarity, quality, and learnings
 - an explicit Alpha 2 bridge for self-application, pilot conversion, and project extension
 - an Alpha 3 adoption baseline for getting started, existing-project application, contribution guidance, and starter-pack reuse
-- the first concrete Alpha 4 handoff assets for model-agnostic restart packages between agents
+- an Alpha 4 handoff baseline for model-agnostic restart packages, project conventions, and semi-automated handoff capture
 
 In practical terms, that currently includes:
 
@@ -184,11 +184,11 @@ If this is your first time here, start with:
 
 The next steps are:
 
-- consolidate the first Alpha 4 handoff baseline without losing the Alpha 3 adoption gains
+- consolidate the current Alpha 4 handoff baseline without losing the Alpha 3 adoption gains
 - keep validating the Crisis Monitor pilot and adjacent real slices
 - keep converting pilot learnings into framework improvements
 - keep using AletheIA to improve AletheIA itself
-- extend Alpha 4 from concept + template into more repeatable handoff operating patterns
+- extend Alpha 4 from documented patterns into more repeatable handoff operating flows
 - keep Alpha 5 framed as evidence-oriented inference for higher-risk tasks
 
 ---
@@ -198,7 +198,7 @@ The next steps are:
 - Alpha 1 established the governance and validation baseline.
 - Alpha 2 established the pilot, self-application, and conversion bridge.
 - Alpha 3 is making the framework easier to adopt and contribute to.
-- Alpha 4 is starting to make inter-agent continuity explicit and reusable.
+- Alpha 4 is making inter-agent continuity explicit, reusable, and more operational.
 
 ---
 

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -174,11 +174,13 @@ Current Alpha 4 baseline artifacts now include:
 - `starter-pack/guides/agent-handoff-generation.md`
 - `starter-pack/templates/agent-handoff-template.md`
 - `docs/project-handoff-conventions.md`
+- `docs/handoff-capture-pattern.md`
 
 Next artifacts for this phase may include:
 
-- `docs/handoff-capture-pattern.md`
 - execution-scope fields such as allowed files, forbidden files, allowed data, semantic guardrails, acceptance criteria, and expected response format
+- project-level handoff examples drawn from real pilot work
+- more explicit draft/review flows for semi-automated handoff assembly
 
 ---
 
@@ -240,8 +242,11 @@ Across all three alphas, AletheIA should preserve a few boundaries:
 ## Near-term priority order
 
 1. consolidate the current Alpha 4 handoff baseline
-   - agent handoff concept doc
-   - agent handoff template
+   - concept doc
+   - generation guide
+   - handoff template
+   - project-level conventions
+   - handoff capture pattern
    - alignment with Alpha 3 adoption assets
 2. keep the current Alpha 3 adoption baseline coherent
    - getting started

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -32,27 +32,14 @@ If you are adopting AletheIA inside a real project and need to make the local la
 - `starter-pack/templates/project-extension-template.md`
 
 
-## Alpha 4 preview
-
-If you are thinking about cross-agent continuity and operational restart packages, read:
-
-- `docs/agent-handoffs.md`
-
-
 ## Alpha 4 baseline
 
-The first practical Alpha 4 handoff baseline now includes:
+The current practical Alpha 4 handoff baseline now includes:
 
 - `docs/agent-handoffs.md`
 - `starter-pack/guides/agent-handoff-generation.md`
 - `starter-pack/templates/agent-handoff-template.md`
-
-Use these when you need model-agnostic continuity between agents without relying on hidden thread memory.
-
-For local repo conventions that sit on top of the shared handoff structure, also read:
-
 - `docs/project-handoff-conventions.md`
-
-For the next step toward semi-automated handoff creation from completed work, also read:
-
 - `docs/handoff-capture-pattern.md`
+
+Use this set when you need model-agnostic continuity between agents without relying on hidden thread memory.


### PR DESCRIPTION
## Summary
- align README, roadmap, and starter-pack with the current Alpha 4 handoff baseline
- promote handoff capture into the baseline instead of leaving it framed as only a future step
- reduce redundancy and make the Alpha 4 block read as one coherent operating set

## Validation
- bash scripts/check-governance.sh