### PR TITLE
Add advisory model strategy guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ In practical terms, that currently includes:
 - a quality baseline
 - a first learnings path
 - a reusable starter-pack slice
+- an advisory-only model-strategy guidance slice for task shape, capability profile, reasoning depth, and trust / hosting fit
 - a first structured risk inference slice
 - concrete example artifacts for bounded semantic-risk scenarios
 - a first concrete distribution baseline for packaging shape, delivery surface, adoption depth, and meaning preservation across surfaces
@@ -185,35 +186,38 @@ If this is your first time here, start with:
 3. `docs/architecture.md`
 4. `docs/governance.md`
 5. `docs/token-policy.md`
-6. `docs/durable-decisions.md`
-7. `docs/enforcement-boundaries.md`
-8. `docs/quality.md`
-9. `docs/self-application.md`
-10. `docs/pilot-crisis-monitor.md`
-11. `docs/pilot-conversion.md`
-12. `docs/project-extension-pattern.md`
-13. `docs/apply-to-existing-project.md`
-14. `CONTRIBUTING.md`
-15. `starter-pack/`
-16. `starter-pack/templates/project-extension-template.md`
-17. `docs/agent-handoffs.md`
-18. `starter-pack/guides/agent-handoff-generation.md`
-19. `starter-pack/templates/agent-handoff-template.md`
-20. `docs/project-handoff-conventions.md`
-21. `docs/handoff-capture-pattern.md`
-22. `docs/work-slice-pattern.md`
-23. `starter-pack/templates/work-slice-template.md`
-24. `starter-pack/guides/risk-to-gate-mapping.md`
-25. `docs/structured-risk-inference.md`
-26. `starter-pack/templates/inference-artifact-template.md`
-27. `starter-pack/guides/inference-trigger-guidance.md`
-28. `starter-pack/guides/inference-artifact-generation.md`
-29. `docs/inference-pilot-scenarios.md`
-30. `examples/work-slices/standard-slice/README.md`
-31. `examples/handoffs/compact-reviewable-handoff.md`
-32. `examples/handoffs/high-stakes-handoff.md`
-33. `examples/structured-risk-inference/README.md`
-34. `examples/`
+6. `starter-pack/guides/model-strategy-by-task.md`
+7. `docs/durable-decisions.md`
+8. `docs/enforcement-boundaries.md`
+9. `docs/quality.md`
+10. `docs/self-application.md`
+11. `docs/pilot-crisis-monitor.md`
+12. `docs/pilot-conversion.md`
+13. `docs/project-extension-pattern.md`
+14. `docs/apply-to-existing-project.md`
+15. `CONTRIBUTING.md`
+16. `starter-pack/`
+17. `starter-pack/templates/project-extension-template.md`
+18. `starter-pack/templates/project-model-strategy-template.md`
+19. `docs/agent-handoffs.md`
+20. `starter-pack/guides/agent-handoff-generation.md`
+21. `starter-pack/templates/agent-handoff-template.md`
+22. `docs/project-handoff-conventions.md`
+23. `docs/handoff-capture-pattern.md`
+24. `docs/work-slice-pattern.md`
+25. `starter-pack/templates/work-slice-template.md`
+26. `starter-pack/guides/risk-to-gate-mapping.md`
+27. `docs/structured-risk-inference.md`
+28. `starter-pack/templates/inference-artifact-template.md`
+29. `starter-pack/guides/inference-trigger-guidance.md`
+30. `starter-pack/guides/inference-artifact-generation.md`
+31. `docs/inference-pilot-scenarios.md`
+32. `examples/work-slices/standard-slice/README.md`
+33. `examples/handoffs/compact-reviewable-handoff.md`
+34. `examples/handoffs/high-stakes-handoff.md`
+35. `examples/structured-risk-inference/README.md`
+36. `examples/model-strategy/README.md`
+37. `examples/`
 
 ---
 

--- a/docs/project-extension-pattern.md
+++ b/docs/project-extension-pattern.md
@@ -59,6 +59,7 @@ This includes things such as:
 - branch conventions for a given team
 - domain terminology
 - provider choices
+- local model strategy profiles tied to the available fleet, budget, and hosting posture
 - local handoff patterns
 - risk policies that depend on the project context
 
