### PR TITLE
Harden Alpha 2 bridge with pilot evidence

### DIFF
--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -28,7 +28,7 @@ The public repository is organized around three blocks:
    - how pilot learnings return into framework evolution
    - how self-application, pilot conversion, and project extension stay connected
 
-The Crisis Monitor pilot is the first concrete example of this bridge.
+The Crisis Monitor pilot is the first concrete example of this bridge, and it now includes real-world validation beyond the first explicability slice.
 
 The key idea is simple:
 
@@ -37,7 +37,7 @@ AletheIA should be reusable outside the original pilot while still preserving th
 That reuse depends on an explicit boundary between the framework core and each project's local extension layer.
 
 
-At this point, Alpha 2 is organized around four explicit bridge artifacts:
+At this point, Alpha 2 is organized around four explicit bridge artifacts and is now supported by stronger real-world validation from the Crisis Monitor pilot:
 
 - `docs/self-application.md`
 - `docs/pilot-crisis-monitor.md`
@@ -113,6 +113,7 @@ This means the current operational-composition baseline can now be read across:
 - optional filesystem-based context routing experiments
 - round-based maintenance guidance over existing work-slice contracts
 - regression-aware continuation and reusable learning across rounds
+- a more tangible operational reading of important loops through proof, contract, health, alert, investigation, and lane summary
 
 Alongside that operational layer, the starter-pack now also carries an advisory-only model-strategy guidance slice that helps projects map task shape, capability profile, reasoning depth, and trust / hosting posture into their local model fleets without making vendor choice part of the framework core.
 

--- a/docs/iterative-maintenance-governance.md
+++ b/docs/iterative-maintenance-governance.md
@@ -21,6 +21,7 @@ That shift matters because real maintenance work is shaped by:
 
 - repeated rounds rather than isolated patches
 - regressions that appear after seemingly successful work
+- regressions that may stay partially silent until someone looks at the lane health
 - early decisions that either support or weaken later iterations
 - the need to resume context without replaying the full history
 
@@ -93,8 +94,24 @@ Examples:
 - a regression can force stronger review or wider validation before the next continuation
 - repeated regressions in the same area should raise the expected gate for later rounds
 - a non-obvious regression can justify a handoff, a learning record, or selective structured inference
+- a silent degradation can justify a small lane health reading before the next round is treated as trustworthy
 
 That is a governance move, not a benchmark move.
+
+---
+
+## A practical operational reading
+
+In higher-value iterative loops, the most useful operational sequence is often:
+
+1. **proof** — establish that the lane or round actually works in a real slice
+2. **contract** — harden consistency around what the lane is supposed to mean
+3. **health metric** — make the lane readable as a health signal, not only as a successful patch
+4. **alert** — surface degradation before it becomes purely anecdotal
+5. **investigation** — make the degraded case inspectable without replaying everything
+6. **lane summary** — keep a compact readout of the current operational picture
+
+This sequence should be read as a **proportional pattern**, not as a universal framework obligation.
 
 ---
 
@@ -107,6 +124,7 @@ This reference becomes harmful if it pushes AletheIA into:
 - multi-round runtime orchestration inside the core
 - score-first thinking instead of decision quality and reviewability
 - heavy process for every local or reversible change
+- treating observability as mandatory framework infrastructure for every project
 
 AletheIA should stay small enough to teach, inspect, and adapt.
 If a maintenance-oriented idea only works by inflating the framework, it should remain optional or experimental.
@@ -121,9 +139,27 @@ The lowest-regret way to apply this reference is:
 2. strengthen the practical link between regression and gate escalation
 3. make continuity between rounds more restartable
 4. preserve reusable learnings when regressions or validation failures repeat
-5. test the idea through docs, starter-pack guidance, and examples before changing any core contract
+5. use small operational readings when a loop is important enough to justify them
+6. test the idea through docs, starter-pack guidance, and examples before changing any core contract
 
 That sequence preserves clarity and keeps the experiment reversible.
