### PR TITLE
Alpha 6: add distribution, presets, and adapters roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ The next steps are:
 - Alpha 2 established the pilot, self-application, and conversion bridge.
 - Alpha 3 is making the framework easier to adopt and contribute to.
 - Alpha 4 is making inter-agent continuity explicit, reusable, and more operational.
+- Alpha 5 remains the next conceptual future phase for decision-quality in higher-risk work.
+- Alpha 6 is the future distribution phase for presets, bundles, and adapters.
+- Alpha 7 is a later tooling follow-up for optional bootstrap and delivery automation.
 
 ---
 
@@ -232,15 +235,19 @@ The first Alpha 4 handoff baseline now adds:
 
 ## Future direction after Alpha 4
 
-AletheIA may eventually need a further phase focused on structured risk inference before execution in higher-risk tasks.
+The next future-facing phases should stay clearly separated by role:
 
-That future direction should stay evidence-oriented and conditional, rather than claiming strong formal verification that the framework does not yet provide.
+- **Alpha 5** — decision-quality through structured, evidence-oriented inference for higher-risk work
+- **Alpha 6** — distribution, presets, and adapters for packaging the same framework meaning across environments
+- **Alpha 7** — optional bootstrap and delivery tooling after the distribution model is already stable
+
+These future phases are about extending AletheIA's reach and delivery discipline.
+They are not about redefining the framework core.
 
 See also:
 
-- `docs/agent-handoffs.md`
-- `starter-pack/templates/agent-handoff-template.md`
 - `docs/structured-risk-inference.md`
+- `docs/distribution-presets-adapters.md`
 
 ---
 

--- a/docs/distribution-presets-adapters.md
+++ b/docs/distribution-presets-adapters.md
@@ -1,0 +1,211 @@
+# Distribution, Presets & Adapters
+
+## Goal
+
+This document explains the future Alpha 6 direction for AletheIA.
+
+In simple terms:
+
+keep the framework core stable,
+but make it easier to package, deliver, and reuse across different project shapes and agent environments.
+
+---
+
+## Why this phase exists
+
+AletheIA is becoming stronger as an operating framework.
+
+It already has:
+
+- a governance baseline
+- real pilot learnings
+- an adoption baseline
+- a model-agnostic handoff baseline
+- a future direction for structured risk inference
+
+The next gap is not primarily conceptual.
+
+The next gap is distribution.
+
+Today, AletheIA is easier to understand than to package consistently across:
+
+- different project shapes
+- different editor or agent-shell environments
+- lighter vs fuller adoption footprints
+
+Alpha 6 exists to improve that distribution layer without redefining the framework core.
+
+---
+
+## Useful reference, limited influence
+
+Tools such as `maestro-bundle-cli` are useful references for this phase because they show a practical packaging mindset:
+
+- bundle a baseline
+- adapt it to different editors
+- offer lighter or fuller installation paths
+
+That is useful inspiration.
+
+But the lesson for AletheIA is specifically about:
+
+- packaging
+- delivery
+- presets
+- adapters
+
+It is not about replacing AletheIA's core operating model with a CLI-first or tool-specific worldview.
+
+---
+
+## Alpha 6 thesis
+
+Alpha 6 should prove a simple idea:
+
+**the same AletheIA meaning can be delivered through different forms without distorting the framework core.**
+
+That means:
+
+- same framework meaning
+- different delivery forms
+- no core distortion
+
+AletheIA should stay recognizable even if teams adopt it through different presets, environments, or setup footprints.
+
+---
+
+## The three tracks of Alpha 6
+
+### 1. Presets / Bundles
+
+AletheIA should eventually support curated packages for common project shapes.
+
+Examples:
+
+- web application preset
+- AI product preset
+- regulated-domain preset
+- lightweight starter preset
+
+The goal is not to create many bundles quickly.
+
+The goal is to define a reusable preset model that can package the same core in context-appropriate ways.
+
+### 2. Adapters
+
+AletheIA should eventually support delivery adapters for different editor and agent environments.
+
+Examples:
+
+- AGENTS-style delivery
+- Claude-style delivery
+- Codex-oriented delivery
+- future editor or shell adapters
+
+The goal is not to privilege one editor.
+
+The goal is to preserve the same framework meaning across environments.
+
+### 3. Adoption modes
+
+AletheIA should eventually support more than one installation footprint.
+
+Examples:
+
+- lightweight mode
+- fuller operating mode
+
+This helps teams adopt the framework with the right amount of structure for their context, instead of forcing one universal level of ceremony.
+
+---
+
+## What Alpha 6 is not
+
+Alpha 6 is not about:
+
+- changing the decision or governance core
+- making one editor the canonical interface
+- introducing mandatory external integrations
+- promising a one-command bootstrap experience yet
+- replacing the roadmap Alpha 1 through Alpha 5 concepts with packaging concerns
+
+This phase should stay clearly in the delivery layer.
+
+---
+
+## Likely first artifacts
+
+Good first Alpha 6 artifacts would include:
+
+- a preset taxonomy
+- an adapter taxonomy
+- lite vs fuller adoption mode guidance
+- delivery mapping examples across environments
+
+These should make the distribution model explicit before any heavier tooling is introduced.
+
+---
+
+## Relationship to Alpha 7
+
+Alpha 6 defines the model.
+
+Alpha 7 may later operationalize it.
+
+That means Alpha 6 should answer questions such as:
+
+- what is a preset?
+- what is an adapter?
+- what should vary by environment?
+- what must remain framework-stable?
+- what does lightweight vs fuller adoption mean?
+
+Only after those answers are stable should AletheIA seriously consider:
+
+- bootstrap tooling
+- installation automation
+- delivery CLI flows
+
+That later work belongs to Alpha 7, not to Alpha 6.
+
+---
+
+## Good signs
+
+Alpha 6 is going well when:
+
+- the framework becomes easier to package without becoming tool-dependent
+- teams can imagine different delivery forms without confusing them with framework truth
+- presets and adapters feel like delivery choices, not conceptual forks
+- AletheIA remains provider-agnostic and core-stable
+
+---
+
+## Risks
+
+The main risks are:
+
+- letting packaging concerns redefine the framework core
+- overpromising CLI or automation too early
+- importing tool-specific assumptions into the framework model
+- treating external integrations as mandatory before the distribution model is stable
+
+---
+
+## Mitigations
+
+Alpha 6 should mitigate those risks by:
+
+- keeping packaging explicitly separate from the governance core
+- treating external integrations as out of scope for now
+- defining presets and adapters conceptually before automating them
+- keeping Alpha 7 as a later tooling phase rather than collapsing both phases together
+
+---
+
+## Suggested next reading
+
+- `docs/roadmap-alpha.md`
+- `docs/project-extension-pattern.md`
+- `docs/agent-handoffs.md`
+- `docs/structured-risk-inference.md`

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -226,9 +226,80 @@ Potential first artifacts for this phase may include:
 
 ---
 
