### PR TITLE
Add iterative maintenance governance guidance

### DIFF
--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -100,6 +100,9 @@ The current low-regret operational-composition baseline is now anchored by:
 - `examples/handoffs/compact-reviewable-handoff.md`
 - `examples/handoffs/high-stakes-handoff.md`
 - `starter-pack/experiments/workspace-context-routing/README.md`
+- `docs/iterative-maintenance-governance.md`
+- `starter-pack/guides/round-based-maintenance.md`
+- `examples/iterative-maintenance/three-round-loop/README.md`
 
 This means the current operational-composition baseline can now be read across:
 
@@ -107,6 +110,8 @@ This means the current operational-composition baseline can now be read across:
 - risk-sensitive gate selection
 - stronger restart-package continuity
 - optional filesystem-based context routing experiments
+- round-based maintenance guidance over existing work-slice contracts
+- regression-aware continuation and reusable learning across rounds
 
 This layer sits around the Alpha 4 and Alpha 5 baselines without becoming a new core contract family of its own.
 These materials remain intentionally smaller than the core contracts.

--- a/docs/iterative-maintenance-governance.md
+++ b/docs/iterative-maintenance-governance.md
@@ -1,0 +1,136 @@
+# Iterative Maintenance Governance
+
+## Goal
+
+This document explains how AletheIA can learn from **SWE-CI** without trying to become SWE-CI.
+
+The benchmark is useful because it highlights a real operational problem:
+
+**maintenance quality depends on what happens across rounds, not only inside one patch.**
+
+AletheIA can contribute to that problem as a governance layer.
+It does not need to reproduce the benchmark to do so.
+
+---
+
+## What SWE-CI reveals
+
+SWE-CI is valuable because it shifts attention away from one-shot correctness and toward **maintainability across ongoing change**.
+
+That shift matters because real maintenance work is shaped by:
+
+- repeated rounds rather than isolated patches
+- regressions that appear after seemingly successful work
+- early decisions that either support or weaken later iterations
+- the need to resume context without replaying the full history
+
+This is exactly the kind of problem where a framework like AletheIA can help govern better.
+
+---
+
+## What is reference, not direction
+
+AletheIA should treat these parts of SWE-CI as **reference only**:
+
+- the benchmark itself
+- EvoScore as an evaluation metric
+- zero-regression rate as a benchmark scoring output
+- a fixed Architect / Programmer protocol
+- a CI harness or oracle-following runtime
+- a benchmark-shaped environment as a framework requirement
+
+Those pieces are useful for diagnosis.
+They are not the core of AletheIA.
+
+---
+
+## What is directionally compatible
+
+The problem that SWE-CI exposes is highly compatible with AletheIA's existing layers.
+
+AletheIA already has reusable pieces for:
+
+- framing a bounded unit of work
+- recording a decision before execution
+- tying risk posture to validation depth
+- preserving continuity through restart packages
+- storing reusable learnings when a failure or pattern repeats
+- making hidden regression risk more reviewable through structured inference when that is proportional
+
+The practical next move is not a new benchmark layer.
+It is making these pieces more legible in **iterative maintenance loops**.
+
+---
+
+## The compatible thesis
+
+AletheIA can help govern iterative maintenance by making each round more explicit.
+
+In that reading, one round should become easier to understand as:
+
+- a bounded work slice
+- a decision about what this round will and will not attempt
+- an execution step with visible validation expectations
+- a potential regression event that changes the next gate
+- a continuity artifact for the next round or reviewer
+- a place where reusable learning may be captured
+
+This keeps the framework focused on governance rather than on benchmark reproduction.
+
+---
+
+## Regression as a governance event
+
+SWE-CI makes regressions impossible to ignore.
+That is the strongest lesson for AletheIA.
+
+Inside AletheIA, regression should not be read only as a final metric.
+It can also be read as an operational event that affects the current round.
+
+Examples:
+
+- a previously green behavior breaks and the round should no longer close as if it were clean progress
+- a regression can force stronger review or wider validation before the next continuation
+- repeated regressions in the same area should raise the expected gate for later rounds
+- a non-obvious regression can justify a handoff, a learning record, or selective structured inference
+
+That is a governance move, not a benchmark move.
+
+---
+
+## What would drift the framework away from its core
+
+This reference becomes harmful if it pushes AletheIA into:
+
+- benchmark mimicry
+- mandatory dual-agent architecture
+- multi-round runtime orchestration inside the core
+- score-first thinking instead of decision quality and reviewability
+- heavy process for every local or reversible change
+
+AletheIA should stay small enough to teach, inspect, and adapt.
+If a maintenance-oriented idea only works by inflating the framework, it should remain optional or experimental.
+
+---
+
+## Low-regret implementation shape
+
+The lowest-regret way to apply this reference is:
+
+1. treat each round as a composed work slice
+2. strengthen the practical link between regression and gate escalation
+3. make continuity between rounds more restartable
+4. preserve reusable learnings when regressions or validation failures repeat
+5. test the idea through docs, starter-pack guidance, and examples before changing any core contract
+
+That sequence preserves clarity and keeps the experiment reversible.
+
+---
+
+## Suggested next reading
+
+- `starter-pack/guides/round-based-maintenance.md`
+- `docs/work-slice-pattern.md`
+- `starter-pack/guides/risk-to-gate-mapping.md`
+- `docs/structured-risk-inference.md`
+- `examples/iterative-maintenance/three-round-loop/README.md`

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -331,13 +331,17 @@ Current artifacts in this layer now include:
 - `examples/handoffs/compact-reviewable-handoff.md`
 - `examples/handoffs/high-stakes-handoff.md`
 - `starter-pack/experiments/workspace-context-routing/README.md`
