### PR TITLE
Alpha 7: add bootstrap output examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ See also:
 - `docs/delivery-mapping-examples.md`
 - `docs/bootstrap-principles.md`
 - `docs/delivery-tooling-boundaries.md`
+- `docs/bootstrap-output-examples.md`
 - `docs/domain-governance-packs.md`
 - `docs/web-app-security-trust-boundaries.md`
 - `docs/ai-agent-security-prompt-injection.md`

--- a/docs/bootstrap-output-examples.md
+++ b/docs/bootstrap-output-examples.md
@@ -1,0 +1,202 @@
+# Bootstrap Output Examples
+
+## Goal
+
+This document provides first future-facing examples of what safe Alpha 7 bootstrap outputs could look like.
+
+In simple terms:
+
+if AletheIA eventually generates setup outputs,
+it helps to show a few examples of the output shape before any heavier tooling exists.
+
+---
+
+## Why this matters
+
+Bootstrap principles define posture.
+Delivery tooling boundaries define limits.
+
+But teams also need examples of what a healthy output might look like when tooling stays inside those limits.
+
+These examples are not generator contracts.
+They are illustrative output shapes for what Alpha 7 should aim for if and when it emits files or packages.
+
+---
+
+## Output principle
+
+A bootstrap output is healthy when:
+
+- it reflects a model already defined in Alpha 6
+- it remains inspectable and reviewable
+- it makes its source assumptions visible
+- it points back to canonical docs when meaning matters
+
+A bootstrap output is unhealthy when:
+
+- it hides what preset or mode influenced it
+- it quietly redefines framework meaning
+- it behaves like a black box install artifact
+- it makes one surface canonical by default
+
+---
+
+## Example 1 — Lightweight repo onboarding package
+
+### Input assumptions
+
+- preset: Core Starter
+- adoption mode: Lite
+- delivery surface: repo-native
+
+### Healthy output shape
+
+A bootstrap helper might emit a small onboarding package such as:
+
+- a short reading order
+- a recommended first starter-pack subset
+- a note that Alpha 4 and Alpha 5 layers are postponed unless justified
+- explicit links back to canonical docs
+
+### Why this is healthy
+
+- the output is small and inspectable
+- the preset and adoption mode remain visible
+- the tooling is not inventing new framework meaning
+
+---
+
+## Example 2 — Existing project adoption package
+
+### Input assumptions
+
+- preset: Existing Project Adoption
+- adoption mode: Standard
+- delivery surface: repo or instruction package
+
+### Healthy output shape
+
+A bootstrap helper might emit:
+
+- a short adoption checklist
+- explicit links to `docs/apply-to-existing-project.md`
+- the project extension template as a recommended artifact
+- a note about what remains project-local versus framework-level
+
+### Why this is healthy
+
+- it packages existing guidance instead of replacing it
+- it preserves the core versus extension boundary
+- it remains readable without trusting the tool blindly
+
+---
+
+## Example 3 — Multi-agent continuity package
+
+### Input assumptions
+
+- preset: Multi-Agent Continuity
+- adoption mode: Standard or Fuller
+- delivery surface: instruction or handoff-oriented output
+
+### Healthy output shape
+
+A bootstrap helper might emit:
+
+- a short handoff starter package
+- references to the handoff template
+- references to project handoff conventions
+- a note that handoff structure remains model-agnostic
+
+### Why this is healthy
+
+- it packages the Alpha 4 baseline without rewriting it
+- it keeps continuity explicit rather than hidden in memory
+- it does not privilege one agent shell as the framework truth
+
+---
+
+## Example 4 — Risk-aware review package
+
+### Input assumptions
+
+- preset: Risk-Aware Delivery
+- adoption mode: Fuller
+- delivery surface: review-oriented
+
+### Healthy output shape
+
+A bootstrap helper might emit:
+
+- a pointer to the inference artifact template
+- a small trigger reminder for when inference is justified
+- references to example artifacts
+- a note that inference is selective, not universal ceremony
+
+### Why this is healthy
+
+- it preserves the conditional nature of Alpha 5
+- it links the team back to reviewable canonical artifacts
+- it avoids pretending to automate judgment itself
+
+---
+
+## Example 5 — Security-sensitive delivery package
+
+### Input assumptions
+
+- preset: Security-Sensitive
+- adoption mode: Fuller
+- delivery surface: repo or instruction package
+
+### Healthy output shape
+
+A bootstrap helper might emit:
+
+- strong references to the governance baseline
+- references to future domain governance packs as optional planned layers
+- a warning that domain packs are not universal defaults
+- a note that project-local security rules still require explicit human ownership
+
+### Why this is healthy
+
+- it keeps future packs in the right layer
+- it does not silently install domain-specific truth as universal framework behavior
+- it stays honest about what is planned versus what is active
+
+---
+
+## What these outputs should not become
+
+These examples should not become:
+
+- fixed generator contracts too early
+- proof that Alpha 7 should automate everything
+- replacement docs for the canonical repo surfaces
+- a reason to blur preset, adapter, and adoption mode into one opaque command
+
+They are examples of healthy output posture, not promises of final implementation.
+
+---
+
+## Good signs
+
+Alpha 7 output examples are healthy when:
+
+- each output stays traceable to preset, mode, and delivery surface
+- generated material remains readable before adoption
+- the outputs package the framework without redefining it
+- the examples make future tooling safer rather than more magical
+
+---
+
+## Suggested next reading
+
+- `docs/bootstrap-principles.md`
+- `docs/delivery-tooling-boundaries.md`
+- `docs/roadmap-alpha.md`
+- `docs/distribution-presets-adapters.md`
+- `docs/preset-taxonomy.md`
+- `docs/adapter-taxonomy.md`
+- `docs/adoption-mode-guidance.md`
+- `docs/delivery-mapping-examples.md`

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -306,6 +306,7 @@ Current Alpha 7 artifacts now include:
 
 - `docs/bootstrap-principles.md`
 - `docs/delivery-tooling-boundaries.md`
+- `docs/bootstrap-output-examples.md`
 
 ---
 


### PR DESCRIPTION
## Summary
- add the third concrete Alpha 7 artifact as bootstrap output examples
- connect the new Alpha 7 doc to the roadmap and README future direction
- show healthy output shapes before any heavier bootstrap tooling exists

## Validation
- bash /Users/nevitonsantana/orchids-projects/aletheia/scripts/check-governance.sh