+
+---
+
+## What recent real-world evidence changed
+
+The Crisis Monitor pilot did not turn AletheIA into an observability framework.
+
+What it did was make one important point more concrete:
+
+**iterative maintenance is easier to govern when silent degradation becomes legible before the next continuation is treated as safe.**
+
+That real-world evidence makes iterative maintenance in AletheIA less abstract.
+It shows that rounds, gates, continuity, and reusable learning are stronger when a meaningful loop can also answer:
+
+- is the lane still coherent?
+- is the explainability still there?
+- are we continuing on top of a fragile step without noticing?
 
 ---
 
@@ -134,3 +170,4 @@ That sequence preserves clarity and keeps the experiment reversible.
 - `starter-pack/guides/risk-to-gate-mapping.md`
 - `docs/structured-risk-inference.md`
 - `examples/iterative-maintenance/three-round-loop/README.md`
+- `examples/pilot-conversion/crisis-monitor-real-world-validation.md`

--- a/docs/pilot-conversion.md
+++ b/docs/pilot-conversion.md
@@ -43,6 +43,7 @@ Sometimes it should become:
 - a governance clarification
 - a policy pack refinement
 - a test or executable baseline improvement
+- a new example that makes the conversion path inspectable
 
 The job of conversion is to choose the smallest reusable form that preserves the learning.
 
@@ -59,6 +60,7 @@ Examples:
 - users did not understand why approval was needed
 - audit and chat were telling different stories
 - a pilot slice proved a smaller-first strategy works better
+- a lane started to degrade quietly even though the main flow still worked
 
 ### 2. Write the learning explicitly
 
@@ -104,6 +106,7 @@ Examples:
 - token discipline
 - enforcement boundaries
 - durable decision discipline
+- iterative maintenance framing
 
 ### 2. Starter-pack artifact
 
@@ -114,6 +117,7 @@ Examples:
 - a guide
 - a checklist
 - a template
+- a repeatable sequence for proof, review, and escalation
 
 ### 3. Governance refinement
 
@@ -156,6 +160,10 @@ If the learning is useful, decide what kind of artifact it should become.
 
 A lightweight doc or template may be the right first conversion.
 
+### Do not mistake observability in one pilot for a universal framework requirement
+
+A useful lane metric or scorecard in one product can justify a framework learning without turning observability into mandatory framework infrastructure.
+
 ---
 
 ## Good Alpha 2 signs
@@ -165,25 +173,36 @@ Alpha 2 is going well when:
 - a real pilot learning can be traced to a merged framework change
 - the framework change is smaller than the pilot itself
 - the reusable part is separated from the product residue
-- the repo shows a growing chain of pilot -> learning -> improvement
+- the repo shows a growing chain of `pilot -> learning -> improvement`
+- the latest field evidence makes older framework guidance more concrete rather than more abstract
 
 ---
 
 ## Crisis Monitor example
 
-The Crisis Monitor pilot already produced reusable lessons such as:
+The Crisis Monitor pilot now provides a stronger conversion example than an early explicability slice alone.
 
-- start with low-risk explicability improvements
-- validate decision and audit together
-- prefer controlled reversible actions in early proof
+The recent chain was:
 
-Those lessons already influenced framework artifacts like:
+1. real authenticated smoke proved the lane under real conditions
+2. explainability contract hardening made the lane more coherent
+3. a health metric and alert exposed explainability degradation risk
+4. an investigable decision feed made the gap reviewable by occurrence
+5. a lane scorecard summarized the operational picture
+6. the framework absorbed the reusable part as stronger Alpha 2 and iterative-maintenance guidance
 
-- governance clarity
-- durable decision discipline
-- enforcement-boundary clarification
+What remained product-specific:
 
-This is exactly the kind of loop Alpha 2 is trying to make explicit.
+- Cris naming
+- exact event names
+- the local observability route shape
+
+What became reusable:
+
+- prove the lane before broadening claims
+- harden the contract before widening the surface
+- treat silent degradation as something worth governing
+- convert repeated operational evidence into small framework artifacts rather than core inflation
 
 ---
 