+- `docs/iterative-maintenance-governance.md`
+- `starter-pack/guides/round-based-maintenance.md`
+- `examples/iterative-maintenance/three-round-loop/README.md`
 
-Together, these artifacts now define a first operational-composition baseline and strengthen four practical moves without inflating the core:
+Together, these artifacts now define a first operational-composition baseline and strengthen five practical moves without inflating the core:
 
 - make bounded work more legible through composed slices
 - connect risk posture to proof depth and gate choice
 - make handoffs more restartable without making them more bureaucratic
 - test filesystem-based context routing as an optional starter-pack experiment
+- make iterative maintenance rounds more legible through composed slices, regression-aware gates, and reusable learning
 
 ---
 

--- a/docs/work-slice-pattern.md
+++ b/docs/work-slice-pattern.md
@@ -62,6 +62,7 @@ Use a work slice when at least one of these is true:
 - the work will cross an agent, review, or validation boundary
 - the work needs a clearer risk read before execution
 - the work may produce a reusable learning
+- the work is part of an iterative maintenance loop where one round should remain legible from the next
 
 You do **not** need a fully explicit work slice for every tiny action.
 
@@ -117,6 +118,7 @@ They are a practical reading layer.
 | `decision-recorded` | a decision record makes the next step explicit |
 | `execution-in-progress` | an execution record is planned or running |
 | `validation-pending` | execution advanced, but proof or review is still incomplete |
+| `review` | the slice now needs explicit inspection before it may close cleanly |
 | `validated` | the required proof exists and closure is justified |
 | `blocked` | the slice cannot advance safely under current conditions |
 | `escalated` | the next step requires a higher-trust review or human gate |
@@ -124,6 +126,19 @@ They are a practical reading layer.
 
 This vocabulary should stay optional and operational.
 It should not become a new mandatory core state machine at this stage.
+
+### Regression-sensitive progression
+
+In iterative maintenance work, a detected regression may change the slice progression rather than leaving the round on the same path.
+
+A healthy operational read might become:
+
+- `validation-pending -> review` when a previously stable behavior breaks
+- `review -> blocked` when the regression is real and unresolved
+- `blocked -> escalated` when the unresolved regression now requires a higher-trust review or wider validation boundary
+
+This does not create a new engine state machine.
+It makes a governance-relevant event easier to read inside the slice.
 
 ---
 
@@ -198,3 +213,4 @@ This is a convenience pattern, not a required filesystem contract.
 - `examples/work-slices/standard-slice/README.md`
 - `examples/handoffs/compact-reviewable-handoff.md`
 - `examples/handoffs/high-stakes-handoff.md`
+- `examples/iterative-maintenance/three-round-loop/README.md`

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,8 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
   - mostra como task brief, decision, execution, handoff e learning podem compor uma unidade operacional
 - `structured-risk-inference/`
   - mostra exemplos concretos de inference artifacts para risco de refactor e handoff de alto impacto
+- `iterative-maintenance/`
+  - mostra um loop de manutenção em três rodadas com regressão escalando o gate e gerando learning reutilizável
 
 ---
 
@@ -55,3 +57,4 @@ O alpha agora já cobre:
 - risk-to-gate posture examples
 - optional filesystem-context-routing experimentation
 - examples of structured risk inference for bounded semantic-risk scenarios
+- iterative maintenance examples where regression changes the round gate instead of remaining only a final observation

--- a/examples/iterative-maintenance/three-round-loop/README.md
+++ b/examples/iterative-maintenance/three-round-loop/README.md
@@ -1,0 +1,81 @@
+# Iterative Maintenance — Three-Round Loop
+
+## Goal
+
+This example shows how AletheIA can make an iterative maintenance loop more legible **without** introducing a new round schema or copying the SWE-CI benchmark architecture.
+
+The example treats each round as a **work slice composition** built from existing artifacts.
+
+---
+
+## Scenario
+
+A team is maintaining a shared configuration-normalization helper.
+
+The maintenance loop evolves across three rounds:
+
+### Round 1
+- introduces a bounded improvement
+- validates it sufficiently
+- closes without relevant regression
+
+### Round 2
+- expands the helper to another path
+- accidentally regresses a previously stable legacy alias behavior
+- escalates the round instead of pretending progress is clean
+
+### Round 3
+- resolves the regression
+- widens validation because the area now has recent regression history
+- stores a reusable learning for future rounds
+
+---
+
+## Why this matters
+
+The point is not to simulate CI scoring.
+The point is to show that AletheIA can make a maintenance loop easier to read across:
+
+- round framing
+- decision continuity
+- regression-aware gating
+- restartable handoff
+- reusable learning
+
+---
+
+## Artifact layout
+
+### `round-1/`
+- `README.md`
+- `task-brief.json`
+- `decision-record.json`
+- `execution-record.json`
+
+### `round-2/`
+- `README.md`
+- `task-brief.json`
+- `decision-record.json`
+- `execution-record.json`
+- `handoff-record.json`
+
+### `round-3/`
+- `README.md`
+- `task-brief.json`
+- `decision-record.json`
+- `execution-record.json`
+- `handoff-record.json`
+- `learning-record.json`
+
+---
+
+## Experimental question
+
+Does this example make a maintenance loop:
+
+- more legible
+- more auditable
+- less dependent on implicit memory
+- more explicit about how regression changes the next gate?
+
+If not, the pattern should stay optional and continue evolving before any contract is hardened.

