### PR TITLE
Future track: add domain governance pack plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,14 +257,27 @@ The next future-facing phases should stay clearly separated by role:
 - **Alpha 6** — distribution, presets, and adapters for packaging the same framework meaning across environments
 - **Alpha 7** — optional bootstrap and delivery tooling after the distribution model is already stable
 
-These future phases are about extending AletheIA's reach and delivery discipline.
+A separate future track will also shape reusable domain governance packs.
+The first planned packs in that track are:
+
+- **Web App Security & Trust Boundaries Pack**
+- **AI Agent Security & Prompt Injection Pack**
+
+These future phases and domain packs are about extending AletheIA's reach and delivery discipline.
 They are not about redefining the framework core.
+
+The domain packs should sit between the reusable framework core and project-local rules:
+
+`AletheIA core -> domain governance pack -> project extension`
 
 See also:
 
 - `docs/structured-risk-inference.md`
 - `starter-pack/templates/inference-artifact-template.md`
 - `docs/distribution-presets-adapters.md`
+- `docs/domain-governance-packs.md`
+- `docs/web-app-security-trust-boundaries.md`
+- `docs/ai-agent-security-prompt-injection.md`
 
 ---
 

--- a/docs/ai-agent-security-prompt-injection.md
+++ b/docs/ai-agent-security-prompt-injection.md
@@ -1,0 +1,233 @@
+# AI Agent Security & Prompt Injection
+
+## Goal
+
+This document explains a future domain governance pack for AI agent security and prompt injection in AletheIA.
+
+In simple terms:
+
+make agent security boundaries explicit and reusable,
+without confusing them with provider-specific prompt recipes or pretending the problem is solved by the framework core alone.
+
+---
+
+## Why this future pack exists
+
+AletheIA already contributes useful generic discipline for agent work.
+
+It already reinforces things such as:
+
+- execution boundaries
+- semantic guardrails
+- explicit handoffs
+- authoritative validation
+- controlled critical actions
+- structured risk inference for higher-risk tasks
+
+That is useful, but still not the same as an explicit agent-security layer.
+
+A real assistant such as Cris can still face risks such as:
+
+- direct prompt injection
+- indirect prompt injection through retrieved or monitored content
+- tool abuse
+- data exfiltration through tool calls
+- memory or retrieval poisoning
+- ambiguity about what content is trusted enough to influence action
+
+This future pack exists to make those security boundaries explicit and reusable.
+
+---
+
+## Core idea
+
+This pack should define a reusable operating layer where:
+
+- instructions are not all trusted equally
+- external content is not promoted into instructions by default
+- tool use follows least privilege
+- ambiguous or adversarial inputs fail safely
+- agent action remains bounded even when the input tries to redefine those bounds
+
+---
+
+## Planned pack blocks
+
+### A. Instruction Trust Hierarchy
+
+This future pack should make explicit that not all instructions have the same authority.
+
+A reusable hierarchy should distinguish between things such as:
+
+- framework or core instructions
+- project rules
+- system policy
+- user input
+- retrieved content
+- tool outputs
+- external documents or monitored content
+
+The goal is to keep instruction authority reviewable instead of implicit.
+
+### B. Trusted vs Untrusted Content
+
+This future pack should make explicit that:
+
+- external content should enter as data, evidence, or context
+- external content should not become instruction by default
+- retrieved content and monitoring content are untrusted unless explicitly reclassified by trusted logic
+- the system should distinguish content trust from instruction authority
+
+### C. Prompt Injection Resistance
+
+This future pack should make explicit that the assistant should resist:
+
+- direct prompt injection
+- indirect prompt injection
+- hidden instructions inside retrieved material
+- attempts to override scope, policy, role, or validation expectations
+
+The goal is not perfect immunity.
+The goal is explicit defensive posture.
+
+### D. Monitoring Content as Untrusted Input
+
+For agentic products such as Crisis Monitor, this future pack should make explicit that:
+
+- monitored content is untrusted by default
+- mentions, documents, news, snippets, and captured text enter as evidence or context
+- monitored content must not silently become operational instruction
+- the assistant should preserve the boundary between what was observed and what it is allowed to do
+
+### E. Tool Permissioning & Least Privilege
+
+This future pack should make explicit that:
+
+- tools should have the narrowest useful scope
+- read, mutate, and exfiltrate capabilities should be distinguished
+- unsafe tool chaining should be avoided
+- sensitive tool use may require human gate or explicit confirmation
+- data should not be sent to third parties without a clear rule that allows it
+
+### F. Tool-Use Guardrails
+
+This future pack should make explicit that:
+
+- tool use must stay inside the execution boundary
+- inputs should not coerce unsafe tool calls indirectly
+- tools must not become a bypass around policy or scope
+- trust in a tool output does not automatically imply permission to act on it
+
+### G. Memory / Retrieval Safety
+
+This future pack should make explicit that:
+
+- retrieved memory is not equivalent to trusted truth
+- retrieval poisoning and memory poisoning are real risks
+- source marking matters
+- the system should distinguish retrieved fact, inferred conclusion, and executable instruction
+
+### H. Agent Action Boundaries
+
+This future pack should make explicit that:
+
+- the agent may suggest some actions
+- the agent may execute only some actions
+- some actions require confirmation or human escalation
+- an input asking for something unsafe should not redefine the agent's allowed boundary
+
+### I. Safe Failure, Refusal & Escalation
+
+This future pack should make explicit that:
+
+- ambiguous trust conditions should tend toward safe failure
+- refusal is sometimes the correct behavior
+- escalation should happen when trust hierarchy or execution boundary becomes unclear
+- higher-risk ambiguity should not be smoothed over by confident language
+
+### J. Adversarial Evaluation Scenarios
+
+Good future evaluation scenarios for this pack would include:
+
+- a retrieved document trying to redefine assistant behavior
+- prompt injection through externally monitored content
+- a user trying to extract policy or hidden instructions
+- a tool-use path that could exfiltrate sensitive data
+- a poisoned memory or retrieval layer influencing action
+- an input trying to pressure the agent into skipping validation or scope boundaries
+
+---
+
+## Relationship to Alpha 4 and Alpha 5
+
+This future pack connects directly to the phases already in progress.
+
+### Alpha 4
+
+Alpha 4 contributes:
+
+- execution boundaries
+- restart packages
+- semantic guardrails
+- safer continuity between agents
+
+### Alpha 5
+
+Alpha 5 may later contribute:
+
+- selective structured inference for higher-risk agent changes
+- clearer assumptions, unknowns, and test gaps before execution
+
+This future pack should build on those phases,
+not replace them.
+
+---
+
+## Crisis Monitor motivation without lock-in
+
+Crisis Monitor and the Cris Assistente are strong motivating examples for this pack.
+
+They make concrete problems visible, such as:
+
+- monitored content that should not become instruction
+- sensitive assistant-mediated workflows
+- tool and context boundaries that matter operationally
+
+Those examples are useful.
+
+But this future pack should still remain reusable beyond one assistant or one product.
+
+---
+
+## What this pack is not
+
+This future pack is not:
+
+- a perfect defense against jailbreaks
+- a substitute for server-side security
+- a policy for one provider family only
+- a prompt recipe disguised as framework logic
+- proof that AletheIA already enforces these protections technically
+
+The goal is explicit reusable agent-security discipline,
+not exaggerated claims.
+
+---
+
+## Good signs
+
+This future pack is going well when:
+
+- monitored and retrieved content stay in the right trust category
+- tool use becomes easier to review for least privilege and exfiltration risk
+- refusal and escalation feel like part of the operating model, not a special case
+- the pack still makes sense across different providers and agent shells
+
+---
+
+## Suggested next reading
+
+- `docs/domain-governance-packs.md`
+- `docs/agent-handoffs.md`
+- `docs/structured-risk-inference.md`
+- `docs/project-extension-pattern.md`