@@ -117,11 +118,33 @@ Examples:
 - local file ownership agreements between Codex and Claude
 - domain thread labels used by one team
 - provider-specific trust rules
+- project-local model routing defaults and override notes
 - local merge conventions tied to a repo or org
 
 These can still be rigorous.
 
 They just should not be mistaken for universal framework truth.
+
+---
+
+## Model strategy profiles are usually local
+
+A project-local model strategy profile is a good example of an extension artifact.
+
+It usually depends on:
+
+- which models the team actually has
+- which models are self-hosted or externally hosted
+- what kind of context may leave the trust boundary
+- budget ceilings and latency tolerance
+- tool support in the local workflow
+
+That is why AletheIA should teach the pattern without turning one project's model stack into framework truth.
+
+See:
+
+- `starter-pack/guides/model-strategy-by-task.md`
+- `starter-pack/templates/project-model-strategy-template.md`
 
 ---
 

--- a/docs/token-policy.md
+++ b/docs/token-policy.md
@@ -223,6 +223,18 @@ Oversized context is not only inefficient; it also makes decision quality harder
 
 ---
 
+## Relationship to model strategy
+
+Token policy and model strategy are related, but they are not the same thing.
+
+- `docs/token-policy.md` answers: **how much context and cost expansion is justified?**
+- `starter-pack/guides/model-strategy-by-task.md` answers: **what kind of model fit and reasoning depth are proportional to this task?**
+
+Both layers should reinforce each other.
+Neither one should silently replace the other.
+
+---
+
 ## Relationship to the rest of AletheIA
 
 This policy connects directly to:

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,8 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
   - mostra como task brief, decision, execution, handoff e learning podem compor uma unidade operacional
 - `structured-risk-inference/`
   - mostra exemplos concretos de inference artifacts para risco de refactor e handoff de alto impacto
+- `model-strategy/`
+  - mostra routing provider-agnostic e um profile local ilustrativo para fleets mistos de modelos
 
 ---
 
@@ -55,3 +57,4 @@ O alpha agora já cobre:
 - risk-to-gate posture examples
 - optional filesystem-context-routing experimentation
 - examples of structured risk inference for bounded semantic-risk scenarios
+- advisory-only model-strategy examples for task-to-model-fit guidance

--- a/examples/model-strategy/README.md
+++ b/examples/model-strategy/README.md
@@ -1,0 +1,36 @@
+# Model Strategy Examples
+
+## Goal
+
+This folder makes AletheIA's model-strategy guidance tangible.
+
+The guide stays provider-agnostic.
+These examples show:
+
+- how routing can be described without naming vendors
+- how a real local fleet can be mapped into that routing
+- how user override remains allowed even when a local default exists
+
+---
+
+## Files
+
+- `provider-agnostic-routing.md`
+  - shows task-shape to capability-profile recommendations without naming vendors
+- `mixed-fleet-local-profile.md`
+  - shows an illustrative local profile using a mixed fleet of hosted and self-hosted models
+
+---
+
+## Reading rule
+
+Treat these examples as:
+
+- small
+- adaptable
+- advisory
+- non-canonical for vendor choice
+
+The framework suggests.
+The project translates.
+The user still decides.