--- a/examples/iterative-maintenance/three-round-loop/round-1/README.md
+++ b/examples/iterative-maintenance/three-round-loop/round-1/README.md
@@ -1,0 +1,19 @@
+# Round 1
+
+## Goal
+
+Introduce a bounded normalization improvement in one code path.
+
+## Read of the round
+
+This round is still narrow enough to close with normal proof.
+It does not yet carry meaningful regression history.
+
+## Expected progression
+
+- framed
+- context-scoped
+- decision-recorded
+- execution-in-progress
+- validation-pending
+- validated

--- a/examples/iterative-maintenance/three-round-loop/round-1/decision-record.json
+++ b/examples/iterative-maintenance/three-round-loop/round-1/decision-record.json
@@ -1,0 +1,69 @@
+{
+  "id": "decision-iter-maint-round-1",
+  "task_brief_id": "task-iter-maint-round-1",
+  "input": {
+    "signal": "Clean up one configuration-normalization path without widening the maintenance surface too early",
+    "raw": {
+      "requester": "maintainer",
+      "loop": "iterative-maintenance"
+    }
+  },
+  "context_snapshot": {
+    "summary": "The helper already supports stable legacy aliases elsewhere. This round should improve one bounded path while preserving that older behavior.",
+    "sources_considered": [
+      "current helper behavior notes",
+      "existing validation assumptions",
+      "prior stable alias semantics"
+    ],
+    "omitted_context": [
+      "future global cleanup ideas",
+      "unrelated integration modules"
+    ]
+  },
+  "interpretation": {
+    "summary": "A bounded first round is safer than expanding the helper broadly before the new behavior has proved stable.",
+    "key_signals": [
+      "the improvement is local enough for a normal maintenance round",
+      "the helper already has stable behavior that must not drift",
+      "the round is medium risk because shared helper semantics are reusable"
+    ],
+    "assumptions": [
+      "Targeted regression checking is enough at this stage.",
+      "No handoff is needed if the round closes cleanly."
+    ]
+  },
+  "decision": {
+    "action": "continue",
+    "target": "bounded helper normalization in the primary path",
+    "next_step": "Implement the local improvement and validate it against current stable behavior."
+  },
+  "justification": {
+    "reason": "The round is narrow, the validation plan is visible, and regressions can still be checked directly before closure.",
+    "policy_refs": [
+      "clarity over speed",
+      "bounded change before wider expansion",
+      "validation should stay proportional to risk"
+    ]
+  },
+  "provenance": {
+    "facts": [
+      "The target path is local and currently inconsistent.",
+      "Legacy alias behavior elsewhere is already treated as stable.",
+      "The round deliberately avoids multi-path expansion."
+    ],
+    "inferences": [
+      "A clean first round will make later expansion safer.",
+      "The main risk is accidental behavior drift rather than architectural failure."
+    ],
+    "rules_applied": [
+      "prefer bounded rounds before broader maintenance",
+      "preserve stable behavior when changing a shared helper"
+    ]
+  },
+  "metadata": {
+    "confidence": 0.87,
+    "risk": "medium",
+    "trace_id": "trace-iter-maint-round-1",
+    "created_at": "2026-04-08T16:10:00Z"
+  }
+}

--- a/examples/iterative-maintenance/three-round-loop/round-1/execution-record.json
+++ b/examples/iterative-maintenance/three-round-loop/round-1/execution-record.json
@@ -1,0 +1,39 @@
+{
+  "id": "execution-iter-maint-round-1",
+  "decision_id": "decision-iter-maint-round-1",
+  "adapter": {
+    "name": "repo-native-maintenance-round",
+    "mode": "local"
+  },
+  "target": {
+    "kind": "shared_helper_round",
+    "ref": "config-normalization-round-1"
+  },
+  "environment": {
+    "branch": "codex/iterative-maintenance-governance",
+    "sandbox": true
+  },
+  "status": "completed",
+  "result_summary": "The primary normalization path was improved and the round closed with targeted proof and no relevant regression detected.",
+  "validations": [
+    {
+      "name": "primary-path tests",
+      "status": "pass",
+      "evidence_ref": "tests/primary-normalization"
+    },
+    {
+      "name": "legacy alias regression check",
+      "status": "pass",
+      "evidence_ref": "tests/legacy-aliases"
+    },
+    {
+      "name": "diff inspection",
+      "status": "pass",
+      "evidence_ref": "review-notes/round-1-diff"
+    }
+  ],
+  "timestamps": {
+    "started_at": "2026-04-08T16:20:00Z",
+    "finished_at": "2026-04-08T16:45:00Z"
+  }
+}

