### PR TITLE
Alpha 7: add bootstrap generator contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The next steps are:
 - Alpha 4 is making inter-agent continuity explicit, reusable, and more operational.
 - Alpha 5 now provides an experimental baseline for decision-quality in higher-risk work.
 - Alpha 6 now provides a first concrete distribution baseline for presets, adapters, adoption modes, and delivery mappings.
-- Alpha 7 now begins with bootstrap principles and delivery-tooling boundaries for optional automation.
+- Alpha 7 now includes bootstrap principles, delivery-tooling boundaries, output examples, and a first future-facing generator contract for optional automation.
 - A current operational-composition baseline now makes bounded work, restartable handoffs, and risk-sensitive validation more tangible without expanding the core contracts.
 
 ---

--- a/docs/bootstrap-generator-contract.md
+++ b/docs/bootstrap-generator-contract.md
@@ -1,0 +1,231 @@
+# Bootstrap Generator Contract
+
+## Goal
+
+This document defines a first future-facing contract for what an Alpha 7 bootstrap generator should receive, what it may emit, and what traceability it must preserve.
+
+In simple terms:
+
+if Alpha 7 eventually generates setup outputs,
+it helps to define the contract of that generation before promising any implementation.
+
+---
+
+## Why this matters
+
+Bootstrap principles define posture.
+Delivery tooling boundaries define stopping points.
+Bootstrap output examples show healthy shapes.
+
+The remaining question is:
+
+**what is the smallest stable contract a future generator should honor?**
+
+Without that contract, Alpha 7 risks jumping from principles straight to tooling behavior that is too magical, too ambiguous, or too tightly coupled to one environment.
+
+---
+
+## Core idea
+
+A bootstrap generator should be understood as:
+
+**a bounded translator from already-defined distribution choices into inspectable delivery outputs**
+
+That means the generator should:
+
+- accept only inputs whose meaning is already defined elsewhere
+- emit only inspectable outputs
+- preserve traceability back to canonical docs
+- remain reviewable before adoption
+
+It should not invent framework meaning during generation.
+
+---
+
+## Generator inputs
+
+A healthy Alpha 7 generator contract should start from explicit inputs such as:
+
+### 1. Preset selection
+
+The generator may accept a preset that Alpha 6 already defined.
+
+Examples:
+
+- Core Starter
+- Existing Project Adoption
+- Multi-Agent Continuity
+- Risk-Aware Delivery
+- Security-Sensitive
+
+### 2. Adoption mode
+
+The generator may accept an adoption mode such as:
+
+- Lite
+- Standard
+- Fuller
+
+### 3. Delivery surface
+
+The generator may accept a target surface such as:
+
+- repo-native package
+- instruction-facing package
+- handoff-oriented package
+- review-oriented package
+
+### 4. Explicit local choices
+
+The generator may accept project-local selections that do not redefine framework meaning.
+
+Examples:
+
+- preferred subset of starter-pack artifacts
+- whether future-facing layers remain omitted
+- whether example artifacts should be included
+
+These inputs should remain visible and reviewable.
+
+---
+
+## Generator outputs
+
+A healthy Alpha 7 generator contract may emit:
+
+### 1. A small delivery bundle
+
+Examples:
+
+- reading-order bundle
+- starter-pack subset
+- adoption checklist
+- handoff starter bundle
+- risk-aware review bundle
+
+### 2. A trace manifest
+
+Every generated output should make it possible to answer:
+
+- which preset was selected
+- which adoption mode was selected
+- which delivery surface was selected
+- which canonical docs remain authoritative
+- which output files are framework-derived versus locally adjusted
+
+### 3. Reviewable emitted files
+
+Generated material should stay inspectable before teams depend on it operationally.
+
+That means a generator may emit:
+
+- markdown guidance
+- starter-pack copies or subsets
+- small manifest-style records
+- delivery notes pointing back to canonical docs
+
+---
+
+## Minimum contract fields
+
+A future Alpha 7 generator contract should be able to express at least:
+
+- `preset`
+- `adoption_mode`
+- `delivery_surface`
+- `requested_outputs`
+- `canonical_refs`
+- `local_choices`
+- `generated_files`
+- `traceability_notes`
+- `review_required`
+
+This is still a document-level contract.
+It is not yet a JSON schema.
+
+---
+
+## Traceability rule
+
+A healthy generator must preserve a clear line back to the framework.
+
+That means each generated bundle should make visible:
+
+- which Alpha 6 choice shaped it
+- which Alpha 7 delivery choice shaped it
+- where canonical meaning still lives
+- what remains project-local
+
+If the output hides these distinctions, the generator is already doing too much.
+
+---
+
+## Review rule
+
+A generator output should be treated as:
+
+**reviewable before adoption**
+
+That means a healthy contract should assume:
+
+- inspection is possible
+- acceptance is explicit
+- teams can edit or discard generated outputs
+- the framework still makes sense without the generator
+
+---
+
+## What this contract should not include yet
+
+This first contract should not yet define:
+
+- a CLI syntax
+- a runtime installer flow
+- project-local rule inference
+- automatic policy selection
+- silent security posture decisions
+- environment-specific implementation logic
+
+Those belong later, if they belong at all.
+
+---
+
+## Relationship to other Alpha 7 artifacts
+
+This document sits after:
+
+- `docs/bootstrap-principles.md`
+- `docs/delivery-tooling-boundaries.md`
+- `docs/bootstrap-output-examples.md`
+
+In simple terms:
+
+- bootstrap principles define the posture
+- delivery tooling boundaries define the stop lines
+- bootstrap output examples define healthy output shapes
+- this generator contract defines the smallest future-facing input/output agreement
+
+---
+
+## Good signs
+
+A first Alpha 7 generator contract is healthy when:
+
+- its inputs are smaller than its ambition
+- its outputs are inspectable and traceable
+- it remains subordinate to Alpha 6 meaning
+- it does not assume one canonical environment
+- it still works as a contract without any implementation yet
+
+---
+
+## Suggested next reading
+
+- `docs/bootstrap-principles.md`
+- `docs/delivery-tooling-boundaries.md`
+- `docs/bootstrap-output-examples.md`
+- `docs/distribution-presets-adapters.md`
+- `docs/preset-taxonomy.md`
+- `docs/adapter-taxonomy.md`
+- `docs/adoption-mode-guidance.md`
+- `docs/delivery-mapping-examples.md`