--- a/examples/model-strategy/mixed-fleet-local-profile.md
+++ b/examples/model-strategy/mixed-fleet-local-profile.md
@@ -1,0 +1,109 @@
+# Mixed-Fleet Local Profile Example
+
+> Illustrative local profile.
+> Not a framework default.
+> Replace this fleet with your own.
+
+This example shows how one project might map a mixed fleet into AletheIA's capability profiles.
+
+---
+
+## Example fleet inventory
+
+| Model label | Provider / runtime | Hosting | Capability profile | Good fit | Max reasoning depth | Cautions |
+|---|---|---|---|---|---|---|
+| Claude Opus | hosted frontier model | hosted | Deep planner / reviewer | planning, arbitration, high-stakes review | Elevated | expensive for routine execution |
+| Claude Sonnet | hosted frontier model | hosted | Balanced executor | bounded execution, general implementation, richer handoffs | Standard | less ideal than premium options for ambiguous arbitration |
+| GPT | hosted frontier model | hosted | Balanced executor or Deep planner / reviewer | review, synthesis, execution, depending on local preference | Standard or Elevated | local project should pin the exact fit |
+| Gemini | hosted frontier model | hosted | Balanced executor | broader execution, summarization, drafting | Standard | local performance may vary by task type |
+| Llama self-hosted | self-hosted open-weight | self-hosted | Lightweight helper or Balanced executor | sensitive summarization, restricted-context drafting | Standard | weaker on ambiguous planning |
+| Qwen self-hosted | self-hosted open-weight | self-hosted | Balanced executor | restricted-context execution and compression | Standard | may need tighter scope control |
+| DeepSeek self-hosted | self-hosted open-weight | self-hosted | Balanced executor or Deep planner / reviewer | coding-heavy bounded tasks in restricted environments | Standard | review quality should be validated locally |
+
+---
+
+## Example local routing guidance
+
+### Planning
+
+Recommended default:
+- Claude Opus
+
+Fallbacks:
+- GPT
+- DeepSeek self-hosted when trust boundary requires it
+
+### Execution
+
+Recommended default:
+- Claude Sonnet
+
+Fallbacks:
+- Gemini
+- DeepSeek self-hosted
+- Qwen self-hosted for restricted environments
+
+### Review
+
+Recommended default:
+- Claude Opus
+
+Fallbacks:
+- GPT
+- DeepSeek self-hosted for restricted reviews with narrower scope
+
+### Handoff / compression
+
+Recommended default:
+- Claude Sonnet
+
+Restricted-context preference:
+- Llama self-hosted
+- Qwen self-hosted
+
+### Structured risk inference
+
+Recommended default:
+- Claude Opus
+
+Fallbacks:
+- GPT
+- DeepSeek self-hosted when the trust posture matters more than the strongest hosted reasoning
+
+---
+
+## Override examples
+
+### Override example 1 — acceptable, higher cost
+
+A user picks Claude Opus for a bounded execution slice that would normally go to Claude Sonnet.
+
+Read:
+- acceptable override
+- likely higher cost
+- little added value unless the slice is more ambiguous than first assumed
+
+### Override example 2 — acceptable, lower expected quality
+
+A user picks a self-hosted Llama or Qwen option for planning because the context is sensitive.
+
+Read:
+- acceptable override
+- stronger trust posture
+- likely lower planning quality or more iteration
+
+### Override example 3 — discouraged by trust boundary
+
+A user wants to send restricted internal material to an externally hosted model even though the project profile says self-hosted is preferred or required.
+
+Read:
+- user may still insist in a permissive local workflow
+- the project should at least warn clearly
+- this is a trust-riskier override, not a neutral one
+
+---
+
+## Reading note
+
+This example is intentionally local and mixed.
+Its purpose is to prove that AletheIA can accommodate a fleet with hosted, self-hosted, premium, cheaper, and fallback models without making any of them a universal framework default.

--- a/examples/model-strategy/provider-agnostic-routing.md
+++ b/examples/model-strategy/provider-agnostic-routing.md
@@ -1,0 +1,48 @@
+# Provider-Agnostic Routing Example
+
+This example uses only AletheIA capability profiles.
+It does **not** recommend a specific vendor.
+
+---
+
+## Scenario matrix
+
+| Scenario | Recommended default | Why | Override note |
+|---|---|---|---|
+| Docs formatting or small support work | Lightweight helper + Light | the task is local, reversible, and easy to inspect | recommended default, user may override |
+| Bounded implementation with clear scope | Balanced executor + Standard | the work needs care, but not the deepest reasoning | recommended default, user may override |
+| Ambiguous planning or decomposition | Deep planner / reviewer + Standard or Elevated | the main risk is decision quality, not raw output volume | recommended default, user may override |
+| Critical review or semantic-risk refactor | Deep planner / reviewer + Elevated | the task needs stronger challenge and more reviewable reasoning | recommended default, user may override |
+| Handoff or restart-package generation | Lightweight helper + Light, or Balanced executor + Standard | use the smaller fit unless ambiguity or sensitivity makes more judgment necessary | recommended default, user may override |
+| Structured risk inference | Deep planner / reviewer + Elevated | this should be explicit, reviewable, and selective | recommended default, user may override |
+
+---
+
+## Hosting notes
+
+Use trust or hosting constraints to narrow the choice further.
+
+Examples:
+
+- if externally hosted use is fine, use the cheapest adequate fit
+- if the task contains restricted material, prefer or require self-hosted options
+- if the task moves across a trust boundary, hosting posture may matter more than raw capability
+
+---
+
+## Example override reads
+
+### Override 1 — stronger than needed
+
+A user may still pick a stronger model for a bounded execution task.
+The likely trade-off is higher cost without much decision-quality gain.
+
+### Override 2 — cheaper than recommended
+
+A user may pick a cheaper model for planning.
+The likely trade-off is weaker decomposition or more revision cycles.
+
+### Override 3 — self-hosted despite lower quality
+
+A user may choose a weaker self-hosted model for sensitive material.
+The likely trade-off is lower planning quality, but a better trust posture.

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -12,6 +12,7 @@ The goal is to provide a practical baseline for:
 - branch isolation
 - quality gates
 - durable decisions