--- a/docs/domain-governance-packs.md
+++ b/docs/domain-governance-packs.md
@@ -1,0 +1,243 @@
+# Domain Governance Packs
+
+## Goal
+
+This document explains a future track for reusable domain governance packs in AletheIA.
+
+In simple terms:
+
+some governance patterns are too domain-specific to live in the framework core,
+but too reusable to remain only as project-local rules.
+
+---
+
+## Why this layer exists
+
+AletheIA already has a growing reusable core.
+
+That core covers things such as:
+
+- decision structure
+- governance hooks
+- validation expectations
+- learnings
+- handoff discipline
+- structured risk inference direction
+
+Real projects still need domain-specific governance on top of that.
+
+Examples:
+
+- web app security
+- trust boundaries in multi-tenant products
+- agent security
+- prompt injection resistance
+- tool-use hardening
+
+If all of that is pushed into the framework core, the core becomes too heavy.
+
+If all of that stays purely local, reuse is lost.
+
+Domain governance packs exist to hold that middle layer.
+
+---
+
+## Where this layer sits
+
+AletheIA should eventually be understood as three layers:
+
+### 1. Framework core
+
+The reusable baseline.
+
+Examples:
+
+- governance concepts
+- token discipline
+- durable decisions
+- quality and validation expectations
+- handoff structure
+- structured risk inference direction
+
+### 2. Domain governance pack
+
+The reusable domain layer.
+
+Examples:
+
+- web app security and trust boundaries
+- AI agent security and prompt injection resistance
+- future domain-specific governance packs that can be reused across more than one project
+
+### 3. Project extension
+
+The local layer.
+
+Examples:
+
+- one product's ownership map
+- one team's branch rules
+- one repo's provider choices
+- one assistant's local operating behavior
+
+The intended relationship is:
+
+`AletheIA core -> domain governance pack -> project extension`
+
+---
+
+## What a domain governance pack is
+
+A domain governance pack is a reusable operating layer for a specific class of risks, boundaries, and trust assumptions.
+
+It should help answer questions such as:
+
+- what should remain authoritative in this domain?
+- what is safe or unsafe by default?
+- what boundaries matter most?
+- what should be treated as trusted versus untrusted?
+- what kinds of validation or escalation should happen before closure?
+
+A domain governance pack is not required to begin as executable enforcement.
+
+It can begin as:
+
+- a public framing document
+- reusable operating guidance
+- candidate evaluation scenarios
+- future template or checklist direction
+
+---
+
+## What a domain governance pack is not
+
+A domain governance pack is not:
+
+- a replacement for the framework core
+- a project-local operating manual disguised as reusable truth
+- a vendor-specific implementation guide
+- a new Alpha phase by itself
+- a promise that technical enforcement already exists
+
+The right goal is reusable domain discipline, not premature universality.
+
+---
+
+## When something deserves a pack
+
+A pattern deserves to become a reusable domain governance pack when it is:
+
+- recurring across more than one project shape
+- still meaningful after removing one product's vocabulary
+- strongly tied to a domain-specific trust model or risk model
+- useful enough to teach as a reusable layer
+- likely to benefit from future examples, templates, or evaluation scenarios
+
+A pattern should probably stay project-local when it depends mostly on:
+
+- one product
+- one team's workflow
+- one provider choice
+- one repository structure
+- one assistant's local behavior
+
+---
+
+## Relationship to the roadmap
+
+This future track connects to the current roadmap in a specific way.
+
+### Alpha 1
+
+Provides the generic governance baseline.
+
+### Alpha 3
+
+Creates the opening for reusable domain governance packs without forcing them into the core too early.
+
+### Alpha 4
+
+Contributes execution boundaries, restart-package logic, semantic guardrails, and safer continuity between agents.
+
+### Alpha 5
+
+May later strengthen higher-risk decisions inside domain packs through selective structured inference.
+
+Domain governance packs should therefore be understood as a future extension layer,
+not as a replacement for those phases.
+
+---
+
+## First planned packs
+
+The first planned packs in this future track are:
+
+### 1. Web App Security & Trust Boundaries Pack
+
+This pack would focus on things such as:
+
+- client versus server separation
+- secrets and credentials
+- auth and data isolation patterns
+- tenant-scoped context assembly
+- runtime hardening
+- inbound integration trust
+- logging and artifact hygiene
+- untrusted content handling
+
+### 2. AI Agent Security & Prompt Injection Pack
+
+This pack would focus on things such as:
+
+- instruction trust hierarchy
+- trusted versus untrusted content
+- prompt injection resistance
+- monitoring content as untrusted input
+- tool permissioning and least privilege
+- retrieval and memory safety
+- refusal and escalation boundaries
+- adversarial evaluation scenarios
+
+---
+
+## Good signs
+
+This future track is going well when:
+
+- domain-specific guidance becomes more reusable without bloating the core
+- packs remain provider-agnostic and teachable
+- project-local rules remain clearly local
+- the framework stays recognizable even as domain coverage grows
+
+---
+
+## Risks
+
+The main risks are:
+
+- turning one product's security habits into framework truth
+- importing vendor-specific language too early
+- pretending a future pack is already technically enforced
+- letting domain packs quietly replace the core operating model
+
+---
+
+## Mitigations
+
+This future track should reduce those risks by:
+
+- clearly labeling the packs as future reusable layers
+- keeping them separate from the framework core
+- writing them in vendor-agnostic language
+- treating enforcement as a later question, not an implied claim
+- preserving the boundary between reusable pack and project extension
+
+---
+
+## Suggested next reading
+
+- `docs/roadmap-alpha.md`
+- `docs/governance.md`
+- `docs/project-extension-pattern.md`
+- `docs/agent-handoffs.md`
+- `docs/structured-risk-inference.md`

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -297,6 +297,51 @@ It should remain:
 
 ---
 