@@ -201,23 +220,17 @@ Together, they make the Alpha 2 loop concrete:
 
 ## What Alpha 2 should prove with this
 
-By adding the pilot conversion loop, AletheIA should show that:
+By making pilot conversion explicit, AletheIA should show that:
 
 - real pilots do not remain isolated stories
 - framework maturity can be fed by disciplined field evidence
 - repo evolution can stay small, explicit, and traceable
+- new guidance can harden because the field taught something concrete, not because the framework wanted to grow
 
 ---
 
-## Future evolution
+## Example
 
-Later versions may add:
+See:
 
-- explicit pilot-to-artifact mapping tables
-- scorecards for conversion quality
-- links between learnings and merged PRs
-- domain-specific conversion patterns
-
-Alpha 2 does not need that yet.
-
-It only needs a visible and repeatable conversion path.
+- `examples/pilot-conversion/crisis-monitor-real-world-validation.md`

--- a/docs/pilot-crisis-monitor.md
+++ b/docs/pilot-crisis-monitor.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-This document explains how AletheIA was first tested in a real product flow inside the Crisis Monitor project.
+This document explains how AletheIA was tested in a real product flow inside the Crisis Monitor project and how that pilot matured over time.
 
 It exists to answer four questions:
 
@@ -24,6 +24,7 @@ It is the first real proving ground where the framework could be tested against:
 - real approval logic
 - real audit surfaces
 - real operational tradeoffs
+- real signals of degradation after the first proof already worked
 
 This matters because AletheIA should not mature only through internal framework theory.
 
@@ -50,6 +51,7 @@ In practice, users could still face ambiguity around:
 - why a proposal required approval
 - what exactly still depended on human decision
 - whether chat and audit were telling the same story
+- whether the quality of the assisted flow was getting better or quietly degrading over time
 
 That made the product a strong first pilot for AletheIA, because the framework is specifically concerned with the space between:
 
@@ -64,20 +66,23 @@ If the product makes the decision path more explicit, then:
 - the flow becomes easier to trust
 - approval becomes easier to interpret
 - audit becomes more useful
+- degradations become easier to detect before they turn into silent fragility
 - AletheIA gets a real product proof without needing a large new capability
 
 ---
 
-## Scope of the first pilot slice
+## Scope of the pilot
 
-The first pilot slice stayed intentionally small.
+The pilot stayed intentionally bounded.
 
 It focused on:
 
 - proposal explicability
 - routing clarity
 - approval rationale
-- lightweight proof that chat and audit stay coherent
+- real-flow validation
+- explainability consistency
+- small operational observability around the pilot lane
 
 It did **not** try to:
 
@@ -85,6 +90,7 @@ It did **not** try to:
 - replace approval policy
 - create a full new runtime
 - generalize the whole framework through one product feature
+- turn product observability into a mandatory framework requirement
 
 ---
 
@@ -92,7 +98,7 @@ It did **not** try to:
 
 ### Slice 1 — Decision trace clarity
 
-In the Crisis Monitor product, the first slice made the proposal card more explicit about:
+The first slice made the proposal flow more explicit about:
 
 - chosen skill
 - routing origin
@@ -100,7 +106,7 @@ In the Crisis Monitor product, the first slice made the proposal card more expli
 - next decision needed
 - why the proposal requires approval
 
-This proved that a small change in explicability could already produce meaningful value.
+This proved that a small explicability improvement could already produce meaningful value.
 
 ### Slice 2 — Functional authenticated smoke
 
@@ -114,13 +120,61 @@ It validated a real local flow:
 4. controlled reject
 5. final audit read
 
-This mattered because it moved the pilot from:
+This moved the pilot from:
 
 - static or render-level proof
 
-to:
+into:
 
 - real product behavior under controlled conditions
