### PR TITLE
Add advisory model usage plans

### DIFF
--- a/docs/project-extension-pattern.md
+++ b/docs/project-extension-pattern.md
@@ -60,6 +60,7 @@ This includes things such as:
 - domain terminology
 - provider choices
 - local model strategy profiles tied to the available fleet, budget, and hosting posture
+- optional user-approved usage plans for a session, workstream, or feature slice
 - local handoff patterns
 - risk policies that depend on the project context
 
@@ -140,6 +141,8 @@ It usually depends on:
 - tool support in the local workflow
 
 That is why AletheIA should teach the pattern without turning one project's model stack into framework truth.
+
+In the same way, a project may define a short-lived usage plan for a feature or session without turning that plan into framework enforcement.
 
 See:
 

--- a/examples/model-strategy/README.md
+++ b/examples/model-strategy/README.md
@@ -19,6 +19,8 @@ These examples show:
   - shows task-shape to capability-profile recommendations without naming vendors
 - `mixed-fleet-local-profile.md`
   - shows an illustrative local profile using a mixed fleet of hosted and self-hosted models
+- `approved-usage-plan.md`
+  - shows how a local team may agree on a short-lived model usage plan without turning it into framework enforcement
 
 ---
 

--- a/examples/model-strategy/approved-usage-plan.md
+++ b/examples/model-strategy/approved-usage-plan.md
@@ -1,0 +1,80 @@
+# Approved Usage Plan Example
+
+> Illustrative local example.
+> Not a framework default.
+> Not an authorization for automatic model switching.
+
+This example shows how a team may agree on a short-lived usage plan before starting a bounded piece of work.
+
+---
+
+## Context
+
+The team is about to implement a medium-sized feature with:
+
+- some ambiguity in planning
+- bounded implementation work afterward
+- a final review step
+- normal user override still allowed
+
+---
+
+## Agreed local usage plan
+
+### Planning
+
+Preferred default:
+- Deep planner / reviewer profile
+
+Local translation example:
+- premium hosted planning model when available
+- balanced hosted fallback if the planning question narrows quickly
+
+### Execution
+
+Preferred default:
+- Balanced executor profile
+
+Local translation example:
+- mid-cost hosted execution model
+- self-hosted bounded executor when trust posture requires it
+
+### Review
+
+Preferred default:
+- Deep planner / reviewer profile
+
+Local translation example:
+- stronger hosted reviewer for semantic review
+- restricted self-hosted reviewer when the material should not leave the trust boundary
+
+### Handoff / compression
+
+Preferred default:
+- Lightweight helper or Balanced executor profile
+
+Local translation example:
+- cheaper hosted summarizer for normal context
+- self-hosted summarizer for sensitive continuity artifacts
+
+---
+
+## Why this is useful
+
+A usage plan can help the team align on:
+
+- where to spend more model quality
+- where to reduce cost
+- where trust / hosting posture matters more than convenience
+- which fallbacks are acceptable before the work begins
+
+---
+
+## Why this is still advisory-only
+
+Even with this plan:
+
+- the user may still choose another model
+- the project may warn about trade-offs
+- the framework still does not auto-route models
+- the plan remains local to this work item, not framework truth

--- a/starter-pack/guides/model-strategy-by-task.md
+++ b/starter-pack/guides/model-strategy-by-task.md
@@ -174,6 +174,29 @@ AletheIA should not keep a premium model in the loop once the hard part is over.
 
 ---
 
+
+## Usage-plan posture
+
+A useful local next step is to turn the guidance into a **user-approved usage plan** for a session, workstream, or feature slice.
+
+That plan may say things such as:
+
+- which model class is preferred for planning
+- which model class is preferred for execution
+- which fallback is acceptable
+- when a stronger model is justified
+- when a cheaper model is enough
+- what trust / hosting boundary applies
+
+This is still **advisory-only**.
+The plan may guide choices, but it does not remove the user's ability to override them.
+
+The important distinction is:
+
+- a usage plan can make local defaults explicit
+- a usage plan does **not** imply automatic model switching in the framework
+- a usage plan does **not** make a project-local preference into framework truth
+
 ## User override principle
 
 AletheIA suggests.
@@ -185,6 +208,7 @@ That means:
 - a user may deliberately choose a different model
 - the local project may document trade-offs, warnings, or preferences
 - this guide does **not** require automatic blocking or automatic routing
+- a user-approved usage plan may organize local defaults, but it still does not authorize framework-level auto-routing
 
 Good override examples:
 

--- a/starter-pack/templates/project-model-strategy-template.md
+++ b/starter-pack/templates/project-model-strategy-template.md
@@ -85,6 +85,36 @@ State any project-local constraints such as:
 
 ---
 
+
+## Optional session or feature usage plan
+
+Use this section when a team wants to agree on a short-lived plan before work starts.
+
+Examples:
+- planning for this feature should default to the deep planner / reviewer profile
+- bounded implementation should default to the balanced executor profile
+- handoff packaging may use a cheaper or self-hosted option when trust posture requires it
+- fallback is acceptable when the preferred model is unavailable or disproportional
+
+### Planning default for this work
+
+### Execution default for this work
+
+### Review default for this work
+
+### Handoff / compression default for this work
+
+### Fallbacks allowed for this work
+
+### Trust / hosting posture for this work
+
+### Reminder
+
+This usage plan is still advisory.
+It helps the team align before the work starts, but it does not remove user override.
+
+---
+
 ## User override policy
 
 This profile is **recommended**, not obligatory.


### PR DESCRIPTION
## Summary\n- extend model-strategy guidance with an advisory usage-plan posture\n- add a session/feature usage-plan section to the project model strategy template\n- add an example showing approved local defaults without framework auto-routing\n\n## Validation\n- bash scripts/check-governance.sh