### PR TITLE
Alpha 5: consolidate example baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Today, this public draft already contains:
 - an explicit Alpha 2 bridge for self-application, pilot conversion, and project extension
 - an Alpha 3 adoption baseline for getting started, existing-project application, contribution guidance, and starter-pack reuse
 - an Alpha 4 handoff baseline for model-agnostic restart packages, project conventions, and semi-automated handoff capture
-- an emerging Alpha 5 baseline for structured risk inference in higher-risk work
+- an Alpha 5 experimental baseline for structured risk inference in higher-risk work, including concrete example artifacts
 
 In practical terms, that currently includes:
 
@@ -166,6 +166,7 @@ In practical terms, that currently includes:
 - a first learnings path
 - a reusable starter-pack slice
 - a first structured risk inference slice
+- concrete example artifacts for bounded semantic-risk scenarios
 
 ---
 
@@ -199,7 +200,8 @@ If this is your first time here, start with:
 24. `starter-pack/guides/inference-trigger-guidance.md`
 25. `starter-pack/guides/inference-artifact-generation.md`
 26. `docs/inference-pilot-scenarios.md`
-27. `examples/`
+27. `examples/structured-risk-inference/README.md`
+28. `examples/`
 
 ---
 
@@ -207,11 +209,11 @@ If this is your first time here, start with:
 
 The next steps are:
 
-- consolidate the current Alpha 5 inference baseline without losing the Alpha 4 handoff baseline or the Alpha 3 adoption gains
+- keep the current Alpha 5 baseline coherent and example-driven without losing the Alpha 4 handoff baseline or the Alpha 3 adoption gains
 - keep validating the Crisis Monitor pilot and adjacent real slices
 - keep converting pilot learnings into framework improvements
 - keep using AletheIA to improve AletheIA itself
-- keep Alpha 5 proportional, selective, and grounded in real semantic-risk scenarios
+- keep Alpha 5 proportional, selective, and grounded in bounded semantic-risk scenarios
 - let Alpha 6, Alpha 7, and future domain packs remain future-facing layers rather than near-term core work
 
 ---
@@ -222,7 +224,7 @@ The next steps are:
 - Alpha 2 established the pilot, self-application, and conversion bridge.
 - Alpha 3 is making the framework easier to adopt and contribute to.
 - Alpha 4 is making inter-agent continuity explicit, reusable, and more operational.
-- Alpha 5 is becoming an experimental baseline for decision-quality in higher-risk work.
+- Alpha 5 now provides an experimental baseline for decision-quality in higher-risk work.
 - Alpha 6 is the future distribution phase for presets, bundles, and adapters.
 - Alpha 7 is a later tooling follow-up for optional bootstrap and delivery automation.
 
@@ -261,6 +263,7 @@ The current Alpha 5 experimental baseline now adds:
 - `starter-pack/guides/inference-trigger-guidance.md`
 - `starter-pack/guides/inference-artifact-generation.md`
 - `docs/inference-pilot-scenarios.md`
+- `examples/structured-risk-inference/README.md`
 
 ---
 

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -65,3 +65,13 @@ The current Alpha 5 experimental baseline is now anchored by:
 - `starter-pack/guides/inference-trigger-guidance.md`
 - `starter-pack/guides/inference-artifact-generation.md`
 - `docs/inference-pilot-scenarios.md`
+- `examples/structured-risk-inference/README.md`
+
+This means Alpha 5 can now be read across:
+
+- concept
+- template
+- trigger discipline
+- generation method
+- pilot posture
+- concrete example artifacts

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -224,6 +224,9 @@ Current Alpha 5 baseline artifacts now include:
 - `starter-pack/guides/inference-trigger-guidance.md`
 - `starter-pack/guides/inference-artifact-generation.md`
 - `docs/inference-pilot-scenarios.md`
+- `examples/structured-risk-inference/README.md`
+
+Together, these artifacts now define Alpha 5 as a concept-plus-examples baseline rather than only a template-and-guidance layer.
 
 ---
 
@@ -365,6 +368,7 @@ Across all phases, AletheIA should preserve a few boundaries:
    - trigger guidance
    - generation guide
    - pilot scenarios
+   - example artifacts
    - alignment with Alpha 4 handoffs and Alpha 3 adoption assets
 2. keep the current Alpha 4 handoff baseline coherent
    - concept doc

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,3 +46,4 @@ O alpha agora já cobre:
 - `ask_human`
 - `block`
 - `block + learning`
+- examples of structured risk inference for bounded semantic-risk scenarios


### PR DESCRIPTION
## Summary\n- align README, overview, roadmap, and examples index with the current example-driven Alpha 5 baseline\n- make the structured-risk-inference examples part of the public baseline narrative\n\n## Testing\n- bash /Users/nevitonsantana/orchids-projects/aletheia/scripts/check-governance.sh\n