+
+### Slice 3 — Explainability contract hardening
+
+The next move was not a bigger feature.
+It was stronger consistency.
+
+The product hardened the explainability contract so the lane could more reliably preserve alignment between:
+
+- the suggested action
+- the explicit explanation for that action
+- the audit trail supporting it
+
+That mattered because the pilot was no longer proving only that a decision could be shown.
+It was proving that the decision story could stay coherent across artifacts.
+
+### Slice 4 — Health metric and alert
+
+Once the lane had a stronger contract, the pilot gained a small health reading around explainability coverage.
+
+That made it possible to ask:
+
+- is the lane still producing enough explainability?
+- is the flow staying legible?
+- is degradation happening even when the main path still technically works?
+
+### Slice 5 — Investigable decision feed
+
+The next slice made degradation more inspectable.
+
+Instead of stopping at a summary metric, the pilot exposed a small decision feed that made specific explainability gaps reviewable.
+
+This mattered because operational quality is easier to improve when the problem is not only visible as a number, but also as a short inspectable event.
+
+### Slice 6 — Lane scorecard
+
+The lane then gained a compact scorecard that summarized:
+
+- current status
+- dominant tension
+- relevant alerts
+- recent investigable items
+
+This did not turn the framework into an observability system.
+It simply showed that a real pilot can evolve from:
+
+`decision clarity -> proof -> contract -> health -> investigation -> summary`
+
+without becoming a giant platform effort.
 
 ---
 
@@ -128,12 +182,15 @@ to:
 
 The pilot proved that AletheIA can add value in a real product without starting from a giant feature.
 
-More specifically, it showed that:
+More specifically, it now shows that:
 
 - explicability can be a valid first proof of the framework
 - approval rationale adds real clarity
 - audit and chat can be checked as parallel surfaces of the same governed flow
-- a lightweight product pilot can generate reusable framework learnings
+- a real flow can be smoke-tested under authentication
+- a decision lane can be hardened through contract consistency before widening surface area
+- small health metrics and alerts can expose silent degradation in a high-value lane
+- a pilot can generate reusable framework learnings about continuity, detection, and conversion
 
 ---
 
@@ -147,6 +204,7 @@ These belong to Crisis Monitor:
 - skill names and routing heuristics
 - approval semantics for monitoring/editorial actions
 - the specific audit UI and product language
+- the exact observability names used for the pilot lane
 
 ### Reusable for AletheIA
 
@@ -155,7 +213,9 @@ These became reusable framework lessons:
 - start pilots with low-risk explicability improvements
 - validate decision and audit together
 - prefer controlled reversible actions for early proof
-- turn pilot findings into framework artifacts, not only product notes
+- strengthen the contract before widening the feature
+- treat degradation detection as part of the operating picture, not only as a final complaint
+- convert real pilot evidence into small reusable framework artifacts instead of inflating the core
 
 ---
 
@@ -168,10 +228,12 @@ This pilot directly influenced the public AletheIA repo by reinforcing:
 - durable decision reasoning
 - the need to distinguish behavioral enforcement from technical enforcement
 - the self-application loop as a real next step
+- iterative maintenance as a governance problem, not only a patch problem
+- pilot conversion as a repeatable path from product evidence to framework maturity
 
 In other words:
 
-the pilot did not stay trapped in product history.
+this pilot did not stay trapped in product history.
 It became input for framework evolution.
 
 ---
@@ -183,21 +245,23 @@ At this stage, the Crisis Monitor pilot should be read as:
 - a **real test field**
 - a **source of disciplined learnings**
 - a **bridge between Alpha 1 and Alpha 2**
+- an example of how product evidence can harden operational guidance without creating new core contracts
 
-It is not yet the final word on AletheIA adoption.
+It is still not the final word on AletheIA adoption.
 
-But it is already enough to prove that the framework can be tested in product reality and then converted into framework maturity.
+But it now proves more than an initial product slice.
+It shows that the framework can be tested in product reality, observed over repeated hardening steps, and then converted into reusable framework maturity.
 
 ---
 