--- a/examples/iterative-maintenance/three-round-loop/round-1/task-brief.json
+++ b/examples/iterative-maintenance/three-round-loop/round-1/task-brief.json
@@ -1,0 +1,38 @@
+{
+  "id": "task-iter-maint-round-1",
+  "title": "Normalize configuration keys in the primary helper path",
+  "problem": "The current helper normalizes casing inconsistently in one primary path, which makes downstream behavior harder to reason about.",
+  "objective": "Improve normalization in the primary path without changing legacy alias behavior in other already-stable call sites.",
+  "classification": {
+    "task_type": "B",
+    "severity": "S2",
+    "risk": "medium"
+  },
+  "scope": {
+    "in": [
+      "shared helper behavior in the primary path",
+      "targeted validation notes"
+    ],
+    "out": [
+      "secondary integration paths",
+      "global interface redesign",
+      "schema or engine changes"
+    ]
+  },
+  "constraints": [
+    "Keep the round bounded to one path.",
+    "Do not widen the helper contract beyond what this round can validate.",
+    "Preserve already-stable legacy alias behavior."
+  ],
+  "success_criteria": [
+    "Primary-path normalization becomes consistent.",
+    "No known stable behavior regresses.",
+    "The round can close with targeted validation."
+  ],
+  "validation_plan": [
+    "Targeted tests for the primary path",
+    "Regression check for existing alias behavior",
+    "Diff inspection"
+  ],
+  "human_gate_required": false
+}

--- a/examples/iterative-maintenance/three-round-loop/round-2/README.md
+++ b/examples/iterative-maintenance/three-round-loop/round-2/README.md
@@ -1,0 +1,20 @@
+# Round 2
+
+## Goal
+
+Expand the shared helper to a second path while preserving the stable behavior that Round 1 left intact.
+
+## Read of the round
+
+This round looks similar on the surface, but it now sits on top of a fresh shared-helper change.
+That makes regression more important.
+
+## Expected progression
+
+- framed
+- context-scoped
+- decision-recorded
+- execution-in-progress
+- validation-pending
+- review
+- blocked

--- a/examples/iterative-maintenance/three-round-loop/round-2/decision-record.json
+++ b/examples/iterative-maintenance/three-round-loop/round-2/decision-record.json
@@ -1,0 +1,69 @@
+{
+  "id": "decision-iter-maint-round-2",
+  "task_brief_id": "task-iter-maint-round-2",
+  "input": {
+    "signal": "Reuse the shared helper in a second path without losing prior guarantees",
+    "raw": {
+      "requester": "maintainer",
+      "loop": "iterative-maintenance"
+    }
+  },
+  "context_snapshot": {
+    "summary": "Round 1 closed cleanly, but the helper is now more reused than before. Round 2 must treat regression risk more seriously.",
+    "sources_considered": [
+      "round-1 task brief",
+      "round-1 decision record",
+      "round-1 execution record",
+      "stable alias behavior expectations"
+    ],
+    "omitted_context": [
+      "longer-term helper redesign ideas",
+      "unrelated maintenance backlog"
+    ]
+  },
+  "interpretation": {
+    "summary": "This round may continue, but only with stronger attention to regression because the shared helper now influences more than one path.",
+    "key_signals": [
+      "the change reuses a path already touched in a previous round",
+      "stable behavior must be preserved across both call paths",
+      "the validation plan must catch semantic drift, not just syntax-level success"
+    ],
+    "assumptions": [
+      "A regression should move the round into explicit review rather than quiet closure.",
+      "A restartable handoff should be prepared if validation fails."
+    ]
+  },
+  "decision": {
+    "action": "continue",
+    "target": "secondary-path helper reuse with widened validation",
+    "next_step": "Execute the reuse and stop the round if cross-path validation reveals regression."
+  },
+  "justification": {
+    "reason": "The round is still bounded, but it sits on top of a now-sensitive helper path and therefore deserves a stronger regression read.",
+    "policy_refs": [
+      "recent regression risk increases proof expectations",
+      "shared helpers deserve stronger review when reuse expands"
+    ]
+  },
+  "provenance": {
+    "facts": [
+      "Round 1 modified the helper successfully.",
+      "Round 2 expands reuse to a second path.",
+      "Legacy alias behavior remains a critical stable expectation."
+    ],
+    "inferences": [
+      "A clean-looking change can still introduce semantic regression.",
+      "This round should be ready to stop at review if prior guarantees break."
+    ],
+    "rules_applied": [
+      "use regression history to widen validation",
+      "prefer explicit review over silent continuation when a stable behavior breaks"
+    ]
+  },
+  "metadata": {
+    "confidence": 0.8,
+    "risk": "medium",
+    "trace_id": "trace-iter-maint-round-2",
+    "created_at": "2026-04-08T17:05:00Z"
+  }
+}