--- a/docs/bootstrap-output-examples.md
+++ b/docs/bootstrap-output-examples.md
@@ -18,8 +18,9 @@ Delivery tooling boundaries define limits.
 
 But teams also need examples of what a healthy output might look like when tooling stays inside those limits.
 
-These examples are not generator contracts.
+These examples are not generator contracts by themselves.
 They are illustrative output shapes for what Alpha 7 should aim for if and when it emits files or packages.
+A separate generator contract can later define the minimum input/output agreement behind those shapes.
 
 ---
 
@@ -194,6 +195,7 @@ Alpha 7 output examples are healthy when:
 
 - `docs/bootstrap-principles.md`
 - `docs/delivery-tooling-boundaries.md`
+- `docs/bootstrap-generator-contract.md`
 - `docs/roadmap-alpha.md`
 - `docs/distribution-presets-adapters.md`
 - `docs/preset-taxonomy.md`

--- a/docs/bootstrap-principles.md
+++ b/docs/bootstrap-principles.md
@@ -170,6 +170,7 @@ Alpha 7 is starting well when:
 
 ## Suggested next reading
 
+- `docs/bootstrap-generator-contract.md`
 - `docs/roadmap-alpha.md`
 - `docs/distribution-presets-adapters.md`
 - `docs/preset-taxonomy.md`

--- a/docs/delivery-tooling-boundaries.md
+++ b/docs/delivery-tooling-boundaries.md
@@ -171,6 +171,7 @@ Alpha 7 tooling boundaries are healthy when:
 ## Suggested next reading
 
 - `docs/bootstrap-principles.md`
+- `docs/bootstrap-generator-contract.md`
 - `docs/roadmap-alpha.md`
 - `docs/distribution-presets-adapters.md`
 - `docs/preset-taxonomy.md`

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -307,6 +307,7 @@ Current Alpha 7 artifacts now include:
 - `docs/bootstrap-principles.md`
 - `docs/delivery-tooling-boundaries.md`
 - `docs/bootstrap-output-examples.md`
+- `docs/bootstrap-generator-contract.md`
 
 ---
 


### PR DESCRIPTION
## Summary\n- add a first future-facing Alpha 7 generator contract for bootstrap tooling inputs, outputs, traceability, and review posture\n- connect the new contract to bootstrap principles, tooling boundaries, and output examples\n- update the roadmap and README Alpha 7 wording to reflect the new artifact\n\n## Validation\n- bash /Users/nevitonsantana/orchids-projects/aletheia/scripts/check-governance.sh