### PR TITLE
Alpha 7: consolidate baseline narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Today, this public draft already contains:
 - an Alpha 5 experimental baseline for structured risk inference in higher-risk work, including concrete example artifacts
 - an Alpha 6 distribution baseline for presets, adapters, adoption modes, and cross-surface delivery mappings
 - a current operational-composition baseline for work slices, risk-to-gate mapping, stronger restart-package examples, and optional filesystem context-routing experiments
+- an early Alpha 7 bootstrap-and-delivery baseline for future tooling contracts that still remains outside the core
 
 In practical terms, that currently includes:
 
@@ -171,6 +172,7 @@ In practical terms, that currently includes:
 - concrete example artifacts for bounded semantic-risk scenarios
 - a first concrete distribution baseline for packaging shape, delivery surface, adoption depth, and meaning preservation across surfaces
 - a lightweight operational-composition baseline for work slices, risk-to-gate mapping, compact handoff continuity, and optional filesystem context-routing experiments
+- a first Alpha 7 tooling baseline across principles, boundaries, output shapes, generator contract, and output contract
 
 ---
 
@@ -227,7 +229,8 @@ The next steps are:
 - keep the operational-composition baseline lightweight, teachable, and clearly outside the core contracts
 - keep experimental workspace context routing optional, inspectable, and clearly non-canonical
 - keep Alpha 6 focused on distribution clarity rather than tooling promises
-- let Alpha 7 and future domain packs remain future-facing layers rather than near-term core work
+- keep Alpha 7 small, bounded, and tooling-light even as its baseline becomes clearer
+- let future domain packs remain future-facing layers rather than near-term core work
 
 ---
 

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -110,3 +110,22 @@ This means the current operational-composition baseline can now be read across:
 
 This layer sits around the Alpha 4 and Alpha 5 baselines without becoming a new core contract family of its own.
 These materials remain intentionally smaller than the core contracts.
+
+The current Alpha 7 bootstrap-and-delivery baseline is now anchored by:
+
+- `docs/bootstrap-principles.md`
+- `docs/delivery-tooling-boundaries.md`
+- `docs/bootstrap-output-examples.md`
+- `docs/bootstrap-generator-contract.md`
+- `docs/delivery-output-contract.md`
+
+This means Alpha 7 can now be read across:
+
+- tooling posture
+- tooling stop lines
+- healthy output shapes
+- future generator IO
+- future output obligations
+
+This is still a future-facing delivery layer, not a core capability baseline.
+

--- a/docs/distribution-presets-adapters.md
+++ b/docs/distribution-presets-adapters.md
@@ -159,7 +159,7 @@ before any heavier tooling is introduced.
 
 Alpha 6 defines the model.
 
-Alpha 7 may later operationalize it.
+Alpha 7 now begins to operationalize it through future-facing tooling contracts, but still without implementation.
 
 That means Alpha 6 should answer questions such as:
 
@@ -175,7 +175,15 @@ Only after those answers are stable should AletheIA seriously consider:
 - installation automation
 - delivery CLI flows
 
-That later work belongs to Alpha 7, not to Alpha 6.
+The current Alpha 7 baseline now starts that work through:
+
+- `docs/bootstrap-principles.md`
+- `docs/delivery-tooling-boundaries.md`
+- `docs/bootstrap-output-examples.md`
+- `docs/bootstrap-generator-contract.md`
+- `docs/delivery-output-contract.md`
+
+That later work still belongs to Alpha 7, not to Alpha 6.
 
 ---
 

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -302,13 +302,15 @@ It should remain:
 - optional
 - clearly outside the framework core itself
 
-Current Alpha 7 artifacts now include:
+Current Alpha 7 baseline artifacts now include:
 
 - `docs/bootstrap-principles.md`
 - `docs/delivery-tooling-boundaries.md`
 - `docs/bootstrap-output-examples.md`
 - `docs/bootstrap-generator-contract.md`
 - `docs/delivery-output-contract.md`
+
+Together, these artifacts now define Alpha 7 as a first future-facing tooling baseline covering posture, boundaries, output shape, generator IO, and output obligations before any implementation is attempted.
 
 ---
 


### PR DESCRIPTION
## Summary\n- align README, overview, roadmap, and distribution docs so Alpha 7 now reads as a coherent early bootstrap-and-delivery baseline\n- clarify that Alpha 7 currently covers principles, boundaries, output shapes, generator IO, and output obligations\n- keep the phase explicitly future-facing and outside the framework core\n\n## Validation\n- bash /Users/nevitonsantana/orchids-projects/aletheia/scripts/check-governance.sh