--- a/examples/iterative-maintenance/three-round-loop/round-2/execution-record.json
+++ b/examples/iterative-maintenance/three-round-loop/round-2/execution-record.json
@@ -1,0 +1,39 @@
+{
+  "id": "execution-iter-maint-round-2",
+  "decision_id": "decision-iter-maint-round-2",
+  "adapter": {
+    "name": "repo-native-maintenance-round",
+    "mode": "local"
+  },
+  "target": {
+    "kind": "shared_helper_round",
+    "ref": "config-normalization-round-2"
+  },
+  "environment": {
+    "branch": "codex/iterative-maintenance-governance",
+    "sandbox": true
+  },
+  "status": "completed",
+  "result_summary": "The helper was reused in the second path, but validation exposed a regression in previously stable legacy alias handling.",
+  "validations": [
+    {
+      "name": "secondary-path tests",
+      "status": "pass",
+      "evidence_ref": "tests/secondary-path"
+    },
+    {
+      "name": "legacy alias regression check",
+      "status": "fail",
+      "evidence_ref": "tests/legacy-aliases"
+    },
+    {
+      "name": "semantic review across both paths",
+      "status": "warn",
+      "evidence_ref": "review-notes/round-2-semantics"
+    }
+  ],
+  "timestamps": {
+    "started_at": "2026-04-08T17:10:00Z",
+    "finished_at": "2026-04-08T17:42:00Z"
+  }
+}

--- a/examples/iterative-maintenance/three-round-loop/round-2/handoff-record.json
+++ b/examples/iterative-maintenance/three-round-loop/round-2/handoff-record.json
@@ -1,0 +1,37 @@
+{
+  "id": "handoff-iter-maint-round-2",
+  "task_brief_id": "task-iter-maint-round-2",
+  "origin": {
+    "actor": "maintenance-agent",
+    "thread": "iterative-maintenance-round-2",
+    "date": "2026-04-08T17:48:00Z"
+  },
+  "status": "blocked_on_regression",
+  "completed": [
+    "Secondary-path reuse of the shared helper was implemented.",
+    "Cross-path validation was run instead of closing on local success alone.",
+    "A legacy alias regression was made explicit before the round closed."
+  ],
+  "pending": [
+    "Repair the legacy alias regression before this maintenance chain resumes normal closure.",
+    "Re-read whether the next round needs stronger validation because the helper now has recent regression history."
+  ],
+  "risks": [
+    "If the regression is treated as minor noise, later rounds may accumulate hidden debt.",
+    "The helper now has a proven history of semantic drift across paths."
+  ],
+  "reopen_context": {
+    "summary": "Round 2 cannot be read as clean progress. The helper reuse works locally, but a previously stable behavior broke and the next round must start from that fact rather than from the implementation diff alone.",
+    "required_files": [
+      "round-2/task-brief.json",
+      "round-2/decision-record.json",
+      "round-2/execution-record.json"
+    ],
+    "next_action": "Start the next round from regression repair and widened validation, not from feature expansion."
+  },
+  "validation_next": [
+    "Repair validation for legacy aliases",
+    "Cross-path semantic review after the repair",
+    "Decision on whether a reusable learning should be stored once the round stabilizes"
+  ]
+}

--- a/examples/iterative-maintenance/three-round-loop/round-2/task-brief.json
+++ b/examples/iterative-maintenance/three-round-loop/round-2/task-brief.json
@@ -1,0 +1,39 @@
+{
+  "id": "task-iter-maint-round-2",
+  "title": "Extend shared normalization helper to the secondary integration path",
+  "problem": "The second integration path still uses older normalization logic, which creates drift against the new primary-path behavior.",
+  "objective": "Reuse the helper across the secondary path without regressing the stable legacy alias behavior already preserved in Round 1.",
+  "classification": {
+    "task_type": "B",
+    "severity": "S2",
+    "risk": "medium"
+  },
+  "scope": {
+    "in": [
+      "secondary integration path",
+      "shared helper reuse",
+      "validation updates for cross-path behavior"
+    ],
+    "out": [
+      "public interface redesign",
+      "policy changes",
+      "new round-specific schema"
+    ]
+  },
+  "constraints": [
+    "Treat the helper as a regression-sensitive area now that one round has already modified it.",
+    "Do not close the round on confidence alone if previously stable behavior breaks.",
+    "Prepare restartable context if review becomes necessary."
+  ],
+  "success_criteria": [
+    "The secondary path uses the shared helper consistently.",
+    "Legacy alias behavior remains intact.",
+    "The round either closes with proof or stops explicitly at a regression boundary."
+  ],
+  "validation_plan": [
+    "Cross-path tests",
+    "Regression check for legacy alias behavior",
+    "Review of helper semantics across both paths"
+  ],
+  "human_gate_required": false
+}

--- a/examples/iterative-maintenance/three-round-loop/round-3/README.md
+++ b/examples/iterative-maintenance/three-round-loop/round-3/README.md
@@ -1,0 +1,21 @@
+# Round 3
+
+## Goal
+
+Resolve the regression introduced in Round 2 and strengthen future maintenance in the same area.
+
+## Read of the round
+
+This round inherits a regression history.
+That means wider validation is now justified even though the immediate objective is still bounded.
+
+## Expected progression
+
+- framed
+- context-scoped
+- decision-recorded
+- execution-in-progress
+- validation-pending
+- review
+- validated
+- learning-stored