+## Alpha 6 — Distribution, Presets & Adapters
+
+Focus:
+- make AletheIA easier to package, deliver, and reuse across project shapes and agent environments without changing the framework core
+
+Includes:
+- preset or bundle models for common project shapes
+- editor and agent-shell adapters that preserve the same framework meaning across environments
+- lighter vs fuller adoption modes
+- clearer distinction between framework core and delivery-layer packaging
+- future-facing distribution guidance that stays provider-agnostic
+
+### What Alpha 6 must prove
+
+By the end of Alpha 6, AletheIA should already show that:
+
+- the framework can be packaged in more than one reusable form without distorting its conceptual core
+- presets can adapt the framework to different project shapes without turning into incompatible forks
+- adapters can deliver the same meaning across editor or agent environments
+- teams can choose lighter vs fuller adoption footprints without changing the framework's governing logic
+
+### Notes
+
+Alpha 6 is not a CLI-first phase.
+It is a distribution-architecture phase.
+
+This phase should not:
+- change the decision or governance core
+- make one editor the canonical interface
+- introduce mandatory external integrations
+- promise one-command installation before the model is stable
+
+Current Alpha 6 direction is documented in:
+
+- `docs/distribution-presets-adapters.md`
+
+Likely first artifacts for this phase may include:
+
+- a preset taxonomy
+- an adapter taxonomy
+- lite vs fuller adoption-mode guidance
+- delivery mapping examples across environments
+
+---
+
+## Alpha 7 — Bootstrap & Delivery Tooling
+
+Focus:
+- operationalize the distribution model from Alpha 6 through optional bootstrap and delivery tooling
+
+### What Alpha 7 should remain
+
+Alpha 7 should stay intentionally smaller and later than Alpha 6.
+
+It may eventually include:
+
+- optional bootstrap CLI flows
+- delivery automation for presets or adapters
+- packaging helpers for distributing AletheIA into real repositories
+
+### Notes
+
+Alpha 7 should only become active after presets, adapters, and adoption modes are already well-defined.
+
+It should remain:
+- provider-agnostic
+- optional
+- clearly outside the framework core itself
+
+---
+
 ## Cross-Alpha principles
 
-Across all three alphas, AletheIA should preserve a few boundaries:
+Across all phases, AletheIA should preserve a few boundaries:
 
 1. It should remain provider-agnostic.
 2. It should not collapse into a single governance template.
@@ -236,6 +307,7 @@ Across all three alphas, AletheIA should preserve a few boundaries:
 4. It should prefer explicit contracts over hidden conventions.
 5. It should treat learnings as reviewable artifacts, not informal memory.
 6. It should evolve through real pilots, not only through internal theory.
+7. It should treat distribution and tooling as delivery-layer concerns, not as replacements for the core operating model.
 
 ---
 
@@ -257,3 +329,5 @@ Across all three alphas, AletheIA should preserve a few boundaries:
 4. continue validating the Crisis Monitor pilot and nearby real slices
 5. convert pilot learnings into framework updates
 6. keep Alpha 5 framed as experimental structured risk inference rather than strong formal verification
+7. shape Alpha 6 as a future distribution layer without distorting the framework core
+8. keep Alpha 7 as a later tooling/bootstrap follow-up, not a near-term promise


### PR DESCRIPTION
## Summary
- add the Alpha 6 distribution/presets/adapters document
- extend the roadmap with Alpha 6 and a lighter Alpha 7 placeholder
- align the README future direction so Alpha 5, Alpha 6, and Alpha 7 have distinct roles

## Validation
- bash scripts/check-governance.sh