### PR TITLE
Alpha 5: add inference artifact examples

### DIFF
--- a/docs/inference-pilot-scenarios.md
+++ b/docs/inference-pilot-scenarios.md
@@ -141,3 +141,4 @@ The goal is to find the first task shapes where the capability clearly earns its
 - `docs/structured-risk-inference.md`
 - `starter-pack/templates/inference-artifact-template.md`
 - `starter-pack/guides/inference-trigger-guidance.md`
+- `examples/structured-risk-inference/README.md`

--- a/docs/structured-risk-inference.md
+++ b/docs/structured-risk-inference.md
@@ -221,6 +221,10 @@ For recommended first pilots, see:
 
 - `docs/inference-pilot-scenarios.md`
 
+For concrete example artifacts, see:
+
+- `examples/structured-risk-inference/README.md`
+
 
 ### 1. Patch review
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,8 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
   - mostra como facts + governance rules produzem `allow`, `review`, `ask_human` e `block`
 - `learning-from-failed-validation/`
   - mostra como uma falha de validação vira bloqueio + aprendizado reaproveitável
+- `structured-risk-inference/`
+  - mostra exemplos concretos de inference artifacts para risco de refactor e handoff de alto impacto
 
 ---
 

--- a/examples/structured-risk-inference/README.md
+++ b/examples/structured-risk-inference/README.md
@@ -1,0 +1,74 @@
+# AletheIA — Structured Risk Inference Examples
+
+## Goal
+
+This folder makes the Alpha 5 inference artifact more concrete.
+
+In simple terms:
+
+it shows what a compact inference artifact can look like in real higher-risk scenarios,
+without pretending the artifact replaces execution or validation.
+
+---
+
+## Why these examples exist
+
+The Alpha 5 docs already explain:
+
+- what structured risk inference is
+- when to trigger it
+- how to assemble the artifact
+- which pilot scenarios are good first candidates
+
+These examples answer a different question:
+
+**what does the artifact actually look like when written well?**
+
+They are intentionally small, reviewable, and tied to realistic task shapes.
+
+---
+
+## Included examples
+
+### 1. `refactor-risk-inference.json`
+
+A refactor that looks mechanically safe but may still change behavior indirectly.
+
+This example shows:
+
+- explicit premises
+- explicit assumptions
+- semantic invariants
+- validation work driven by the main regression risk
+
+### 2. `high-stakes-handoff-inference.json`
+
+A handoff where another agent must continue execution and the main risk is semantic reinterpretation, not syntax.
+
+This example shows:
+
+- rationale preserved across a boundary
+- contract stability called out as an invariant
+- validation priorities that should survive the handoff
+
+---
+
+## What these examples are not
+
+These files are not:
+
+- engine output
+- formal proof artifacts
+- universal truth for every task shape
+
+They are concrete examples for teaching what a healthy Alpha 5 artifact looks like.
+
+---
+
+## Suggested next reading
+
+- `docs/structured-risk-inference.md`
+- `starter-pack/templates/inference-artifact-template.md`
+- `starter-pack/guides/inference-trigger-guidance.md`
+- `starter-pack/guides/inference-artifact-generation.md`
+- `docs/inference-pilot-scenarios.md`