+## Future Track — Reusable Domain Governance Packs
+
+Focus:
+- make recurring domain-specific governance reusable without inflating the AletheIA core
+
+This future track exists for governance patterns that are:
+
+- too domain-specific to live in the framework core
+- too reusable to remain only as project-local rules
+- worth documenting as reusable operating discipline before any heavier automation appears
+
+This is not a new Alpha right now.
+It is a future track for reusable domain governance layers that sit between the framework core and each project's local extension.
+
+The intended layer is:
+
+`AletheIA core -> domain governance pack -> project extension`
+
+The first planned packs in this track are:
+
+- `Web App Security & Trust Boundaries Pack`
+- `AI Agent Security & Prompt Injection Pack`
+
+This future track connects to the existing phases in specific ways:
+
+- Alpha 1 provides the generic governance baseline and core security-adjacent rules
+- Alpha 3 opens the path for reusable domain governance packs beyond the core
+- Alpha 4 contributes execution boundaries, handoffs, and semantic guardrails
+- Alpha 5 may later strengthen higher-risk decisions inside these packs through selective structured inference
+
+Current direction for this track is documented in:
+
+- `docs/domain-governance-packs.md`
+- `docs/web-app-security-trust-boundaries.md`
+- `docs/ai-agent-security-prompt-injection.md`
+
+This future track should not:
+
+- redefine the kernel or policy core
+- collapse vendor-specific guidance into framework truth
+- turn project-local rules into universal enforcement by accident
+- pretend these packs are already active policies in the framework
+
+---
+
 ## Cross-Alpha principles
 
 Across all phases, AletheIA should preserve a few boundaries:

