### PR TITLE
Alpha 7: add bootstrap principles

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The next steps are:
 - Alpha 4 is making inter-agent continuity explicit, reusable, and more operational.
 - Alpha 5 now provides an experimental baseline for decision-quality in higher-risk work.
 - Alpha 6 now provides a first concrete distribution baseline for presets, adapters, adoption modes, and delivery mappings.
-- Alpha 7 remains a later tooling follow-up for optional bootstrap and delivery automation.
+- Alpha 7 now begins with bootstrap principles for optional tooling and delivery automation boundaries.
 
 ---
 
@@ -308,6 +308,7 @@ See also:
 - `docs/adapter-taxonomy.md`
 - `docs/adoption-mode-guidance.md`
 - `docs/delivery-mapping-examples.md`
+- `docs/bootstrap-principles.md`
 - `docs/domain-governance-packs.md`
 - `docs/web-app-security-trust-boundaries.md`
 - `docs/ai-agent-security-prompt-injection.md`

--- a/docs/bootstrap-principles.md
+++ b/docs/bootstrap-principles.md
@@ -1,0 +1,178 @@
+# Bootstrap Principles
+
+## Goal
+
+This document defines a first future-facing set of principles for Alpha 7 bootstrap and delivery tooling.
+
+In simple terms:
+
+if Alpha 7 is going to introduce tooling,
+it should first make explicit what that tooling must preserve and what it must never distort.
+
+---
+
+## Why this matters
+
+Once a framework starts thinking about bootstrap tooling, a predictable risk appears:
+
+the installer or generator becomes more influential than the framework itself.
+
+That creates avoidable problems:
+
+- the tool starts redefining framework meaning
+- one delivery surface becomes de facto canonical
+- setup convenience starts to outrun conceptual clarity
+- teams inherit automation they do not fully understand
+
+Alpha 7 should not begin by asking:
+
+**what command should we build first?**
+
+It should begin by asking:
+
+**what must bootstrap tooling preserve so it remains subordinate to the framework?**
+
+---
+
+## Core idea
+
+Bootstrap tooling should be understood as:
+
+**an optional delivery layer that operationalizes a model already defined elsewhere**
+
+That means Alpha 7 tooling should:
+
+- follow Alpha 6 models
+- stay subordinate to canonical docs
+- remain inspectable
+- remain optional
+- avoid redefining framework truth through automation
+
+Tooling may speed up setup.
+It should not become the source of meaning.
+
+---
+
+## First bootstrap principles
+
+### 1. Model before tooling
+
+Bootstrap should only operationalize concepts that Alpha 6 already clarified.
+
+That means tooling should come after there is a stable model for:
+
+- presets
+- adapters
+- adoption modes
+- delivery mappings
+
+If the model is still ambiguous, the tool will encode that ambiguity and make it harder to fix later.
+
+### 2. Canonical docs stay authoritative
+
+Generated or installed outputs must not replace the canonical repo-native docs as the reference source.
+
+Tooling may compress or distribute.
+It should still point back to the canonical surfaces when meaning matters.
+
+### 3. Inspectability over magic
+
+Bootstrap outputs should stay readable and inspectable.
+
+A team should be able to answer:
+
+- what was generated?
+- why was it generated?
+- which preset or mode drove it?
+- which parts are framework-derived versus project-local?
+
+### 4. Optionality over lock-in
+
+Alpha 7 tooling should remain optional.
+
+Teams should still be able to adopt AletheIA without a CLI or installer.
+
+Tooling should support the framework.
+It should not become a prerequisite for understanding it.
+
+### 5. No single tool becomes framework truth
+
+Bootstrap should not make one editor, one provider, or one instruction style the canonical AletheIA experience.
+
+If a tool only works by making one surface privileged, it is probably trying to do too much.
+
+### 6. Generated outputs must preserve boundaries
+
+Tooling must preserve the distinctions already made explicit in earlier phases, including:
+
+- framework core versus project extension
+- preset versus adapter
+- adoption mode versus framework meaning
+- domain governance pack versus universal core
+
+### 7. Human review should stay possible
+
+Bootstrap outputs should be reviewable before teams treat them as authoritative.
+
+Even when automation is helpful, teams should still be able to inspect and adjust what was produced.
+
+### 8. Progressive complexity is healthier than total installation
+
+Alpha 7 should prefer layered setup over a single promise that “one command installs everything.”
+
+A safer posture is:
+
+- start with explicit distribution choices
+- generate small inspectable outputs
+- expand only where the model is already clear
+
+---
+
+## What Alpha 7 tooling should not do
+
+Bootstrap tooling should not:
+
+- redefine the core operating model
+- silently encode vendor-specific assumptions as framework truth
+- collapse docs, presets, adapters, and packs into one opaque artifact
+- produce outputs that are hard to inspect or revise
+- promise complete automation before the model is stable enough to justify it
+
+---
+
+## Relationship to Alpha 6
+
+Alpha 6 defines the distribution model.
+Alpha 7 may later operationalize it.
+
+That means Alpha 7 should treat the following as inputs, not as open questions:
+
+- `docs/preset-taxonomy.md`
+- `docs/adapter-taxonomy.md`
+- `docs/adoption-mode-guidance.md`
+- `docs/delivery-mapping-examples.md`
+
+If tooling starts inventing meaning beyond those artifacts, it is no longer acting as a safe delivery layer.
+
+---
+
+## Good signs
+
+Alpha 7 is starting well when:
+
+- tooling principles are clearer than tooling ambition
+- inspectability stays more important than cleverness
+- optionality stays explicit
+- generated outputs remain legible and reviewable
+- the framework still makes sense even without the tooling
+
+---
+
+## Suggested next reading
+
+- `docs/roadmap-alpha.md`
+- `docs/distribution-presets-adapters.md`
+- `docs/preset-taxonomy.md`
+- `docs/adapter-taxonomy.md`
+- `docs/adoption-mode-guidance.md`
+- `docs/delivery-mapping-examples.md`

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -295,12 +295,16 @@ It may eventually include:
 
 ### Notes
 
-Alpha 7 should only become active after presets, adapters, and adoption modes are already well-defined.
+Alpha 7 should only become active after presets, adapters, adoption modes, and delivery mappings are already well-defined.
 
 It should remain:
 - provider-agnostic
 - optional
 - clearly outside the framework core itself
+
+Current first Alpha 7 artifact now includes:
+
+- `docs/bootstrap-principles.md`
 
 ---
 


### PR DESCRIPTION
## Summary
- add the first concrete Alpha 7 artifact as bootstrap principles
- connect the new Alpha 7 doc to the roadmap and README future direction
- define tooling boundaries before any heavier bootstrap implementation

## Validation
- bash /Users/nevitonsantana/orchids-projects/aletheia/scripts/check-governance.sh