--- a/examples/iterative-maintenance/three-round-loop/round-3/decision-record.json
+++ b/examples/iterative-maintenance/three-round-loop/round-3/decision-record.json
@@ -1,0 +1,70 @@
+{
+  "id": "decision-iter-maint-round-3",
+  "task_brief_id": "task-iter-maint-round-3",
+  "input": {
+    "signal": "Repair the regression first and only then restore normal maintenance confidence",
+    "raw": {
+      "requester": "maintainer",
+      "loop": "iterative-maintenance"
+    }
+  },
+  "context_snapshot": {
+    "summary": "Round 2 proved that the helper can drift semantically across paths. Round 3 must start from regression repair and stronger proof, not from more expansion.",
+    "sources_considered": [
+      "round-2 task brief",
+      "round-2 decision record",
+      "round-2 execution record",
+      "round-2 handoff record"
+    ],
+    "omitted_context": [
+      "future broad cleanup plans",
+      "unrelated backlog items"
+    ]
+  },
+  "interpretation": {
+    "summary": "The next safe move is to restore prior guarantees, widen validation, and preserve a learning that future rounds can reuse.",
+    "key_signals": [
+      "a previously stable behavior already regressed once",
+      "the helper is now a regression-sensitive area",
+      "future rounds should inherit stronger default scrutiny here"
+    ],
+    "assumptions": [
+      "The regression is concrete enough that targeted repair is preferable to abstract redesign.",
+      "A learning record is warranted if the validation gap is clearly reusable."
+    ]
+  },
+  "decision": {
+    "action": "continue",
+    "target": "regression repair plus widened validation",
+    "next_step": "Repair the alias behavior, run stronger validation, and store the resulting lesson if the round stabilizes."
+  },
+  "justification": {
+    "reason": "The area now has known regression history, so the round should prioritize repair, stronger proof, and future prevention over further expansion.",
+    "policy_refs": [
+      "recent regression history increases the gate",
+      "repair before expansion",
+      "learning should capture repeatable validation gaps"
+    ]
+  },
+  "provenance": {
+    "facts": [
+      "Round 2 introduced a legacy alias regression.",
+      "The helper now affects more than one path.",
+      "The next round must prove restored stability, not just local correctness."
+    ],
+    "inferences": [
+      "A stronger validation set is now proportional.",
+      "The loop should leave behind a reusable maintenance lesson."
+    ],
+    "rules_applied": [
+      "raise the gate after unresolved regression",
+      "capture learning when a missing validation rule becomes obvious"
+    ]
+  },
+  "metadata": {
+    "confidence": 0.86,
+    "risk": "medium",
+    "trace_id": "trace-iter-maint-round-3",
+    "created_at": "2026-04-08T18:10:00Z"
+  }
+}

--- a/examples/iterative-maintenance/three-round-loop/round-3/execution-record.json
+++ b/examples/iterative-maintenance/three-round-loop/round-3/execution-record.json
@@ -1,0 +1,44 @@
+{
+  "id": "execution-iter-maint-round-3",
+  "decision_id": "decision-iter-maint-round-3",
+  "adapter": {
+    "name": "repo-native-maintenance-round",
+    "mode": "local"
+  },
+  "target": {
+    "kind": "shared_helper_round",
+    "ref": "config-normalization-round-3"
+  },
+  "environment": {
+    "branch": "codex/iterative-maintenance-governance",
+    "sandbox": true
+  },
+  "status": "completed",
+  "result_summary": "The legacy alias regression was repaired and the shared helper now closes under wider validation because the area has recent regression history.",
+  "validations": [
+    {
+      "name": "legacy alias regression test",
+      "status": "pass",
+      "evidence_ref": "tests/legacy-aliases"
+    },
+    {
+      "name": "cross-path semantic review",
+      "status": "pass",
+      "evidence_ref": "review-notes/round-3-semantics"
+    },
+    {
+      "name": "wider helper validation set",
+      "status": "pass",
+      "evidence_ref": "tests/helper-wide-validation"
+    },
+    {
+      "name": "diff inspection",
+      "status": "pass",
+      "evidence_ref": "review-notes/round-3-diff"
+    }
+  ],
+  "timestamps": {
+    "started_at": "2026-04-08T18:18:00Z",
+    "finished_at": "2026-04-08T18:52:00Z"
+  }
+}

--- a/examples/iterative-maintenance/three-round-loop/round-3/handoff-record.json
+++ b/examples/iterative-maintenance/three-round-loop/round-3/handoff-record.json
@@ -1,0 +1,35 @@
+{
+  "id": "handoff-iter-maint-round-3",
+  "task_brief_id": "task-iter-maint-round-3",
+  "origin": {
+    "actor": "maintenance-agent",
+    "thread": "iterative-maintenance-round-3",
+    "date": "2026-04-08T18:57:00Z"
+  },
+  "status": "ready_for_next_round",
+  "completed": [
+    "The legacy alias regression was repaired.",
+    "The helper was re-validated with a wider proof set than earlier rounds used.",
+    "A reusable learning was captured for future maintenance in the same area."
+  ],
+  "pending": [
+    "Keep future helper rounds aware that this area now has meaningful regression history.",
+    "Prefer stronger cross-path validation before any further expansion."
+  ],
+  "risks": [
+    "Future rounds may re-open semantic drift if they assume the helper is low-risk again too early."
+  ],
+  "reopen_context": {
+    "summary": "The loop is stable again, but the area should no longer be treated as if it had no recent regression history. Future rounds should inherit a stronger default validation posture here.",
+    "required_files": [
+      "round-3/task-brief.json",
+      "round-3/execution-record.json",
+      "round-3/learning-record.json"
+    ],
+    "next_action": "Use the repaired helper as the new baseline and keep validation wider on the next maintenance move."
+  },
+  "validation_next": [
+    "Use the wider helper validation set as the new default starting point",
+    "Check whether future helper changes still preserve legacy alias semantics"
+  ]
+}