+- advisory model-strategy guidance
 
 Start here if you want the operating method around the framework, not only the technical core.
 
@@ -55,6 +56,17 @@ If you are exploring the current Alpha 5 structured-risk-inference baseline for 
 - `starter-pack/guides/inference-artifact-generation.md`
 - `docs/inference-pilot-scenarios.md`
 
+
+## Model strategy guidance
+
+If you want practical guidance for matching task shape, capability profile, reasoning depth, and trust / hosting constraints, read:
+
+- `starter-pack/guides/model-strategy-by-task.md`
+- `starter-pack/templates/project-model-strategy-template.md`
+- `examples/model-strategy/README.md`
+
+This guidance is advisory-only.
+AletheIA may suggest a fit, but the user may still choose a different model.
 
 ## Current operational-composition baseline
 

--- a/starter-pack/guides/model-strategy-by-task.md
+++ b/starter-pack/guides/model-strategy-by-task.md
@@ -1,0 +1,235 @@
+# Model Strategy by Task
+
+## Goal
+
+This guide helps teams choose a **model capability profile**, a **reasoning depth**, and a **trust / hosting fit** for a task.
+
+It is an operating guide.
+It is **advisory-only**.
+AletheIA may suggest a fit, but the user may still choose a different model.
+
+---
+
+## Why this guide exists
+
+AletheIA already makes two things explicit:
+
+- `docs/token-policy.md` explains how much context and cost expansion is justified
+- the Alpha 5 baseline explains when deeper reasoning is worth the extra effort
+
+What was still missing was a reusable way to answer:
+
+**what kind of model should carry this task, and how much reasoning depth is proportional?**
+
+That answer should depend on:
+
+- the shape of the task
+- the risk and ambiguity involved
+- the reversibility of the work
+- the trust or hosting constraints of the context
+- the user's freedom to override the recommendation
+
+---
+
+## What this guide is not
+
+This guide is **not**:
+
+- a universal vendor ranking
+- a policy pack
+- a runtime router
+- a core framework contract
+- an automatic override blocker
+
+It is a practical starter-pack layer.
+
+---
+
+## The four decision axes
+
+### 1. Task shape
+
+Start by identifying the dominant task shape:
+
+- housekeeping / formatting / support work
+- bounded execution
+- planning / decomposition / arbitration
+- review / critique / validation
+- handoff / compression / restart package generation
+- structured risk inference
+
+### 2. Capability profile
+
+Use one of these three profiles:
+
+#### Lightweight helper
+
+Best fit for:
+- small reversible tasks
+- mechanical cleanup
+- basic summarization
+- light transformation work
+
+#### Balanced executor
+
+Best fit for:
+- bounded implementation
+- moderate context assembly
+- handoff packaging with some judgment
+- execution work that still needs care, but not the deepest reasoning
+
+#### Deep planner / reviewer
+
+Best fit for:
+- ambiguous planning
+- architectural decomposition
+- high-stakes review
+- semantic-risk refactors
+- structured risk inference
+
+### 3. Reasoning depth
+
+Use reasoning depth as a practical shorthand for how much deliberate work the task should receive.
+
+#### Light
+
+Use when:
+- the task is local
+- the work is reversible
+- correctness is easy to inspect afterward
+
+#### Standard
+
+Use when:
+- the task has real but bounded complexity
+- the work touches more than one relevant artifact
+- some judgment is required, but the downside is still moderate
+
+#### Elevated
+
+Use when:
+- ambiguity remains high
+- reviewability matters more than speed
+- the cost of a wrong decision is meaningful
+- the task is hard to validate after the fact
+
+### 4. Trust / hosting constraint
+
+Before choosing a real model, check the boundary posture:
+
+- **externally hosted allowed**
+- **hosted but restricted**
+- **self-hosted preferred**
+- **self-hosted required**
+
+Trust / hosting constraints may override cost or convenience.
+
+---
+
+## Default recommendation matrix
+
+| Task shape | Recommended capability profile | Recommended reasoning depth | Trust / hosting default | Escalate when | Reduce cost when | Override note |
+|---|---|---|---|---|---|---|
+| Housekeeping / formatting / support work | Lightweight helper | Light | Externally hosted allowed | hidden ambiguity appears or the work stops being local | the task is clearly mechanical | user may deliberately choose a different model |
+| Bounded execution | Balanced executor | Standard | Externally hosted allowed, unless local constraints apply | the work becomes cross-boundary, harder to validate, or more semantic than expected | the plan is already stable and the execution is repetitive | user may deliberately choose a different model |
+| Planning / decomposition / arbitration | Deep planner / reviewer | Standard or Elevated | Hosted allowed unless project trust rules narrow it | the decision is hard to reverse, ambiguous, or high-impact | the planning question becomes local and mechanical | user may deliberately choose a different model |
+| Review / critique / validation | Deep planner / reviewer | Elevated | Hosted but restricted by default when sensitive material is involved | semantic ambiguity, trust-boundary impact, or weak validation design appear | the review becomes a narrow checklist against a stable diff | user may deliberately choose a different model |
+| Handoff / compression / restart package generation | Lightweight helper or Balanced executor | Light or Standard | Hosted but restricted when continuity artifacts contain sensitive context | ambiguity is high, the next agent needs stronger interpretation support, or the context is sensitive | the handoff is narrow and already well-bounded | user may deliberately choose a different model |
+| Structured risk inference | Deep planner / reviewer | Elevated | Hosted but restricted, or self-hosted preferred/required for sensitive contexts | assumptions are weak, downside is high, or reviewability matters before execution | structured inference is not actually proportional to the slice | user may deliberately choose a different model |
+
+---
+
+## Escalation rules
+
+Escalate capability or reasoning depth when one or more of these appear:
+
+- higher ambiguity than first expected
+- lower reversibility
+- trust-boundary impact
+- validation that is hard to design or hard to trust
+- handoff that carries real interpretation risk
+- semantic-risk refactor
+- review that needs stronger challenge rather than fast execution
+
+Typical moves:
+
+- `Lightweight helper -> Balanced executor`
+- `Balanced executor -> Deep planner / reviewer`
+- `Light -> Standard -> Elevated`
+- `externally hosted allowed -> hosted but restricted -> self-hosted preferred/required`
+
+---
+
+## De-escalation rules
+
+Reduce cost or depth when:
+
+- the plan has already been closed
+- the task is now stable and repetitive
+- the work became mechanical transformation rather than judgment-heavy reasoning
+- the same result can now be achieved with a smaller model class
+- the context can be safely handled with a less sensitive hosting posture
+
+AletheIA should not keep a premium model in the loop once the hard part is over.
+
+---
+
+## User override principle
+
+AletheIA suggests.
+The user decides.
+
+That means:
+
+- a recommendation is a default, not a lock
+- a user may deliberately choose a different model
+- the local project may document trade-offs, warnings, or preferences
+- this guide does **not** require automatic blocking or automatic routing
+
+Good override examples:
+
+- choosing a stronger model for comfort on a medium-risk planning task
+- choosing a cheaper model after the plan is already stable
+- choosing a self-hosted option because the context is sensitive
+
+Poor override examples may still happen, but they should be described as **higher-cost**, **lower-quality**, or **trust-riskier** choices — not as impossible choices.
+
+---
+
+## Relationship to local project profiles
+
+This guide stays provider-agnostic on purpose.
+
+Real model names such as:
+
+- Opus
+- Sonnet
+- GPT
+- Gemini
+- Llama
+- Qwen
+- DeepSeek
+
+belong in a **project-local model strategy profile**, because they depend on:
+
+- which models are actually available
+- budget ceilings
+- trust boundaries
+- hosting setup
+- tool integrations
+- team preference
+
+Use:
+
+- `starter-pack/templates/project-model-strategy-template.md`
+
+for that local translation layer.
+
+---
+
+## Suggested next reading
+
+- `docs/token-policy.md`
+- `starter-pack/guides/risk-to-gate-mapping.md`
+- `starter-pack/guides/inference-trigger-guidance.md`
+- `docs/project-extension-pattern.md`

