### PR TITLE
Alpha 5: add inference artifact template

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ In simple terms:
 
 ---
 
+## Why the name AletheIA
+
+The name combines **Aletheia** — the idea of truth as something brought into the open rather than left hidden — with **IA**, signaling the framework's focus on AI-assisted work.
+
+Conceptually, the name points to the framework's main intention:
+
+- make reasoning more explicit
+- make decisions more reviewable
+- make validation and learnings less hidden
+- keep AI work from moving straight from output to action without an operating layer
+
+In that sense, AletheIA is not about treating AI output as truth.
+It is about creating the conditions for AI-assisted work to become more inspectable, governable, and revealable before execution.
+
+---
+
 ## Why AletheIA exists
 
 Many AI workflows still follow a fragile pattern:
@@ -247,6 +263,7 @@ They are not about redefining the framework core.
 See also:
 
 - `docs/structured-risk-inference.md`
+- `starter-pack/templates/inference-artifact-template.md`
 - `docs/distribution-presets-adapters.md`
 
 ---

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -220,7 +220,7 @@ This phase should begin as an experimental capability, not a mandatory step for 
 Potential first artifacts for this phase may include:
 
 - `docs/structured-risk-inference.md`
-- a starter-pack template for inference artifacts
+- `starter-pack/templates/inference-artifact-template.md`
 - trigger guidance for when the capability should run
 - pilot scenarios focused on refactors, patch review, or semantic regression risk
 

--- a/docs/structured-risk-inference.md
+++ b/docs/structured-risk-inference.md
@@ -282,3 +282,10 @@ If this enters the roadmap, it should start as:
 - scoped primarily to code and semantic-risk tasks
 
 It should not start as a mandatory core phase for every workflow.
+
+---
+
+## Suggested next reading
+
+- `starter-pack/templates/inference-artifact-template.md`
+- `docs/agent-handoffs.md`

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -43,3 +43,11 @@ The current practical Alpha 4 handoff baseline now includes:
 - `docs/handoff-capture-pattern.md`
 
 Use this set when you need model-agnostic continuity between agents without relying on hidden thread memory.
+
+
+## Alpha 5 preview
+
+If you are exploring structured risk inference for higher-risk work, read:
+
+- `docs/structured-risk-inference.md`
+- `starter-pack/templates/inference-artifact-template.md`

--- a/starter-pack/templates/inference-artifact-template.md
+++ b/starter-pack/templates/inference-artifact-template.md
@@ -1,0 +1,115 @@
+# Inference Artifact Template
+
+## Goal
+
+Use this template when a task triggers structured risk inference before execution.
+
+This is not a replacement for tests or validation.
+It is a compact artifact for making higher-risk reasoning more reviewable.
+
+---
+
+## Trigger context
+
+### Why inference was triggered
+
+Examples:
+- multi-module change
+- sensitive business rule
+- security or governance impact
+- refactor with invisible regression risk
+- insufficient test confidence
+- high-stakes handoff
+
+### Decision being scrutinized
+
+State the change or decision that still needs structured review before execution proceeds.
+
+---
+
+## Hypothesis
+
+Describe the expected behavior after the change.
+
+---
+
+## Premises
+
+List the main evidence supporting the hypothesis.
+
+Examples:
+- observed code path
+- existing contract behavior
+- current validation result
+- documented invariant
+
+---
+
+## Assumptions
+
+List what is being assumed but not yet demonstrated.
+
+---
+
+## Impacted paths
+
+List the main functional or semantic paths likely to be affected.
+
+Examples:
+- flow A -> component X -> side effect Y
+- route B -> service C -> persistence D
+
+---
+
+## Invariants
+
+List what must remain true after the change.
+
+---
+
+## Risks
+
+For each major risk, describe:
+
+- description
+- likelihood: low | medium | high
+- impact: low | medium | high
+
+---
+
+## Unknowns
+
+List what could not be verified yet.
+
+---
+
+## Test gaps
+
+List which meaningful scenarios are not currently covered.
+
+---
+
+## Suggested tests
+
+List the tests or validation moves that would most reduce uncertainty.
+
+---
+
+## Confidence
+
+### Confidence level
+
+Use:
+- low
+- medium
+- high
+
+### Confidence basis
+
+Explain why this confidence level was assigned.
+
+---
+
+## Recommended next action
+
+State the next action that should happen after this inference artifact is reviewed.


### PR DESCRIPTION
## Summary
- add the first practical Alpha 5 artifact as an inference artifact template
- wire the template into the structured risk inference docs and starter-pack
- add a conceptual explanation of the AletheIA name to the README

## Validation
- bash scripts/check-governance.sh