--- a/examples/structured-risk-inference/high-stakes-handoff-inference.json
+++ b/examples/structured-risk-inference/high-stakes-handoff-inference.json
@@ -1,0 +1,48 @@
+{
+  "hypothesis": "Passing the remaining notification-review UI work to another agent with this inference artifact preserved will allow the new escalation states to be rendered without changing backend contract semantics.",
+  "premises": [
+    "The authoritative contract already exposes escalation_state and audit_reason for the notification-review screen.",
+    "The remaining work is explicitly scoped to the UI layer and should not modify the API contract or server-side state model.",
+    "The source-of-truth artifact already defines the meaning of each escalation state and marks the backend contract as stable for this slice."
+  ],
+  "assumptions": [
+    "The receiving agent will not reinterpret escalation_state into a different semantic category for presentation.",
+    "No hidden view-model formatter currently depends on legacy status strings that are not described in the source-of-truth artifact."
+  ],
+  "impacted_paths": [
+    "notification review route -> UI state mapping -> escalation badge rendering",
+    "notification review route -> audit metadata -> audit reason display"
+  ],
+  "invariants": [
+    "The backend contract remains unchanged.",
+    "Escalation state meaning remains one-to-one with the documented contract.",
+    "Audit reason remains visible where the source-of-truth artifact requires it."
+  ],
+  "risks": [
+    {
+      "description": "The receiving agent may remap escalation states into a visually convenient but semantically incorrect UI representation.",
+      "likelihood": "medium",
+      "impact": "high"
+    },
+    {
+      "description": "A copy or presentation change may hide or downgrade audit_reason even though the contract still provides it.",
+      "likelihood": "medium",
+      "impact": "medium"
+    }
+  ],
+  "unknowns": [
+    "There is no existing visual regression artifact covering the new escalation states.",
+    "It is not yet verified whether any downstream component assumes the old status vocabulary."
+  ],
+  "test_gaps": [
+    "No test currently asserts one-to-one UI mapping for every escalation_state value.",
+    "No test currently verifies audit_reason visibility for the new review states after the handoff completes."
+  ],
+  "suggested_tests": [
+    "Add a focused UI mapping test for every documented escalation_state value.",
+    "Add a regression check for audit_reason visibility on the notification-review screen.",
+    "Require the receiving agent to report whether any legacy status formatter had to be preserved or replaced."
+  ],
+  "confidence_level": "medium",
+  "confidence_basis": "The backend contract and state meanings are already explicit, but the handoff still carries semantic risk because the receiving agent must preserve rationale, not only instructions, across a UI-only continuation boundary."
+}

--- a/examples/structured-risk-inference/refactor-risk-inference.json
+++ b/examples/structured-risk-inference/refactor-risk-inference.json
@@ -1,0 +1,48 @@
+{
+  "hypothesis": "Extracting checkout eligibility logic into a shared helper preserves current behavior while reducing duplicated branching.",
+  "premises": [
+    "The current checkout flow and the admin override flow both evaluate eligibility against the same product rules, but do so in duplicated code paths.",
+    "The source-of-truth artifact states that blocked accounts must never reach checkout and premium accounts may bypass the waitlist.",
+    "Existing unit coverage already asserts the blocked-account path and the premium-account bypass in the current implementation."
+  ],
+  "assumptions": [
+    "No caller depends on the current order of conditional checks beyond the documented rules.",
+    "The admin override path does not rely on an undocumented side effect in the existing inline implementation."
+  ],
+  "impacted_paths": [
+    "checkout request -> eligibility evaluation -> payment availability",
+    "admin override flow -> shared eligibility helper -> final allow/block decision"
+  ],
+  "invariants": [
+    "Blocked accounts must still be denied before checkout begins.",
+    "Premium accounts must still bypass the waitlist when the documented rule applies.",
+    "The final allow or block decision must remain traceable to the same documented eligibility rules."
+  ],
+  "risks": [
+    {
+      "description": "The shared helper changes the evaluation order and unintentionally allows a blocked account to pass through a later premium branch.",
+      "likelihood": "medium",
+      "impact": "high"
+    },
+    {
+      "description": "The admin override path loses an existing semantic distinction because both paths are normalized too aggressively.",
+      "likelihood": "medium",
+      "impact": "medium"
+    }
+  ],
+  "unknowns": [
+    "There is no current integration test covering blocked-account behavior through the admin override path.",
+    "It is not yet demonstrated whether downstream audit labels depend on the old inline branch structure."
+  ],
+  "test_gaps": [
+    "No integration scenario currently covers blocked-account handling after the helper extraction.",
+    "No regression test currently asserts that premium bypass and admin override semantics remain distinct where required."
+  ],
+  "suggested_tests": [
+    "Add an integration test for blocked-account denial after helper extraction.",
+    "Add a regression test covering premium bypass and admin override behavior through the shared helper.",
+    "Add a validation step for audit labels if those labels are expected downstream."
+  ],
+  "confidence_level": "medium",
+  "confidence_basis": "The main rules are documented and partly covered, but the helper extraction crosses more than one path and still leaves an important integration gap around the admin override branch."
+}


### PR DESCRIPTION
## Summary\n- add concrete structured-risk-inference example artifacts\n- add a dedicated examples folder for Alpha 5\n- wire the examples into the inference docs and examples index\n\n## Testing\n- bash /Users/nevitonsantana/orchids-projects/aletheia/scripts/check-governance.sh\n