--- a/starter-pack/templates/project-model-strategy-template.md
+++ b/starter-pack/templates/project-model-strategy-template.md
@@ -1,0 +1,125 @@
+# Project Model Strategy Template
+
+Use this template when a project wants to translate AletheIA's provider-agnostic guidance into a real local model fleet.
+
+This template is **recommended**, not mandatory.
+It documents local defaults and trade-offs.
+It does not remove the user's ability to choose a different model.
+
+---
+
+## Project identity
+
+### Project name
+
+### Team or user scope
+
+### Last updated
+
+---
+
+## Local model inventory
+
+Fill one row per model or runtime that is actually available.
+
+| Model label | Provider / runtime | Hosted vs self-hosted | Allowed data class / trust boundary | Cost posture | Latency posture | Context posture | Best-fit task shapes | Max recommended reasoning depth | Notable weaknesses |
+|---|---|---|---|---|---|---|---|---|---|
+| Example: Planning premium | Example provider | hosted | public + internal docs only | high | medium | large | planning, review | Elevated | expensive for routine execution |
+| Example: Execution default | Example provider | hosted | public + normal working context | medium | fast | moderate | bounded execution, handoffs | Standard | less reliable for high-stakes arbitration |
+| Example: Sensitive local runtime | local runtime | self-hosted | restricted / sensitive only | low-medium | medium | moderate | summarization, handoff, restricted-context tasks | Standard | weaker on ambiguous planning |
+
+---
+
+## Capability mapping
+
+Map the real fleet into the AletheIA capability profiles.
+
+### Lightweight helper
+
+Recommended local models:
+
+### Balanced executor
+
+Recommended local models:
+
+### Deep planner / reviewer
+
+Recommended local models:
+
+---
+
+## Local routing guidance
+
+### Recommended default for planning
+
+### Recommended default for execution
+
+### Recommended default for review
+
+### Recommended default for handoff / compression
+
+### Recommended default for structured risk inference
+
+### Escalation triggers
+
+Examples:
+- ambiguity stayed high
+- trust boundary tightened
+- review risk increased
+- validation became harder than expected
+
+### Fallback triggers
+
+Examples:
+- premium model unavailable
+- budget ceiling hit
+- task became repetitive
+- trust boundary no longer allows the preferred hosted option
+
+### Trust / hosting restrictions
+
+State any project-local constraints such as:
+- public-only context for externally hosted models
+- self-hosted required for customer-sensitive material
+- no third-party model for certain artifacts
+
+---
+
+## User override policy
+
+This profile is **recommended**, not obligatory.
+
+### Override principle
+
+The user may choose a different model.
+
+### Benign overrides
+
+Examples:
+- stronger model than recommended for comfort or speed of convergence
+- cheaper model after the plan is already stable
+- self-hosted model for sensitive summarization
+
+### Higher-cost or higher-risk overrides
+
+Examples:
+- premium model for routine formatting work
+- weak model for high-ambiguity planning
+- externally hosted model for material that the project would rather keep restricted
+
+### Alert-only vs block
+
+If the project wants to react to overrides, state the posture clearly.
+
+Examples:
+- alert only
+- warn on trust mismatch, but do not block
+- never auto-block in the local workflow
+
+---
+
+## Notes
+
+Use this template to make local model strategy explicit.
+Do not treat it as a universal framework rule.
+Replace any example fleet with the models the project actually has.


### PR DESCRIPTION
## Summary\n- add advisory-only model strategy guidance to the starter-pack\n- add a project-local template for mapping real model fleets\n- add provider-agnostic and mixed-fleet examples plus light editorial cross-links\n\n## Validation\n- bash /Users/nevitonsantana/orchids-projects/aletheia/scripts/check-governance.sh