-## What Alpha 2 should do next with this pilot
+## What Alpha 2 should do with this pilot
 
-The next useful moves are:
+The useful moves now are:
 
-1. deepen the pilot write-up when new slices land
-2. keep converting product learnings into explicit framework artifacts
-3. avoid mixing product-specific residue with reusable framework core
-4. use this pilot as one of the main anchors for the Alpha 2 story
+1. keep converting new product learnings into explicit framework artifacts
+2. use the pilot as evidence that self-application is not only rhetorical
+3. keep the reusable lesson separate from the product residue
+4. preserve the pilot as one of the main anchors for the Alpha 2 story
 
 ---
 
@@ -208,6 +272,6 @@ The Crisis Monitor pilot and the self-application loop are complementary:
 - the pilot provides real field evidence
 - self-application provides the conversion logic back into the framework
 
-Together, they form the real center of Alpha 2:
+Together, they form the practical center of Alpha 2:
 
 `pilot -> learning -> framework improvement`

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -92,6 +92,8 @@ Current Alpha 2 bridge artifacts now include:
 
 Together, these four artifacts define how AletheIA learns from pilots, improves itself, and preserves the boundary between reusable core and local project context.
 
+Recent Crisis Monitor validation now gives Alpha 2 a stronger bridge than early explicability alone. The bridge is now supported by a real sequence of product proof, contract hardening, operational health reading, investigation, and compact lane summary before the learnings return to the framework.
+
 ---
 
 ## Alpha 3 — Adoption + Ecosystem
@@ -344,6 +346,8 @@ Together, these artifacts now define a first operational-composition baseline an
 - make iterative maintenance rounds more legible through composed slices, regression-aware gates, and reusable learning
 
 Alongside that operational layer, the starter-pack now also carries an advisory-only model-strategy guidance slice for matching task shape, capability profile, reasoning depth, and trust / hosting posture without turning model choice into a framework-level rule.
+
+The iterative-maintenance slice now has stronger operational grounding as well: it should be read as a proportional pattern for important loops where proof, contract, health metric, alert, investigation, and lane summary make continuation safer without becoming a universal requirement.
 
 ---
 

--- a/docs/self-application.md
+++ b/docs/self-application.md
@@ -82,6 +82,7 @@ Examples:
 - governance baseline passes
 - tests still pass
 - docs align with implementation
+- a pilot-derived claim can be connected back to real evidence
 
 ### 4. A durable learning
 
@@ -108,6 +109,23 @@ This is the practical bridge between:
 
 ---
 
+## What recent real-world validation added
+
+The Crisis Monitor pilot made the self-application loop more concrete because it did not stop at an initial product proof.
+
+The recent sequence moved through:
+
+1. authenticated smoke of a real flow
+2. explainability contract hardening
+3. health metric and alert around the lane
+4. investigable decision feed
+5. compact lane scorecard
+6. conversion of those learnings into new framework guidance
+
+That matters because it shows self-application as a chain of small reviewable moves, not as a vague promise to “learn from pilots later.”
+
+---
+
 ## What self-application is not
 
 Self-application is not:
@@ -115,6 +133,7 @@ Self-application is not:
 - forcing every tiny change through heavy artifacts
 - pretending the framework is already fully automated
 - blocking momentum with unnecessary ceremony
+- copying product observability mechanics directly into the framework core
 
 It is a discipline of proportion.
 
@@ -130,6 +149,7 @@ Alpha 2 is going well when:
 - the repo shows why something changed, not only that it changed
 - the public narrative and the internal reasoning stay aligned
 - the framework starts to improve itself with its own language
+- real-world validation creates smaller reusable artifacts instead of larger speculative machinery
 
 ---
 
@@ -155,23 +175,22 @@ By adding the self-application loop, AletheIA should show that:
 - the framework can shape its own evolution
 - pilot learnings can become reusable artifacts
 - repo evolution can be governed without becoming rigid
+- real pilot evidence can harden the framework without turning product details into framework law
 
 ---
 