--- a/docs/web-app-security-trust-boundaries.md
+++ b/docs/web-app-security-trust-boundaries.md
@@ -1,0 +1,190 @@
+# Web App Security & Trust Boundaries
+
+## Goal
+
+This document explains a future domain governance pack for web app security and trust boundaries in AletheIA.
+
+In simple terms:
+
+make recurring web application security boundaries explicit and reusable,
+without pretending they belong in the framework core by default.
+
+---
+
+## Why this future pack exists
+
+AletheIA already has generic governance rules that matter for security.
+
+It already reinforces things such as:
+
+- no exposed secrets
+- validation in an authoritative layer
+- controlled critical actions
+- explicit execution boundaries
+
+That is useful, but still too generic for common web application realities such as:
+
+- client versus server separation
+- tenant isolation
+- API abuse controls
+- webhook verification
+- logging hygiene
+- untrusted content handling
+
+This future pack exists to make those patterns reusable without turning the AletheIA core into a web-only framework.
+
+---
+
+## Core idea
+
+This pack should define a reusable operating layer for web apps and APIs where:
+
+- public surfaces are not treated as authoritative
+- sensitive logic stays in the authoritative layer
+- data access is scoped correctly
+- integrations are verified before trust is granted
+- operational artifacts do not become new leak paths
+
+---
+
+## Planned pack blocks
+
+### A. Client / Server Separation
+
+This future pack should make explicit that:
+
+- the public client is not the authoritative layer
+- secrets and sensitive logic do not belong in the client
+- the client should not define critical business truth
+- the server or another authoritative layer must hold the final decision for sensitive behavior
+
+### B. Secrets & Credential Exposure
+
+This future pack should make explicit that:
+
+- API keys must never live in the frontend
+- secrets should remain only in the authoritative layer
+- public config and secret config must be distinguished clearly
+- secrets should not appear in bundles, logs, traces, or reusable artifacts without necessity
+
+### C. Auth & Data Isolation Patterns
+
+This future pack should make explicit that:
+
+- row-level isolation or an equivalent mechanism should exist where per-user or per-tenant data boundaries matter
+- authorization must remain explicit and reviewable
+- least privilege should be the default posture
+- UI visibility is not enough to prove access control correctness
+
+### D. Tenant-Scoped Retrieval & Context Assembly
+
+This future pack should make explicit that:
+
+- context sent to models or agents must be scoped before inference
+- retrieval should not cross tenant or user boundaries implicitly
+- the system, not the model, should decide what context is allowed to be assembled
+- broad retrieval should not silently become cross-tenant exposure
+
+### E. Authoritative Business Logic
+
+This future pack should make explicit that:
+
+- pricing, payment, permission, eligibility, critical state transitions, and similar rules belong in the authoritative layer
+- the client can request or display,
+  but should not become the source of truth for sensitive business logic
+
+### F. API & Runtime Hardening
+
+This future pack should make explicit that:
+
+- rate limiting, quotas, throttling, or equivalent abuse controls matter for sensitive routes
+- runtime surfaces should degrade safely under ambiguity or abuse
+- fail-closed defaults are preferable when critical validation fails
+- API trust should not depend only on optimistic assumptions about well-behaved callers
+
+### G. Trusted Inbound Integrations
+
+This future pack should make explicit that:
+
+- inbound integrations should be verified before they are trusted
+- webhook signatures or equivalent origin checks matter
+- idempotency and replay protection should be considered for state-changing inbound events
+- inbound integration trust should remain reviewable and auditable
+
+### H. Telemetry, Logging & Artifact Hygiene
+
+This future pack should make explicit that:
+
+- logs and traces should not carry secrets or sensitive payloads unnecessarily
+- learnings, handoffs, and inference artifacts should follow data minimization
+- operational artifacts should not become accidental exfiltration surfaces
+- security hygiene includes what gets written down, not only what gets executed
+
+### I. Untrusted Content Handling & Rendering Safety
+
+This future pack should make explicit that:
+
+- external content should be treated as untrusted by default
+- rendering safety, sanitization, and content handling matter for user-visible and operator-visible surfaces
+- content, evidence, and commands should not be collapsed into the same trust category
+- external content should not silently become an instruction path
+
+### J. Likely Evaluation Scenarios
+
+Good future evaluation scenarios for this pack would include:
+
+- a secret appearing in a client bundle or log
+- a cross-tenant retrieval or context leak
+- a webhook accepted without source verification
+- a sensitive route with no meaningful abuse controls
+- a client trying to define price or another critical state transition
+- untrusted content being rendered or reused unsafely
+
+---
+
+## What this pack is not
+
+This future pack is not:
+
+- a Supabase tutorial
+- a Vercel tutorial
+- a complete AppSec manual
+- a universal policy for all software systems
+- proof that these protections are already enforced by AletheIA itself
+
+The goal is reusable domain governance language,
+not a vendor-specific implementation handbook.
+
+---
+
+## Relationship to AletheIA today
+
+AletheIA already contains security-adjacent core rules such as:
+
+- `security.no_exposed_secrets`
+- `security.authoritative_validation_required`
+- `security.controlled_critical_actions`
+
+This future pack would not replace those rules.
+
+It would extend them into a clearer web app and API trust-boundary layer that teams could reuse across real projects.
+
+---
+
+## Good signs
+
+This future pack is going well when:
+
+- web-specific trust boundaries are easier to teach and review
+- teams can reuse the logic without inheriting one vendor's worldview
+- security-critical behavior stays in the authoritative layer
+- artifacts and telemetry remain part of the security model instead of being ignored
+
+---
+
+## Suggested next reading
+
+- `docs/domain-governance-packs.md`
+- `docs/governance.md`
+- `docs/project-extension-pattern.md`
+- `docs/structured-risk-inference.md`


### PR DESCRIPTION
## Summary\n- add a future-track roadmap section for reusable domain governance packs\n- add umbrella documentation for domain governance packs\n- add future pack plans for web app security and AI agent security\n\n## Testing\n- bash /Users/nevitonsantana/orchids-projects/aletheia/scripts/check-governance.sh\n