--- a/examples/iterative-maintenance/three-round-loop/round-3/learning-record.json
+++ b/examples/iterative-maintenance/three-round-loop/round-3/learning-record.json
@@ -1,0 +1,27 @@
+{
+  "id": "learning-iter-maint-round-3",
+  "source": {
+    "type": "review",
+    "ref": "handoff-iter-maint-round-3"
+  },
+  "learning_type": "pattern",
+  "title": "Recent regression history should widen validation for the next maintenance round",
+  "summary": "When a shared helper regresses a previously stable behavior during iterative maintenance, the next round should not restart from a clean-risk assumption. It should widen validation and treat the area as regression-sensitive until stability is re-established.",
+  "evidence": [
+    "task-iter-maint-round-2",
+    "execution-iter-maint-round-2",
+    "task-iter-maint-round-3",
+    "execution-iter-maint-round-3"
+  ],
+  "actionability": {
+    "apply_to": [
+      "starter-pack guide",
+      "review checklist"
+    ],
+    "recommended_change": "When recent regression history exists in a shared area, raise the default validation posture for the next round instead of treating the next change as if the area were clean."
+  },
+  "review": {
+    "status": "accepted",
+    "approved_by": "framework-designer"
+  }
+}

--- a/examples/iterative-maintenance/three-round-loop/round-3/task-brief.json
+++ b/examples/iterative-maintenance/three-round-loop/round-3/task-brief.json
@@ -1,0 +1,40 @@
+{
+  "id": "task-iter-maint-round-3",
+  "title": "Repair the legacy alias regression and stabilize future helper maintenance",
+  "problem": "Round 2 expanded helper reuse but regressed a previously stable alias behavior, so the maintenance chain cannot continue as if the area were clean.",
+  "objective": "Restore the stable alias behavior, widen validation for the shared helper, and capture a reusable lesson for future rounds.",
+  "classification": {
+    "task_type": "B",
+    "severity": "S2",
+    "risk": "medium"
+  },
+  "scope": {
+    "in": [
+      "repair of the alias regression",
+      "stronger helper validation",
+      "learning capture for future rounds"
+    ],
+    "out": [
+      "broader helper redesign",
+      "benchmark scoring",
+      "new policy or schema families"
+    ]
+  },
+  "constraints": [
+    "Treat the helper as regression-sensitive until stability is re-established.",
+    "Do not resume feature expansion before the regression is repaired.",
+    "Capture a reusable learning if the repair exposes a repeatable pattern."
+  ],
+  "success_criteria": [
+    "The legacy alias behavior is restored.",
+    "Validation is wider than in Round 1 because the area now has regression history.",
+    "The loop leaves behind a reusable lesson rather than only a repaired diff."
+  ],
+  "validation_plan": [
+    "Legacy alias regression test",
+    "Cross-path semantic review",
+    "Wider helper validation set",
+    "Diff inspection"
+  ],
+  "human_gate_required": false
+}

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -66,8 +66,12 @@ If you want to make bounded work more tangible without changing the core contrac
 - `examples/work-slices/standard-slice/README.md`
 - `examples/handoffs/compact-reviewable-handoff.md`
 - `examples/handoffs/high-stakes-handoff.md`
+- `docs/iterative-maintenance-governance.md`
+- `starter-pack/guides/round-based-maintenance.md`
+- `examples/iterative-maintenance/three-round-loop/README.md`
 
 This baseline is intentionally smaller than the core contracts and mainly reinforces Alpha 4 continuity plus Alpha 5 validation posture.
+It now also makes iterative maintenance rounds and regression-aware continuation more tangible without changing the core contracts.
 
 ## Experimental workspace context routing
 

--- a/starter-pack/guides/risk-to-gate-mapping.md
+++ b/starter-pack/guides/risk-to-gate-mapping.md
@@ -154,6 +154,24 @@ Even if the base task looks moderate, increase the gate when one or more of thes
 
 ---
 
+## Regression-sensitive escalation
+
+A regression is not only a validation datapoint.
+It can change the current slice state and the next gate.
+
+If a previously stable behavior breaks during a round, a practical read is:
+
+- `validation-pending -> review`
+- `review -> blocked` when the regression is confirmed and unresolved
+- `blocked -> escalated` when the regression becomes high-impact, crosses a trust boundary, or demands a stronger review lane
+
+Regression history should also affect later rounds.
+If the same area already regressed recently, start the next round with stronger expected proof than a clean area would need.
+
+When the regression is semantic and difficult to validate directly, selective structured inference may become proportional even if it would not have been warranted in a cleaner round.
+
+---
+
 ## Common block triggers
 
 Block or slow closure when:
@@ -193,3 +211,5 @@ See these governance examples for a compact posture mapping:
 - `docs/work-slice-pattern.md`
 - `docs/structured-risk-inference.md`
 - `docs/agent-handoffs.md`
+- `starter-pack/guides/round-based-maintenance.md`
+- `examples/iterative-maintenance/three-round-loop/README.md`

--- a/starter-pack/guides/round-based-maintenance.md
+++ b/starter-pack/guides/round-based-maintenance.md
@@ -1,0 +1,173 @@
+# Round-Based Maintenance
+
+## Goal
+
+This guide explains how to operate **iterative maintenance work** with AletheIA by treating each round as a **composed work slice**.
+
+It does not introduce a new round schema.
+It does not require a benchmark harness.
+It uses the contracts that already exist.
+
+---
+
+## What a round is
+
+A round is one bounded maintenance move inside a longer chain of evolution.
+
+A healthy round should answer:
+
+- what this iteration is trying to improve
+- what it will deliberately leave for later
+- what risk it carries
+- what proof is required before it may close
+- whether a regression changed the next step
+
+A round is not the whole maintenance story.
+It is one legible step inside that story.
+
+---
+
+## Round as work slice
+
+The safest way to model a round in AletheIA is as a **work slice composition**.
+
+A round can usually be made explicit through:
+
+1. `task brief`
+2. `decision record`
+3. `execution record`
+4. `handoff record` when the next boundary matters
+5. `learning record` when the round generates reusable learning
+
+This means round-based maintenance should begin as an operating pattern, not as a new core contract family.
+
+---
+
+## Generic roles inside a round
+
+You do not need to copy SWE-CI's exact roles.
+AletheIA can stay generic.
+
+A practical round often involves some mix of:
+
+- **planner** — frames the next bounded move
+- **executor** — performs the change
+- **reviewer** — evaluates whether the round may truly advance or must slow down
+
+Sometimes one agent or one human may play more than one role.
+The important part is that the transitions stay reviewable.
+
+---
+
+## What the decision record should clarify
+
+Before execution, the round should make explicit:
+
+- the current gap being addressed
+- what was accepted into this round
+- what was intentionally left out
+- what risk posture applies
+- what validation is expected
+- what kind of failure would change the gate
+
+That is what keeps a round from collapsing into “another attempt.”
+
+---
+
+## Minimum validation for a round
+
+Every round should declare its minimum proof before execution ends.
+
+That proof might include:
+
+- targeted tests
+- smoke checks
+- diff inspection
+- review of sensitive files
+- contract consistency checks
+- selective structured inference when semantic risk is hard to validate directly
+
+The key is not maximum ceremony.
+The key is visible closure discipline.
+
+---
+
+## Regression as a round event
+
+If a previously stable behavior breaks, the round should no longer be read as clean progress.
+
+In practice, regression can change the round in several ways:
+
+- `validation-pending -> review`
+- `review -> blocked`
+- `blocked -> escalated` when the regression stays unresolved or becomes more sensitive
+
+Regression should also influence later rounds.
+A recent regression in the same area is a signal that the next round deserves a stronger gate.
+
+---
+
+## When to widen the gate
+
+Increase the validation or review burden when:
+
+- a round touches a path with recent regression history
+- the new change sits on top of an earlier fragile decision
+- the regression is semantic and not easy to catch by simple tests
+- the next round crosses an agent or ownership boundary
+- the cost of another failure is now higher than in the first round
+
+Do not widen the gate just because work is iterative.
+Widen it because the round history justifies it.
+
+---
+
+## When to hand off
+
+Generate a handoff when:
+
+- a reviewer or next maintainer needs to resume from the current round
+- a regression changed the expected next action
+- the next iteration depends on a compact summary of what failed, what was fixed, and what is still open
+- the round should pause at a review or trust boundary
+
+A handoff should remain a restart package, not a transcript of the whole loop.
+
+---
+
+## When to generate a learning record
+
+Generate a learning record when the round exposed something reusable, for example:
+
+- a recurring regression pattern
+- a missing validation rule
+- a fragile module that deserves stronger default scrutiny next time
+- a context gap that made the wrong change easier to introduce
+- a planner/executor/reviewer coordination mistake that is likely to repeat
+
+Learning is most useful when it helps the next round avoid the same failure mode.
+
+---
+
+## Suggested round recipe
+
+1. Frame the round as a bounded work slice.
+2. Record the round decision before execution.
+3. Execute with the minimum declared validation.
+4. If regression appears, change the round state and re-read the gate.
+5. Create a handoff if the next boundary matters.
+6. Store a learning record if the round taught something reusable.
+
+---
+
+## Example
+
+See:
+
+- `examples/iterative-maintenance/three-round-loop/README.md`
+
+That example shows a three-round loop where:
+
+- Round 1 closes cleanly
+- Round 2 introduces a regression and escalates the gate
+- Round 3 resolves the regression, widens validation, and stores a reusable learning


### PR DESCRIPTION
## Summary\n- add SWE-CI-inspired iterative-maintenance governance guidance without changing the core\n- add a round-based maintenance starter-pack guide and make regression a more explicit gate event\n- add a three-round maintenance example showing clean progress, regression escalation, and learning capture\n\n## Validation\n- bash /Users/nevitonsantana/orchids-projects/aletheia/scripts/check-governance.sh