-## Future evolution
+## Relationship to pilot conversion
 
-Later versions may connect self-application more directly to:
+Self-application explains how the framework should govern its own evolution.
 
-- explicit task briefs for framework work
-- policy trace for repo evolution
-- pilot-to-framework scorecards
-- project extension patterns
+Pilot conversion explains how field learnings should enter that evolution.
+
+Together, they make the Alpha 2 loop concrete:
+
+`pilot -> learning -> conversion -> framework improvement`
 
 See also:
 
+- `docs/pilot-crisis-monitor.md`
 - `docs/pilot-conversion.md`
 - `docs/project-extension-pattern.md`
-
-Alpha 2 does not need all of that on day one.
-
-It only needs to make the loop visible and repeatable.

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,6 +31,8 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
   - mostra routing provider-agnostic e um profile local ilustrativo para fleets mistos de modelos
 - `iterative-maintenance/`
   - mostra um loop de manutenção em três rodadas com regressão escalando o gate e gerando learning reutilizável
+- `pilot-conversion/`
+  - mostra como uma validação real no Crisis Monitor vira endurecimento pequeno e reutilizável no framework
 
 ---
 
@@ -61,8 +63,10 @@ O alpha agora já cobre:
 - examples of structured risk inference for bounded semantic-risk scenarios
 - advisory-only model-strategy examples for task-to-model-fit guidance
 - iterative maintenance examples where regression changes the round gate instead of remaining only a final observation
+- pilot-conversion examples where real-world validation becomes a smaller framework improvement instead of core inflation
 
-Together, these newer examples make the repo more practical in two directions:
+Together, these newer examples make the repo more practical in three directions:
 
 - how to choose model fit without making vendor choice part of the core
 - how to carry maintenance work across rounds without treating regression as a purely final metric
+- how to convert real pilot evidence into small reusable framework changes

--- a/examples/pilot-conversion/crisis-monitor-real-world-validation.md
+++ b/examples/pilot-conversion/crisis-monitor-real-world-validation.md
@@ -1,0 +1,80 @@
+# Crisis Monitor — Real-World Validation to Framework Hardening
+
+## Pilot evidence
+
+The Crisis Monitor pilot around the Cris assistant moved through a small but meaningful chain of real-world validation:
+
+1. a real authenticated smoke proved the lane under product conditions
+2. the explainability contract was hardened so the decision story stayed coherent
+3. a small health metric and alert made explainability degradation visible
+4. a decision feed made concrete degraded cases inspectable
+5. a lane scorecard summarized the operational picture without requiring a new UI
+
+This sequence mattered because the pilot stopped being only an early explicability slice.
+It became a bounded example of how a real assisted lane can be proved, checked, and monitored over repeated hardening steps.
+
+---
+
+## What became visible
+
+The pilot made several things more visible than before:
+
+- a lane can technically work while still degrading in explainability quality
+- contract consistency matters before widening product surface area
+- a health reading can expose trouble earlier than manual perception alone
+- investigation becomes easier when degraded cases are reviewable as compact events
+- a lane summary helps continuity because the next reader does not need to reconstruct the whole story from scratch
+
+---
+
+## What became reusable
+
+The reusable lesson is not the exact Crisis Monitor implementation.
+
+The reusable lesson is the operating pattern:
+
+- **prove** the lane first
+- **harden** the contract next
+- add a small **health metric** when silent degradation matters
+- use an **alert** when the degradation should change behavior
+- make the degraded case **investigable**
+- keep a compact **lane summary** for continuation and review
+
+That pattern is useful for iterative maintenance and other important assisted loops where “still working” is not the same as “still healthy.”
+
+---
+
+## What changed in AletheIA
+
+This pilot evidence justified smaller framework changes such as:
+
+- stronger Alpha 2 bridge language in `pilot-crisis-monitor`, `self-application`, and `pilot-conversion`
+- more tangible iterative-maintenance guidance in `iterative-maintenance-governance`
+- stronger operational guidance in `round-based-maintenance`
+
+Those changes make the framework clearer about:
+
+- real-world validation
+- conversion of pilot evidence into framework improvement
+- regression-aware operational continuity
+
+---
+
+## Why this did not justify core inflation
+
+The pilot did **not** justify:
+
+- a new core schema for pilot observability
+- a mandatory scorecard for every project
+- a framework-level observability engine
+- a benchmark harness inside AletheIA
+
+The right conversion was lighter than that.
+
+What the framework needed was:
+
+- clearer docs
+- a stronger starter-pack guide
+- a compact example of pilot-to-framework conversion
+
+This keeps the reusable lesson while leaving the product-specific mechanics in the product.

--- a/starter-pack/guides/round-based-maintenance.md
+++ b/starter-pack/guides/round-based-maintenance.md
@@ -105,6 +105,10 @@ In practice, regression can change the round in several ways:
 Regression should also influence later rounds.
 A recent regression in the same area is a signal that the next round deserves a stronger gate.
 
+Silent degradation matters too.
+A round can still look superficially successful while a useful operational signal is getting weaker.
+When that happens, the next continuation should not be read as fully clean progress.
+
 ---
 
 ## When to widen the gate
@@ -116,9 +120,27 @@ Increase the validation or review burden when:
 - the regression is semantic and not easy to catch by simple tests
 - the next round crosses an agent or ownership boundary
 - the cost of another failure is now higher than in the first round
+- a lane health reading suggests that quality is eroding even when the main path still works
 
 Do not widen the gate just because work is iterative.
 Widen it because the round history justifies it.
+
+---
+
+## A proportional operational sequence
+
+For more important iterative loops, a useful sequence is:
+
+1. prove the round or lane with a real bounded slice
+2. harden the contract that keeps the lane coherent
+3. expose a small health metric when quiet degradation matters
+4. add an alert if degradation should change behavior
+5. make the degraded case investigable
+6. keep a compact summary for the next continuation or reviewer
+
+This should stay proportional.
+It is not required for every maintenance task.
+It is useful when the loop is important enough that continuation quality matters.
 
 ---
 
@@ -144,6 +166,7 @@ Generate a learning record when the round exposed something reusable, for exampl
 - a fragile module that deserves stronger default scrutiny next time
 - a context gap that made the wrong change easier to introduce
 - a planner/executor/reviewer coordination mistake that is likely to repeat
+- a signal that should exist before the next continuation is treated as safe
 
 Learning is most useful when it helps the next round avoid the same failure mode.
 
@@ -155,8 +178,9 @@ Learning is most useful when it helps the next round avoid the same failure mode
 2. Record the round decision before execution.
 3. Execute with the minimum declared validation.
 4. If regression appears, change the round state and re-read the gate.
-5. Create a handoff if the next boundary matters.
-6. Store a learning record if the round taught something reusable.
+5. Add a compact health reading only when the loop is important enough to justify it.
+6. Create a handoff if the next boundary matters.
+7. Store a learning record if the round taught something reusable.
 
 ---
 
@@ -165,9 +189,9 @@ Learning is most useful when it helps the next round avoid the same failure mode
 See:
 
 - `examples/iterative-maintenance/three-round-loop/README.md`
+- `examples/pilot-conversion/crisis-monitor-real-world-validation.md`
 
-That example shows a three-round loop where:
+Together, these examples show both:
 
-- Round 1 closes cleanly
-- Round 2 introduces a regression and escalates the gate
-- Round 3 resolves the regression, widens validation, and stores a reusable learning
+- a generic three-round loop
+- a real pilot conversion where proof, contract, health, alert, investigation, and summary hardened the reusable guidance without changing the core contracts


### PR DESCRIPTION
## Summary\n- strengthen Alpha 2 bridge docs with recent Crisis Monitor validation evidence\n- make iterative maintenance guidance more operationally grounded\n- add a pilot-conversion example showing real-world validation turning into small framework changes\n\n## Validation\n- bash scripts/check-governance.sh