### PR TITLE
Add 1.0 readiness roadmap framing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for contributing to AletheIA.
 
-AletheIA is still in public alpha, so the most valuable contributions are the ones that improve clarity, reviewability, reuse, and practical adoption without making the framework heavier than it needs to be.
+AletheIA is in a **late Alpha completion cycle before 1.0**, so the most valuable contributions right now are the ones that improve clarity, reviewability, reuse, and practical adoption **without opening new strategic tracks before the open Alpha work is sufficiently closed**.
 
 ---
 
@@ -18,6 +18,7 @@ Please prioritize contributions that improve:
 - quality baseline
 - starter-pack reuse
 - adoption without premature complexity
+- coherence of the open Alpha completion work
 
 ---
 
@@ -33,6 +34,10 @@ Strong contribution areas right now include:
 - roadmap alignment
 - adoption guidance
 - pilot-to-framework learnings that clearly generalize
+- Alpha 4 handoff coherence
+- Alpha 5 inference hardening without over-expansion
+- Alpha 6 tangibility without premature enterprise claims
+- Alpha 7 boundary clarity without tooling inflation
 
 ---
 
@@ -46,6 +51,7 @@ Please make sure that:
 - tests still pass when relevant
 - public docs stay understandable for non-specialists
 - the change does not silently turn project-specific residue into framework core
+- the change does not pull deferred post-1.0 tracks into the current priority lane unless it directly helps Alpha completion
 
 ---
 
@@ -58,9 +64,12 @@ Before opening a change, ask:
 - is this improving the reusable framework core?
 - is this a starter-pack improvement?
 - is this a pilot learning that really generalizes?
+- is this helping close an Alpha that is still open before 1.0?
 - is this still specific to one project and therefore better left out of the public core?
 
 If the answer is mostly project-specific, prefer keeping it local or documenting it as a project extension pattern instead of promoting it directly into the framework core.
+
+If the change mostly belongs to a deferred post-1.0 track, it is probably premature unless it also makes the current Alpha completion pass clearer or safer.
 
 ---
 
@@ -72,13 +81,15 @@ Framework-core contributions are a good fit when they are:
 - understandable without one product's vocabulary
 - about operating discipline, contracts, governance, validation, or learnings
 - helpful as a teaching artifact for adopters
+- aligned with the current completion-first roadmap
 
 Examples:
 
 - governance clarifications
 - starter-pack patterns that generalize well
 - roadmap-aligned adoption docs
-- validation/test improvements for the framework itself
+- validation and test improvements for the framework itself
+- Alpha-completion hardening that improves coherence without inflating the core
 
 ---
 
@@ -92,12 +103,14 @@ Avoid promoting these directly into the public core unless they clearly generali
 - one-repo ownership maps
 - one-project naming conventions
 - hidden abstractions that reduce inspectability
+- enterprise-specific rules that belong in a future local extension or post-1.0 adoption layer
 
 These may still be valuable as:
 
 - project extensions
 - pilot write-ups
 - future examples
+- deferred post-1.0 tracks
 
 ---
 
@@ -131,7 +144,8 @@ A good contribution should make it easy for a reviewer to answer:
 - why does it belong in the framework?
 - what stays out of scope?
 - how was it validated?
-- what future contributor should learn from this change?
+- what should a future contributor learn from this change?
+- does this help the current Alpha completion path, or is it better deferred?
 
 ---
 
@@ -163,6 +177,7 @@ Avoid:
 - hidden coupling
 - provider lock-in in the core
 - making the framework sound stronger than it currently is
+- opening post-1.0 roadmap scope before the current Alpha work is sufficiently closed
 
 ---
 
@@ -172,6 +187,7 @@ Before contributing, it may help to read:
 
 - `docs/getting-started.md`
 - `docs/roadmap-alpha.md`
+- `docs/release-1.0-readiness.md`
 - `docs/project-extension-pattern.md`
 - `docs/pilot-conversion.md`
 - `starter-pack/README.md`

--- a/README.md
+++ b/README.md
@@ -92,15 +92,17 @@ This means the framework helps answer questions such as:
 
 ---
 
-## What the first public alpha proves
+## What the current pre-1.0 repository proves
 
-The current public alpha is meant to prove that:
+The current public repository is meant to prove that:
 
 - an input can become a structured decision
 - governance can block unsafe or poorly framed closure
 - failed validation can generate reusable learnings
 - the framework can stay small, inspectable, and deterministic
 - the core can be reused outside its original pilot project
+- pilots can turn into reviewable framework improvements
+- the roadmap can distinguish baseline work from deferred evolution
 
 ---
 
@@ -112,13 +114,13 @@ The current public alpha is meant to prove that:
 - `examples/` — canonical examples and golden fixtures
 - `tests/` — contract, golden, e2e, and learning-oriented checks
 - `starter-pack/` — reusable operating guides, checklists, and templates
-- `docs/` — architecture, roadmap, pilot narrative, and migration notes
+- `docs/` — architecture, roadmap, pilot narrative, and release-readiness notes
 
 ---
 
 ## Initial examples
 
-The alpha starts with a few small examples that make the framework tangible:
+The repository starts with a few small examples that make the framework tangible:
 
 - `hello-world` — the smallest end-to-end path
 - `low-confidence-review` — when ambiguity should stop direct execution
@@ -141,40 +143,32 @@ The alpha starts with a few small examples that make the framework tangible:
 
 ## Current status
 
-This repository is the first public alpha draft of AletheIA.
+AletheIA is still **pre-1.0**.
 
-It was born from real operational work inside the `Crisis Monitor` project and then extracted into a standalone reusable framework.
+The repository is now in a **late Alpha completion cycle**:
 
-Today, this public draft already contains:
+- **Alpha 1–3** are treated as complete enough for the current cycle
+- **Alpha 4–7** remain active completion or hardening lanes before the 1.0 gate
+- post-baseline tracks such as enterprise-readiness, stronger domain packs, and heavier tooling are preserved, but explicitly deferred until after 1.0
+
+Today, the public repository already contains:
 
 - an Alpha 1 baseline for governance, token discipline, durable decisions, enforcement clarity, quality, and learnings
-- an explicit Alpha 2 bridge for self-application, pilot conversion, and project extension, now reinforced by real-world Crisis Monitor validation
+- an Alpha 2 bridge for self-application, pilot conversion, and project extension, reinforced by real-world Crisis Monitor validation
 - an Alpha 3 adoption baseline for getting started, existing-project application, contribution guidance, and starter-pack reuse
 - an Alpha 4 handoff baseline for model-agnostic restart packages, project conventions, and semi-automated handoff capture
 - an Alpha 5 experimental baseline for structured risk inference in higher-risk work, including concrete example artifacts
 - an Alpha 6 distribution baseline for presets, adapters, adoption modes, and cross-surface delivery mappings
-- a current operational-composition baseline for work slices, risk-to-gate mapping, stronger restart-package examples, and optional filesystem context-routing experiments
-- an early Alpha 7 bootstrap-and-delivery baseline for future tooling contracts that still remains outside the core
+- a current operational-composition baseline for work slices, risk-to-gate mapping, stronger restart-package examples, round-based maintenance guidance, and optional filesystem context-routing experiments
+- an early Alpha 7 bootstrap-and-delivery baseline for future tooling contracts that remains clearly outside the core
 
-In practical terms, that currently includes:
+This repository is **not 1.0 yet**.
+The current priority is to close the remaining open Alpha work cleanly before pulling post-1.0 tracks into the main lane.
 
-- core contracts
-- a minimal kernel
-- a governance pack
-- an explicit token policy
-- a small executable governance baseline
-- a lightweight durable decision discipline
-- an explicit boundary between behavioral and technical enforcement
-- a quality baseline
-- a first learnings path
-- a reusable starter-pack slice
-- an advisory-only model-strategy guidance slice for task shape, capability profile, reasoning depth, and trust / hosting fit
-- a first structured risk inference slice
-- a first iterative-maintenance governance slice for round-based continuation, regression-aware gates, reusable learning across rounds, and a clearer proportional pattern of proof, contract, health, alert, investigation, and summary
-- concrete example artifacts for bounded semantic-risk scenarios
-- a first concrete distribution baseline for packaging shape, delivery surface, adoption depth, and meaning preservation across surfaces
-- a lightweight operational-composition baseline for work slices, risk-to-gate mapping, compact handoff continuity, iterative maintenance guidance, and optional filesystem context-routing experiments
-- a first Alpha 7 tooling baseline across principles, boundaries, output shapes, generator contract, and output contract
+See also:
+
+- `docs/roadmap-alpha.md`
+- `docs/release-1.0-readiness.md`
 
 ---
 
@@ -184,179 +178,54 @@ If this is your first time here, start with:
 
 1. `docs/getting-started.md`
 2. `docs/00-overview.md`
-3. `docs/architecture.md`
-4. `docs/governance.md`
-5. `docs/token-policy.md`
-6. `starter-pack/guides/model-strategy-by-task.md`
-7. `docs/durable-decisions.md`
-8. `docs/enforcement-boundaries.md`
-9. `docs/quality.md`
-10. `docs/self-application.md`
-11. `docs/pilot-crisis-monitor.md`
-12. `docs/pilot-conversion.md`
-13. `examples/pilot-conversion/crisis-monitor-real-world-validation.md`
-14. `docs/project-extension-pattern.md`
-15. `docs/apply-to-existing-project.md`
-15. `CONTRIBUTING.md`
-16. `starter-pack/`
-17. `starter-pack/templates/project-extension-template.md`
-18. `starter-pack/templates/project-model-strategy-template.md`
-19. `docs/agent-handoffs.md`
-20. `starter-pack/guides/agent-handoff-generation.md`
-21. `starter-pack/templates/agent-handoff-template.md`
-22. `docs/project-handoff-conventions.md`
-23. `docs/handoff-capture-pattern.md`
-24. `docs/work-slice-pattern.md`
-25. `starter-pack/templates/work-slice-template.md`
-26. `starter-pack/guides/risk-to-gate-mapping.md`
-27. `docs/structured-risk-inference.md`
-28. `starter-pack/templates/inference-artifact-template.md`
-29. `starter-pack/guides/inference-trigger-guidance.md`
-30. `starter-pack/guides/inference-artifact-generation.md`
-31. `docs/inference-pilot-scenarios.md`
-32. `examples/work-slices/standard-slice/README.md`
-33. `examples/handoffs/compact-reviewable-handoff.md`
-34. `examples/handoffs/high-stakes-handoff.md`
-35. `examples/structured-risk-inference/README.md`
-36. `examples/model-strategy/README.md`
-37. `examples/`
+3. `docs/roadmap-alpha.md`
+4. `docs/release-1.0-readiness.md`
+5. `docs/architecture.md`
+6. `docs/governance.md`
+7. `docs/token-policy.md`
+8. `starter-pack/guides/model-strategy-by-task.md`
+9. `docs/durable-decisions.md`
+10. `docs/enforcement-boundaries.md`
+11. `docs/quality.md`
+12. `docs/self-application.md`
+13. `docs/pilot-crisis-monitor.md`
+14. `docs/pilot-conversion.md`
+15. `examples/pilot-conversion/crisis-monitor-real-world-validation.md`
+16. `docs/project-extension-pattern.md`
+17. `docs/apply-to-existing-project.md`
+18. `CONTRIBUTING.md`
+19. `starter-pack/README.md`
+20. `starter-pack/templates/project-extension-template.md`
+21. `starter-pack/templates/project-model-strategy-template.md`
+22. `docs/agent-handoffs.md`
+23. `starter-pack/guides/agent-handoff-generation.md`
+24. `starter-pack/templates/agent-handoff-template.md`
+25. `docs/project-handoff-conventions.md`
+26. `docs/handoff-capture-pattern.md`
+27. `docs/work-slice-pattern.md`
+28. `starter-pack/templates/work-slice-template.md`
+29. `starter-pack/guides/risk-to-gate-mapping.md`
+30. `docs/structured-risk-inference.md`
+31. `starter-pack/templates/inference-artifact-template.md`
+32. `starter-pack/guides/inference-trigger-guidance.md`
+33. `starter-pack/guides/inference-artifact-generation.md`
+34. `docs/inference-pilot-scenarios.md`
+35. `examples/work-slices/standard-slice/README.md`
+36. `examples/handoffs/compact-reviewable-handoff.md`
+37. `examples/handoffs/high-stakes-handoff.md`
+38. `examples/structured-risk-inference/README.md`
 
 ---
 
-## Near-term direction
+## What happens after 1.0
 
-The next steps are:
+After the 1.0 gate is satisfied, the roadmap shifts from Alpha completion into **1.x evolution**.
 
-- keep the current Alpha 6 baseline coherent without losing the Alpha 5 inference baseline, the Alpha 4 handoff baseline, or the Alpha 3 adoption gains
-- keep validating the Crisis Monitor pilot and adjacent real slices
-- keep converting pilot learnings into framework improvements with the Crisis Monitor pilot as the strongest current Alpha 2 evidence
-- keep using AletheIA to improve AletheIA itself
-- keep Alpha 5 proportional, selective, and grounded in bounded semantic-risk scenarios
-- keep the operational-composition baseline lightweight, teachable, and clearly outside the core contracts
-- keep the new model-strategy guidance advisory-only, provider-agnostic in the framework, and translated locally by each project
-- keep iterative-maintenance guidance focused on round legibility, regression-aware continuation, reusable learning, and proportional proof/health reads rather than benchmark imitation
-- keep experimental workspace context routing optional, inspectable, and clearly non-canonical
-- keep Alpha 6 focused on distribution clarity rather than tooling promises
-- keep Alpha 7 small, bounded, and tooling-light even as its baseline becomes clearer
-- let future domain packs remain future-facing layers rather than near-term core work
+The next planned lanes are already preserved as deferred tracks:
 
----
+- **1.1** — enterprise-readiness / regulated adoption
+- **1.2** — pilot expansion / stronger real-world validation
+- **1.3** — distribution & delivery hardening
+- **1.4+** — domain governance packs hardening
 
-## Current phase map
-
-- Alpha 1 established the governance and validation baseline.
-- Alpha 2 established the pilot, self-application, and conversion bridge.
-- Alpha 3 is making the framework easier to adopt and contribute to.
-- Alpha 4 is making inter-agent continuity explicit, reusable, and more operational.
-- Alpha 5 now provides an experimental baseline for decision-quality in higher-risk work.
-- Alpha 6 now provides a first concrete distribution baseline for presets, adapters, adoption modes, and delivery mappings.
-- Alpha 7 now includes bootstrap principles, delivery-tooling boundaries, output examples, a first future-facing generator contract, and a first future-facing delivery output contract for optional automation.
-- A current operational-composition baseline now makes bounded work, restartable handoffs, risk-sensitive validation, iterative maintenance, and regression-aware continuation more tangible without expanding the core contracts.
-- The starter-pack now also includes advisory-only model-strategy guidance for matching task shape, capability profile, reasoning depth, and trust / hosting constraints without turning model choice into framework enforcement.
-
----
-
-## First Alpha 2 bridge
-
-The first explicit bridge into Alpha 2 is:
-
-- `docs/self-application.md`
-- `docs/pilot-crisis-monitor.md`
-- `docs/pilot-conversion.md`
-- `docs/project-extension-pattern.md`
-
-Together, these documents explain how AletheIA should evolve itself, learn from pilots, and preserve a clear boundary between framework core and local project extensions.
-
-The current Alpha 3 adoption baseline after this bridge is:
-
-- `docs/getting-started.md`
-- `docs/apply-to-existing-project.md`
-- `CONTRIBUTING.md`
-- `starter-pack/templates/project-extension-template.md`
-
-The first Alpha 4 handoff baseline now adds:
-
-- `docs/agent-handoffs.md`
-- `starter-pack/guides/agent-handoff-generation.md`
-- `starter-pack/templates/agent-handoff-template.md`
-- `docs/project-handoff-conventions.md`
-- `docs/handoff-capture-pattern.md`
-
-The current Alpha 5 experimental baseline now adds:
-
-- `docs/structured-risk-inference.md`
-- `starter-pack/templates/inference-artifact-template.md`
-- `starter-pack/guides/inference-trigger-guidance.md`
-- `starter-pack/guides/inference-artifact-generation.md`
-- `docs/inference-pilot-scenarios.md`
-- `examples/structured-risk-inference/README.md`
-
----
-
-## Current Alpha 5 and Alpha 6 baselines, plus future direction
-
-The current and next layers should stay clearly separated by role:
-
-- **Alpha 5** — an experimental baseline for decision-quality through structured, evidence-oriented inference in higher-risk work
-- **Alpha 6** — a first concrete distribution baseline for packaging the same framework meaning across environments
-- **Alpha 7** — optional bootstrap and delivery tooling after the distribution model is already stable
-
-The current Alpha 6 baseline now adds:
-
-- `docs/distribution-presets-adapters.md`
-- `docs/preset-taxonomy.md`
-- `docs/adapter-taxonomy.md`
-- `docs/adoption-mode-guidance.md`
-- `docs/delivery-mapping-examples.md`
-
-A separate future track will also shape reusable domain governance packs.
-The first planned packs in that track are:
-
-- **Web App Security & Trust Boundaries Pack**
-- **AI Agent Security & Prompt Injection Pack**
-
-These future phases and domain packs are about extending AletheIA's reach and delivery discipline.
-They are not about redefining the framework core.
-
-The domain packs should sit between the reusable framework core and project-local rules:
-
-`AletheIA core -> domain governance pack -> project extension`
-
-See also:
-
-- `docs/structured-risk-inference.md`
-- `starter-pack/templates/inference-artifact-template.md`
-- `docs/distribution-presets-adapters.md`
-- `docs/preset-taxonomy.md`
-- `docs/adapter-taxonomy.md`
-- `docs/adoption-mode-guidance.md`
-- `docs/delivery-mapping-examples.md`
-- `docs/bootstrap-principles.md`
-- `docs/delivery-tooling-boundaries.md`
-- `docs/bootstrap-output-examples.md`
-- `docs/domain-governance-packs.md`
-- `docs/web-app-security-trust-boundaries.md`
-- `docs/ai-agent-security-prompt-injection.md`
-
----
-
-## Contribution entrypoint
-
-If you want to contribute to AletheIA, start with:
-
-- `CONTRIBUTING.md`
-
-This is the fastest way to understand what kinds of changes belong in the framework core, what should stay local, and how to contribute without inflating the project.
-
----
-
-## Minimal governance baseline
-
-Alpha 1 now includes a small executable governance check:
-
-- `bash scripts/check-governance.sh`
-
-This is intentionally modest.
-
-It does not try to be a heavy enforcement layer yet.
-It only proves that AletheIA can move from governance prose into a small technical baseline.
+Those tracks remain valid, but they are intentionally not the current priority lane.

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -2,7 +2,7 @@
 
 AletheIA is an operating framework for AI-assisted work with a decision kernel at its center.
 
-The public repository is organized around three blocks:
+The public repository is organized around four blocks:
 
 1. **framework core**
    - contracts
@@ -28,6 +28,43 @@ The public repository is organized around three blocks:
    - how pilot learnings return into framework evolution
    - how self-application, pilot conversion, and project extension stay connected
 
+4. **release-readiness framing**
+   - what is already baseline enough
+   - what still blocks 1.0
+   - what has been intentionally deferred until after 1.0
+
+---
+
+## Current phase
+
+AletheIA is currently in a **late Alpha completion cycle before 1.0**.
+
+That means the repository now distinguishes between:
+
+- **established baseline**
+  - Alpha 1
+  - Alpha 2
+  - Alpha 3
+- **Alpha completion pass**
+  - Alpha 4
+  - Alpha 5
+  - Alpha 6
+  - Alpha 7
+- **deferred until post-1.0**
+  - enterprise-readiness / regulated adoption
+  - stronger pilot expansion
+  - broader delivery hardening
+  - domain governance packs hardening
+
+The roadmap and 1.0 gate are now read together through:
+
+- `docs/roadmap-alpha.md`
+- `docs/release-1.0-readiness.md`
+
+---
+
+## Alpha 2 bridge and pilot grounding
+
 The Crisis Monitor pilot is the first concrete example of this bridge, and it now includes real-world validation beyond the first explicability slice.
 
 The key idea is simple:
@@ -36,7 +73,6 @@ AletheIA should be reusable outside the original pilot while still preserving th
 
 That reuse depends on an explicit boundary between the framework core and each project's local extension layer.
 
-
 At this point, Alpha 2 is organized around four explicit bridge artifacts and is now supported by stronger real-world validation from the Crisis Monitor pilot:
 
 - `docs/self-application.md`
@@ -44,14 +80,22 @@ At this point, Alpha 2 is organized around four explicit bridge artifacts and is
 - `docs/pilot-conversion.md`
 - `docs/project-extension-pattern.md`
 
-The current Alpha 3 adoption baseline is now anchored by:
+---
+
+## Established baseline already in place
+
+### Alpha 3 adoption baseline
+
+Anchored by:
 
 - `docs/getting-started.md`
 - `docs/apply-to-existing-project.md`
 - `CONTRIBUTING.md`
 - `starter-pack/templates/project-extension-template.md`
 
-The current Alpha 4 handoff baseline is now anchored by:
+### Alpha 4 handoff baseline
+
+Anchored by:
 
 - `docs/agent-handoffs.md`
 - `starter-pack/guides/agent-handoff-generation.md`
@@ -59,7 +103,9 @@ The current Alpha 4 handoff baseline is now anchored by:
 - `docs/project-handoff-conventions.md`
 - `docs/handoff-capture-pattern.md`
 
-The current Alpha 5 experimental baseline is now anchored by:
+### Alpha 5 experimental baseline
+
+Anchored by:
 
 - `docs/structured-risk-inference.md`
 - `starter-pack/templates/inference-artifact-template.md`
@@ -77,7 +123,9 @@ This means Alpha 5 can now be read across:
 - pilot posture
 - concrete example artifacts
 
-The current Alpha 6 distribution baseline is now anchored by:
+### Alpha 6 distribution baseline
+
+Anchored by:
 
 - `docs/distribution-presets-adapters.md`
 - `docs/preset-taxonomy.md`
@@ -92,7 +140,25 @@ This means Alpha 6 can now be read across:
 - adoption depth
 - cross-surface meaning preservation
 
-The current low-regret operational-composition baseline is now anchored by:
+### Alpha 7 future-facing tooling baseline
+
+Anchored by:
+
+- `docs/bootstrap-principles.md`
+- `docs/delivery-tooling-boundaries.md`
+- `docs/bootstrap-output-examples.md`
+- `docs/bootstrap-generator-contract.md`
+- `docs/delivery-output-contract.md`
+
+This is still a future-facing delivery layer, not an implemented tooling requirement for the 1.0 baseline.
+
+---
+
+## Current low-regret operational-composition layer
+
+This operational layer sits around the current baselines without becoming a new Alpha.
+
+Anchored by:
 
 - `docs/work-slice-pattern.md`
 - `starter-pack/templates/work-slice-template.md`
@@ -104,8 +170,10 @@ The current low-regret operational-composition baseline is now anchored by:
 - `docs/iterative-maintenance-governance.md`
 - `starter-pack/guides/round-based-maintenance.md`
 - `examples/iterative-maintenance/three-round-loop/README.md`
+- `starter-pack/guides/model-strategy-by-task.md`
+- `starter-pack/templates/project-model-strategy-template.md`
 
-This means the current operational-composition baseline can now be read across:
+This layer makes the current baseline more tangible through:
 
 - composed work units
 - risk-sensitive gate selection
@@ -113,28 +181,6 @@ This means the current operational-composition baseline can now be read across:
 - optional filesystem-based context routing experiments
 - round-based maintenance guidance over existing work-slice contracts
 - regression-aware continuation and reusable learning across rounds
-- a more tangible operational reading of important loops through proof, contract, health, alert, investigation, and lane summary
+- advisory-only model strategy by task shape, capability profile, reasoning depth, and trust / hosting posture
 
-Alongside that operational layer, the starter-pack now also carries an advisory-only model-strategy guidance slice that helps projects map task shape, capability profile, reasoning depth, and trust / hosting posture into their local model fleets without making vendor choice part of the framework core.
-
-This layer sits around the Alpha 4 and Alpha 5 baselines without becoming a new core contract family of its own.
-These materials remain intentionally smaller than the core contracts.
-
-The current Alpha 7 bootstrap-and-delivery baseline is now anchored by:
-
-- `docs/bootstrap-principles.md`
-- `docs/delivery-tooling-boundaries.md`
-- `docs/bootstrap-output-examples.md`
-- `docs/bootstrap-generator-contract.md`
-- `docs/delivery-output-contract.md`
-
-This means Alpha 7 can now be read across:
-
-- tooling posture
-- tooling stop lines
-- healthy output shapes
-- future generator IO
-- future output obligations
-
-This is still a future-facing delivery layer, not a core capability baseline.
-
+This layer is useful, but it does **not** replace the need to close the open Alpha work before 1.0.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,6 +8,23 @@ It is meant for readers who do not want to read the whole repository first.
 
 ---
 
+## One orientation note before you start
+
+AletheIA is still **pre-1.0**.
+
+The repository is in its **late Alpha completion cycle**, which means:
+
+- Alpha 1–3 are already treated as complete enough for the current cycle
+- Alpha 4–7 still have explicit completion work before the 1.0 gate
+- post-1.0 tracks already exist, but they are intentionally deferred
+
+If you want to understand that maturity map first, read:
+
+1. `docs/roadmap-alpha.md`
+2. `docs/release-1.0-readiness.md`
+
+---
+
 ## Choose your starting mode
 
 Most readers should start in one of these modes:
@@ -62,6 +79,8 @@ If you only have a few minutes, look at:
 
 - `README.md`
 - `docs/00-overview.md`
+- `docs/roadmap-alpha.md`
+- `docs/release-1.0-readiness.md`
 - `docs/governance.md`
 - `examples/hello-world/`
 - `scripts/check-governance.sh`
@@ -71,6 +90,7 @@ That gives you a compact sense of:
 - the problem AletheIA solves
 - the operating model
 - the governance baseline
+- the current maturity map
 - the smallest runnable proof
 
 ---
@@ -79,9 +99,9 @@ That gives you a compact sense of:
 
 If you want to test AletheIA in practice, start with one of these:
 
-### Option A — inspect the public alpha
+### Option A — inspect the current pre-1.0 baseline
 
-- read the overview and roadmap
+- read the overview, roadmap, and readiness gate
 - inspect the starter-pack
 - run the lightweight examples and tests
 
@@ -105,6 +125,7 @@ Do not start by:
 - trying to automate the entire framework at once
 - copying every artifact into your repo before one real pilot exists
 - assuming your local rules are already reusable framework rules
+- pulling post-1.0 ideas into your first bounded adoption slice
 
 AletheIA works best when adoption starts small and becomes more explicit through use.
 
@@ -117,4 +138,5 @@ After `getting-started.md`, choose one of these paths:
 - **understand the core** -> `docs/00-overview.md`
 - **pilot in an existing project** -> `docs/apply-to-existing-project.md`
 - **inspect the operating method** -> `starter-pack/README.md`
-- **understand the roadmap** -> `docs/roadmap-alpha.md`
+- **understand the maturity path** -> `docs/roadmap-alpha.md`
+- **understand what still blocks 1.0** -> `docs/release-1.0-readiness.md`

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -12,7 +12,7 @@ This document exists to help present AletheIA clearly in public.
 
 ## 3. One-paragraph project description
 
-AletheIA is an operating framework for AI-assisted work. It helps teams structure context, decisions, governance, validation, and learnings before execution, so model output does not act directly on systems without control. The framework is provider-agnostic, deterministic at its core, and designed to be reusable across projects.
+AletheIA is an operating framework for AI-assisted work. It helps teams structure context, decisions, governance, validation, and learnings before execution, so model output does not act directly on systems without control. The framework is provider-agnostic, deterministic at its core, and designed to be reusable across projects. The public repository is currently in a late Alpha completion cycle before 1.0.
 
 ## 4. Suggested GitHub topics
 
@@ -27,25 +27,25 @@ AletheIA is an operating framework for AI-assisted work. It helps teams structur
 - typescript
 - workflows
 
-## 5. Announcement copy — short
+## 5. Announcement copy — current phase
 
 ### English
 
-We just published the first public alpha draft of **AletheIA**: an operating framework for AI-assisted work.
+AletheIA is in its final Alpha-completion phase before **1.0**.
 
-AletheIA introduces an explicit layer between model output and execution, with structured decisions, governance, validation, and learnings.
+It is an operating framework for AI-assisted work that introduces an explicit layer between model output and execution, with structured decisions, governance, validation, and learnings.
 
-It was shaped in real operational work and is now being extracted into a reusable public framework.
+The current focus is to finish the open Alpha work cleanly before moving into the post-1.0 tracks.
 
 Repo: https://github.com/nevitonsantana/aletheia
 
 ### Português
 
-Acabamos de publicar o primeiro alpha público do **AletheIA**: um framework operacional para trabalho assistido por IA.
+O AletheIA está em sua fase final de fechamento dos Alphas antes da **1.0**.
 
-O AletheIA introduz uma camada explícita entre output de modelo e execução, com decisão estruturada, governança, validação e learnings.
+Ele é um framework operacional para trabalho assistido por IA que introduz uma camada explícita entre output de modelo e execução, com decisão estruturada, governança, validação e learnings.
 
-Ele nasceu em trabalho operacional real e agora está sendo extraído como framework público reutilizável.
+O foco atual é fechar bem os Alphas ainda abertos antes de avançar para as trilhas pós-1.0.
 
 Repo: https://github.com/nevitonsantana/aletheia
 
@@ -63,7 +63,7 @@ Instead of letting raw model output act directly on the system, AletheIA introdu
 - proportional validation
 - reusable learnings
 
-The repository is now public as an early alpha draft. The goal of this first version is clarity over completeness and structure over cleverness.
+The public repository is still pre-1.0, but it now has an explicit completion path: finish the remaining Alpha work first, then move into versioned 1.x evolution.
 
 ### Português
 
@@ -77,4 +77,4 @@ Em vez de permitir que o output bruto do modelo aja diretamente no sistema, o Al
 - validação proporcional
 - learnings reutilizáveis
 
-O repositório agora está público como um alpha inicial. O objetivo desta primeira versão é priorizar clareza sobre completude e estrutura sobre esperteza.
+O repositório público ainda está em fase pré-1.0, mas agora tem um caminho explícito de fechamento: concluir primeiro os Alphas ainda abertos e só depois entrar na evolução versionada em 1.x.

--- a/docs/release-1.0-readiness.md
+++ b/docs/release-1.0-readiness.md
@@ -1,0 +1,198 @@
+# AletheIA 1.0 Readiness Gate
+
+This document exists to answer one question clearly:
+
+**what still needs to be true before AletheIA can stop presenting itself as an alpha and become 1.0?**
+
+The current rule is explicit:
+
+> **AletheIA reaches 1.0 when Alpha 1–7 are done enough for the baseline, not when every future track is finished.**
+
+That means:
+
+- 1.0 is blocked by the **open Alpha completion work**
+- 1.0 is **not** blocked by enterprise-readiness, domain packs, or heavier tooling
+- those later tracks remain valid, but they move into **post-1.0 roadmap work**
+
+---
+
+## Why 1.0 is gated by Alpha completion
+
+The Alpha roadmap is the backbone of the framework.
+
+If AletheIA declared 1.0 before the open Alphas are sufficiently hardened, the framework would create avoidable ambiguity about:
+
+- what is already stable enough to teach
+- what still needs operational hardening
+- what is intentionally future-facing
+
+So the 1.0 gate exists to make three things explicit:
+
+1. **Alpha 1–3 are already complete enough** for the current cycle
+2. **Alpha 4–7 still need specific completion work**
+3. **post-1.0 tracks stay deferred until that completion work is done**
+
+---
+
+## Current Alpha status
+
+### Complete enough for the current cycle
+
+- **Alpha 1** — core + governance baseline
+- **Alpha 2** — real pilots + self-application
+- **Alpha 3** — adoption + ecosystem baseline
+
+### Still open for the 1.0 gate
+
+- **Alpha 4** — baseline established, still open
+- **Alpha 5** — baseline established, still open
+- **Alpha 6** — baseline established, still open
+- **Alpha 7** — future-facing but bounded, still not 1.0-ready
+
+See also:
+
+- `docs/roadmap-alpha.md`
+
+---
+
+## Done-enough criteria by Alpha
+
+### Alpha 1 — done enough
+
+Already sufficient for the current cycle.
+No new blocker is defined here beyond keeping the baseline coherent.
+
+### Alpha 2 — done enough
+
+Already sufficient for the current cycle.
+No new blocker is defined here beyond keeping the pilot-to-framework bridge coherent.
+
+### Alpha 3 — done enough
+
+Already sufficient for the current cycle.
+No new blocker is defined here beyond keeping adoption guidance and starter-pack clarity coherent.
+
+### Alpha 4 — done enough when
+
+- handoff docs, template, and examples are coherent without a meaningful gap between concept and use
+- the boundary between schema coverage and richer operational handoff practice is clear
+- at least one strong multi-boundary continuity example exists if the current examples still feel too light
+
+### Alpha 5 — done enough when
+
+- it remains selective rather than universal
+- it has more tangible real or near-real evidence
+- it is better coupled to risk-to-gate and iterative maintenance
+- it is clearer when structured inference adds value and when it only adds overhead
+
+### Alpha 6 — done enough when
+
+- presets, adapters, and adoption modes feel more tangible
+- at least one more concrete extension or distribution example exists
+- plugability is better explained without drifting into enterprise-readiness claims
+
+### Alpha 7 — done enough for 1.0 when
+
+- it remains explicitly optional and future-facing
+- generator, output, and tooling-boundary docs are coherent with each other
+- the roadmap no longer implies that 1.0 depends on real tooling implementation
+
+Important:
+
+**Alpha 7 does not need active tooling implementation before 1.0.**
+It only needs a clear, bounded, non-misleading definition.
+
+---
+
+## 1.0 public-release checklist
+
+The 1.0 flip should happen only after the open Alpha criteria above are satisfied.
+
+At that moment, the public release checklist is:
+
+- remove public-facing language that still frames the repo as an alpha or draft
+- update central docs to say **AletheIA 1.0** clearly and consistently
+- add `"version": "1.0.0"` to `package.json`
+- create `CHANGELOG.md`
+- prepare and publish the public tag/release `v1.0.0`
+
+### Public surfaces to update at the 1.0 flip
+
+- `README.md`
+- `docs/00-overview.md`
+- `docs/getting-started.md`
+- `docs/launch-kit.md`
+- `CONTRIBUTING.md`
+- `package.json`
+- `CHANGELOG.md`
+
+---
+
+## What remains post-1.0
+
+These tracks remain real and already planned, but they are **not** part of the 1.0 gate.
+
+### 1.1 — enterprise-readiness / regulated adoption
+
+Preserved backlog includes:
+
+- enterprise-readiness / regulated adoption roadmap
+- enterprise adoption guidance
+- restricted enterprise extension example
+- stronger local trust-boundary posture for constrained environments
+
+### 1.2 — pilot expansion / stronger real-world validation
+
+Preserved backlog includes:
+
+- expansion beyond the strongest current pilot lane
+- more real-world comparisons between extensions
+- stronger conversion from pilot evidence into framework improvement
+
+### 1.3 — distribution & delivery hardening
+
+Preserved backlog includes:
+
+- broader distribution hardening beyond “done enough”
+- stronger post-baseline preset and adapter material
+- more delivery-layer clarity once the baseline is already stable
+
+### 1.4+ — domain governance packs hardening
+
+Preserved backlog includes:
+
+- stronger domain governance packs
+- reusable trust-boundary and prompt-injection layers
+- heavier Alpha 7 tooling only if later justified
+
+---
+
+## Completion-first queue before 1.0
+
+The current pre-1.0 queue is:
+
+1. **Alpha 4 completion pass**
+2. **Alpha 5 hardening pass**
+3. **Alpha 6 tangibility pass**
+4. **Alpha 7 boundary clarification pass**
+
+Until this queue is sufficiently closed, these post-1.0 tracks remain deferred by design.
+
+---
+
+## What 1.0 will and will not mean
+
+### 1.0 will mean
+
+- the baseline roadmap is coherent enough to teach, reuse, and evolve publicly
+- Alpha 1–7 are done enough for the baseline
+- the framework can move from alpha framing into versioned 1.x evolution
+
+### 1.0 will not mean
+
+- enterprise-ready by default
+- fully tooled bootstrap and delivery automation
+- every future domain pack already hardened
+- the end of framework evolution
+
+1.0 is the moment when the baseline stops being ambiguous, not the moment when every next track is finished.

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -1,176 +1,126 @@
-# AletheIA Alpha Roadmap
+# AletheIA Roadmap — Alpha Completion First
 
-## Alpha 1 — Core + Governance Baseline
+AletheIA still uses **Alpha 1–7** as its primary maturity map.
 
-Focus:
-- prove the framework core
-- harden the minimum governance baseline
+The current roadmap rule is now explicit:
 
-Includes:
-- core contracts
-- minimal deterministic kernel
-- governance pack
-- governance hooks
-- quality baseline
-- learning-from-failed-validation
-- token policy
-- technical governance baseline
-- stronger durable-decision / ADR discipline
-- clearer distinction between behavioral enforcement and technical enforcement
+1. **close the Alphas that are still open**
+2. **declare a formal 1.0 gate**
+3. **only then pull the post-1.0 tracks into priority**
 
-### What Alpha 1 must prove
+This means previously discussed next steps are **not lost**.
+They are preserved below either as:
 
-By the end of Alpha 1, AletheIA should already show that:
-
-- an input can become a structured decision
-- governance can evaluate whether work should proceed
-- unsafe or poorly framed closure can be blocked
-- failed validation can generate reusable learnings
-- token discipline can be explicit instead of implicit
-- the repository has a small executable governance baseline, not only governance prose
-
-### Notes
-
-Alpha 1 should stay intentionally small.
-
-This phase is not the moment for:
-- heavy policy engines
-- installer promises
-- large integration matrices
-- strong claims about enterprise enforcement
-
-The goal is to make the framework inspectable, teachable, and minimally enforceable.
-
-Current Alpha 1 baseline artifacts now include:
-
-- `docs/token-policy.md`
-- `scripts/check-governance.sh`
-- `docs/durable-decisions.md`
-- `docs/enforcement-boundaries.md`
+- a **completion-first queue** that still blocks 1.0, or
+- **deferred until post-1.0** tracks that stay valid but must not compete with Alpha completion.
 
 ---
 
-## Alpha 2 — Real Pilots + Self-Application
+## How to read this roadmap
 
-Focus:
-- prove AletheIA in real product flows
-- start using AletheIA to improve AletheIA
+This roadmap is organized in three layers:
 
-Includes:
-- first real Crisis Monitor pilot write-up
-- second small pilot or adjacent real flow
-- stronger pilot learnings loop
-- project extension pattern
-- self-application loop
-- self-application of AletheIA contracts to framework evolution
-- clearer conversion of pilot learnings into framework improvements
+1. **Established baseline**
+   - Alphas that are complete enough for the current cycle
+2. **Alpha completion pass**
+   - Alphas whose baseline exists but still needs hardening or clearer boundaries before 1.0
+3. **Deferred until post-1.0**
+   - valid tracks that remain intentionally out of the current priority lane
 
-### What Alpha 2 must prove
+See also:
 
-By the end of Alpha 2, AletheIA should already show that:
+- `docs/release-1.0-readiness.md`
+- `docs/00-overview.md`
 
-- the framework works in real product slices, not only examples
-- pilots produce durable learnings, not just anecdotes
-- AletheIA can be applied to its own roadmap and repo evolution
-- project-specific extensions can exist without collapsing the framework into a single product
+---
 
-### Notes
+## Established baseline
 
-This is the phase where real pilots matter more than abstract completeness.
+### Alpha 1 — Core + Governance Baseline
+**Status:** complete enough for the current cycle
 
-The most important move in Alpha 2 is not adding more framework surface.
-It is closing the loop between:
+What Alpha 1 already established:
 
-`pilot -> learning -> framework improvement`
+- framework core contracts
+- minimal deterministic kernel
+- governance baseline
+- token discipline
+- explicit token policy
+- durable decisions
+- enforcement-boundary clarity
+- quality baseline
+- learning-from-failed-validation path
 
-Current Alpha 2 bridge artifacts now include:
+Current anchor artifacts include:
+
+- `docs/token-policy.md`
+- `docs/durable-decisions.md`
+- `docs/enforcement-boundaries.md`
+- `docs/quality.md`
+- `scripts/check-governance.sh`
+
+### Alpha 2 — Real Pilots + Self-Application
+**Status:** complete enough for the current cycle
+
+What Alpha 2 already established:
+
+- real pilot grounding through Crisis Monitor
+- self-application of framework discipline to framework evolution
+- pilot-to-learning-to-framework conversion
+- project extension as a clean local layer
+
+Current anchor artifacts include:
 
 - `docs/self-application.md`
 - `docs/pilot-crisis-monitor.md`
 - `docs/pilot-conversion.md`
 - `docs/project-extension-pattern.md`
+- `examples/pilot-conversion/crisis-monitor-real-world-validation.md`
 
-Together, these four artifacts define how AletheIA learns from pilots, improves itself, and preserves the boundary between reusable core and local project context.
+### Alpha 3 — Adoption + Ecosystem
+**Status:** complete enough for the current cycle
 
-Recent Crisis Monitor validation now gives Alpha 2 a stronger bridge than early explicability alone. The bridge is now supported by a real sequence of product proof, contract hardening, operational health reading, investigation, and compact lane summary before the learnings return to the framework.
+What Alpha 3 already established:
 
----
+- clearer onboarding
+- starter-pack reuse
+- contribution guidance
+- existing-project application path
+- stronger separation between framework core and local extension
 
-## Alpha 3 — Adoption + Ecosystem
+Current anchor artifacts include:
 
-Focus:
-- make the repository easier to adopt, extend, and contribute to
-
-Includes:
-- better onboarding
-- a clearer getting-started path
-- stronger contributor guidance
-- clearer contribution boundaries for framework core vs project extension
-- stronger starter-pack
-- clearer guidance for applying AletheIA in an existing project
-- cleaner release structure
-- reusable domain governance packs
-- tighter release hygiene
-- less pilot-specific residue in public docs
-
-### What Alpha 3 must prove
-
-By the end of Alpha 3, AletheIA should already show that:
-
-- a new team can understand how to start
-- contributors can extend the framework without breaking its core logic
-- the starter-pack is more reusable and less tied to its original extraction context
-- governance patterns can be reused across domains without redefining the whole framework
-
-### Notes
-
-Alpha 3 is not about making the framework heavier.
-It is about making it easier to adopt.
-
-AletheIA should become easier to:
-- read
-- install mentally
-- adapt
-- contribute to
-- test in real projects
+- `docs/getting-started.md`
+- `docs/apply-to-existing-project.md`
+- `CONTRIBUTING.md`
+- `starter-pack/README.md`
+- `starter-pack/templates/project-extension-template.md`
 
 ---
 
-## Alpha 4 — Orchestrated Handoffs & Multi-Agent Continuity
+## Alpha completion pass
 
-Focus:
-- make handoffs between agents explicit, reusable, model-agnostic, and increasingly automatable
+These Alphas are real baselines already, but they are **still open for the 1.0 gate**.
 
-Includes:
-- structured inter-agent handoff contracts
-- handoff generation patterns from real work items
-- clearer separation between human-facing summaries and agent-facing restart packages
-- model-agnostic continuity patterns that do not depend on one LLM or coding tool
-- starter-pack guidance for cross-agent execution flows
-- reusable patterns for passing scope, validation, risks, and next action across agents
+### Alpha 4 — Orchestrated Handoffs & Multi-Agent Continuity
+**Status:** baseline established, still open
 
-### What Alpha 4 must prove
+Alpha 4 already has:
 
-By the end of Alpha 4, AletheIA should already show that:
+- handoff concept docs
+- generation guidance
+- starter-pack template
+- project-level conventions
+- handoff capture pattern
+- restart-package examples
 
-- handoffs can be produced as compact restart packages instead of ad-hoc prompts
-- one agent can stop at its boundary and prepare the next agent's work clearly
-- cross-agent continuity can happen without relying on hidden thread memory
-- handoff artifacts can be generated in a repeatable way from real project work
-- the handoff structure can work across different LLMs and agent shells without changing its core meaning
+What still needs to feel done enough:
 
-### Notes
+- tighter coherence between doc, template, and examples
+- a clearer boundary between schema coverage and richer operational handoff practice
+- at least one stronger multi-boundary continuity example if the current examples still feel too light
 
-Alpha 4 is not about adding more agents for their own sake.
-It is about making agent boundaries safer and more productive.
-
-The key move in Alpha 4 is turning:
-
-`work in one agent -> explicit handoff artifact -> reliable continuation in another agent`
-
-into a reusable operating pattern.
-
-Current Alpha 4 baseline artifacts now include:
+Current anchor artifacts include:
 
 - `docs/agent-handoffs.md`
 - `starter-pack/guides/agent-handoff-generation.md`
@@ -178,48 +128,26 @@ Current Alpha 4 baseline artifacts now include:
 - `docs/project-handoff-conventions.md`
 - `docs/handoff-capture-pattern.md`
 
-Next artifacts for this phase may include:
+### Alpha 5 — Structured Risk Inference & Evidence-Oriented Validation
+**Status:** baseline established, still open
 
-- execution-scope fields such as allowed files, forbidden files, allowed data, semantic guardrails, acceptance criteria, and expected response format
-- project-level handoff examples drawn from real pilot work
-- more explicit draft/review flows for semi-automated handoff assembly
+Alpha 5 already has:
 
----
+- concept framing
+- template
+- trigger guidance
+- generation guidance
+- pilot scenarios
+- example artifacts
 
-## Alpha 5 — Structured Risk Inference & Evidence-Oriented Validation
+What still needs to feel done enough:
 
-Focus:
-- make higher-risk decisions more reviewable before execution through structured, evidence-oriented inference
+- more tangible real or near-real evidence
+- a tighter connection to risk-to-gate and iterative maintenance
+- clearer guidance on when inference helps and when it becomes unnecessary overhead
+- continued selective positioning rather than universal ceremony
 
-Includes:
-- a conditional inference step for higher-risk work
-- compact inference artifacts with premises, assumptions, invariants, risks, unknowns, and test gaps
-- better connection between semantic risk and validation design
-- stronger rationale preservation across high-stakes handoffs
-- experimental use in code and semantic-risk scenarios before broader expansion
-
-### What Alpha 5 must prove
-
-By the end of Alpha 5, AletheIA should already show that:
-
-- higher-risk changes can be reasoned about more explicitly before execution
-- semantic risks can be surfaced without pretending to prove formal correctness
-- evidence, assumptions, and unknowns can be captured in a reusable artifact
-- risk-oriented suggested tests can improve validation quality
-- the capability can remain selective instead of becoming universal ceremony
-
-### Notes
-
-Alpha 5 should not be framed as formal verification.
-It should be framed as structured, reviewable inference for cases where raw confidence is not enough.
-
-The key move in Alpha 5 is inserting a conditional step such as:
-
-`intent -> context -> decision -> [if triggered: inference] -> execution -> validation -> learning`
-
-This phase should begin as an experimental capability, not a mandatory step for every workflow.
-
-Current Alpha 5 baseline artifacts now include:
+Current anchor artifacts include:
 
 - `docs/structured-risk-inference.md`
 - `starter-pack/templates/inference-artifact-template.md`
@@ -228,47 +156,24 @@ Current Alpha 5 baseline artifacts now include:
 - `docs/inference-pilot-scenarios.md`
 - `examples/structured-risk-inference/README.md`
 
-Together, these artifacts now define Alpha 5 as a concept-plus-examples baseline rather than only a template-and-guidance layer.
+### Alpha 6 — Distribution, Presets & Adapters
+**Status:** baseline established, still open
 
----
+Alpha 6 already has:
 
-## Alpha 6 — Distribution, Presets & Adapters
+- distribution architecture framing
+- preset taxonomy
+- adapter taxonomy
+- adoption modes
+- delivery mappings
 
-Focus:
-- make AletheIA easier to package, deliver, and reuse across project shapes and agent environments without changing the framework core
+What still needs to feel done enough:
 
-Includes:
-- preset or bundle models for common project shapes
-- editor and agent-shell adapters that preserve the same framework meaning across environments
-- lighter vs fuller adoption modes
-- clearer distinction between framework core and delivery-layer packaging
-- future-facing distribution guidance that stays provider-agnostic
+- more tangible presets, adapters, and adoption examples
+- at least one stronger local distribution or extension example in a demanding context
+- clearer communication of architectural plugability without claiming enterprise-readiness
 
-### What Alpha 6 must prove
-
-By the end of Alpha 6, AletheIA should already show that:
-
-- the framework can be packaged in more than one reusable form without distorting its conceptual core
-- presets can adapt the framework to different project shapes without turning into incompatible forks
-- adapters can deliver the same meaning across editor or agent environments
-- teams can choose lighter vs fuller adoption footprints without changing the framework's governing logic
-
-### Notes
-
-Alpha 6 is not a CLI-first phase.
-It is a distribution-architecture phase.
-
-This phase should not:
-- change the decision or governance core
-- make one editor the canonical interface
-- introduce mandatory external integrations
-- promise one-command installation before the model is stable
-
-Current Alpha 6 direction is documented in:
-
-- `docs/distribution-presets-adapters.md`
-
-Current Alpha 6 baseline artifacts now include:
+Current anchor artifacts include:
 
 - `docs/distribution-presets-adapters.md`
 - `docs/preset-taxonomy.md`
@@ -276,35 +181,24 @@ Current Alpha 6 baseline artifacts now include:
 - `docs/adoption-mode-guidance.md`
 - `docs/delivery-mapping-examples.md`
 
-Together, these artifacts now define Alpha 6 as a first concrete distribution baseline covering packaging shape, delivery surface, adoption depth, and cross-surface meaning preservation.
+### Alpha 7 — Bootstrap & Delivery Tooling
+**Status:** baseline defined, still not 1.0-ready
 
----
+Alpha 7 already has:
 
-## Alpha 7 — Bootstrap & Delivery Tooling
+- principles
+- tooling boundaries
+- bootstrap output examples
+- generator contract
+- delivery output contract
 
-Focus:
-- operationalize the distribution model from Alpha 6 through optional bootstrap and delivery tooling
+What still needs to feel done enough for 1.0:
 
-### What Alpha 7 should remain
+- clearer boundary language so the tooling layer stays obviously optional and future-facing
+- coherence between generator, output, and boundary docs
+- no implication that 1.0 depends on real delivery tooling
 
-Alpha 7 should stay intentionally smaller and later than Alpha 6.
-
-It may eventually include:
-
-- optional bootstrap CLI flows
-- delivery automation for presets or adapters
-- packaging helpers for distributing AletheIA into real repositories
-
-### Notes
-
-Alpha 7 should only become active after presets, adapters, adoption modes, and delivery mappings are already well-defined.
-
-It should remain:
-- provider-agnostic
-- optional
-- clearly outside the framework core itself
-
-Current Alpha 7 baseline artifacts now include:
+Current anchor artifacts include:
 
 - `docs/bootstrap-principles.md`
 - `docs/delivery-tooling-boundaries.md`
@@ -312,19 +206,14 @@ Current Alpha 7 baseline artifacts now include:
 - `docs/bootstrap-generator-contract.md`
 - `docs/delivery-output-contract.md`
 
-Together, these artifacts now define Alpha 7 as a first future-facing tooling baseline covering posture, boundaries, output shape, generator IO, and output obligations before any implementation is attempted.
-
 ---
 
-## Current Operational Composition Baseline
+## Current operational-composition baseline
 
-Focus:
-- make the current baselines more tangible through composed work slices, clearer risk-to-gate mapping, stronger handoff examples, and optional filesystem-based context routing experiments
+This is **not a new Alpha**.
+It is a proportional operating layer that makes the existing baselines easier to apply.
 
-This is not a new Alpha.
-It is a low-regret operational-composition baseline that composes the current artifacts around Alpha 4 and Alpha 5 without changing the framework core.
-
-Current artifacts in this layer now include:
+Current artifacts in this layer include:
 
 - `docs/work-slice-pattern.md`
 - `starter-pack/templates/work-slice-template.md`
@@ -336,63 +225,92 @@ Current artifacts in this layer now include:
 - `docs/iterative-maintenance-governance.md`
 - `starter-pack/guides/round-based-maintenance.md`
 - `examples/iterative-maintenance/three-round-loop/README.md`
+- `starter-pack/guides/model-strategy-by-task.md`
+- `starter-pack/templates/project-model-strategy-template.md`
 
-Together, these artifacts now define a first operational-composition baseline and strengthen five practical moves without inflating the core:
+This layer currently strengthens:
 
-- make bounded work more legible through composed slices
-- connect risk posture to proof depth and gate choice
-- make handoffs more restartable without making them more bureaucratic
-- test filesystem-based context routing as an optional starter-pack experiment
-- make iterative maintenance rounds more legible through composed slices, regression-aware gates, and reusable learning
+- work-slice legibility
+- risk-to-gate mapping
+- stronger restart-package continuity
+- optional filesystem-based context routing experiments
+- round-based maintenance guidance over existing contracts
+- regression-aware continuation and reusable learning across rounds
+- advisory-only model strategy by task shape, capability profile, reasoning depth, and trust / hosting posture
 
-Alongside that operational layer, the starter-pack now also carries an advisory-only model-strategy guidance slice for matching task shape, capability profile, reasoning depth, and trust / hosting posture without turning model choice into a framework-level rule.
-
-The iterative-maintenance slice now has stronger operational grounding as well: it should be read as a proportional pattern for important loops where proof, contract, health metric, alert, investigation, and lane summary make continuation safer without becoming a universal requirement.
+It should remain smaller than the core and must not replace the Alpha completion pass.
 
 ---
 
-## Future Track — Reusable Domain Governance Packs
+## Completion-first queue
 
-Focus:
-- make recurring domain-specific governance reusable without inflating the AletheIA core
+These previously discussed moves remain **active** and are now the formal queue before 1.0:
 
-This future track exists for governance patterns that are:
+1. **Alpha 4 completion pass**
+2. **Alpha 5 hardening pass**
+3. **Alpha 6 tangibility pass**
+4. **Alpha 7 boundary clarification pass**
 
-- too domain-specific to live in the framework core
-- too reusable to remain only as project-local rules
-- worth documenting as reusable operating discipline before any heavier automation appears
+This queue exists so that new strategic tracks do not compete with what still blocks a clean 1.0 baseline.
 
-This is not a new Alpha right now.
-It is a future track for reusable domain governance layers that sit between the framework core and each project's local extension.
+---
 
-The intended layer is:
+## Deferred until post-1.0
 
-`AletheIA core -> domain governance pack -> project extension`
+These tracks remain valid, but they are now explicitly **deferred until after the 1.0 gate**.
 
-The first planned packs in this track are:
+### 1.1 — Enterprise-readiness / regulated adoption
+Includes the previously discussed backlog items such as:
 
-- `Web App Security & Trust Boundaries Pack`
-- `AI Agent Security & Prompt Injection Pack`
+- enterprise-readiness / regulated adoption roadmap
+- enterprise adoption guidance
+- restricted enterprise extension example
+- stronger articulation of local trust-boundary posture in constrained environments
 
-This future track connects to the existing phases in specific ways:
+### 1.2 — Pilot expansion / stronger real-world validation
+Includes:
 
-- Alpha 1 provides the generic governance baseline and core security-adjacent rules
-- Alpha 3 opens the path for reusable domain governance packs beyond the core
-- Alpha 4 contributes execution boundaries, handoffs, and semantic guardrails
-- Alpha 5 may later strengthen higher-risk decisions inside these packs through selective structured inference
+- expansion beyond the strongest current pilot lane
+- more real-world comparisons between project extensions
+- stronger pilot-to-framework conversion evidence
 
-Current direction for this track is documented in:
+### 1.3 — Distribution & delivery hardening
+Includes:
 
-- `docs/domain-governance-packs.md`
-- `docs/web-app-security-trust-boundaries.md`
-- `docs/ai-agent-security-prompt-injection.md`
+- broader delivery and distribution hardening beyond “done enough”
+- stronger preset and adapter tangibility after the Alpha 6 pass
+- additional delivery-layer material once the baseline is already stable
 
-This future track should not:
+### 1.4+ — Domain governance packs hardening
+Includes:
 
-- redefine the kernel or policy core
-- collapse vendor-specific guidance into framework truth
-- turn project-local rules into universal enforcement by accident
-- pretend these packs are already active policies in the framework
+- stronger domain governance packs
+- future trust-boundary and prompt-injection packs as harder reusable layers
+- heavier Alpha 7 tooling only after the baseline and post-1.0 priorities justify it
+
+These deferred tracks are preserved as backlog on purpose.
+They are not cancelled.
+They are simply not the current priority lane.
+
+---
+
+## Sequence to 1.0
+
+The current order is now explicit:
+
+1. finish the **Alpha completion-first queue**
+2. run the **1.0 readiness check** in `docs/release-1.0-readiness.md`
+3. flip the public surfaces from late-alpha to **AletheIA 1.0**
+4. begin the **1.x roadmap**
+
+Until then, the repository should keep treating:
+
+- enterprise-readiness
+- stronger domain governance packs
+- heavier delivery tooling
+- broader post-baseline distribution work
+
+as **deferred tracks**, not current priorities.
 
 ---
 
@@ -400,49 +318,10 @@ This future track should not:
 
 Across all phases, AletheIA should preserve a few boundaries:
 
-1. It should remain provider-agnostic.
-2. It should not collapse into a single governance template.
-3. It should not confuse product pilot residue with reusable framework core.
-4. It should prefer explicit contracts over hidden conventions.
-5. It should treat learnings as reviewable artifacts, not informal memory.
-6. It should evolve through real pilots, not only through internal theory.
-7. It should treat distribution and tooling as delivery-layer concerns, not as replacements for the core operating model.
-
----
-
-## Near-term priority order
-
-1. keep the current operational-composition baseline coherent
-   - work-slice pattern
-   - risk-to-gate mapping
-   - stronger handoff examples
-   - optional workspace-context-routing experiment
-2. keep the current Alpha 5 inference baseline coherent
-   - concept doc
-   - inference template
-   - trigger guidance
-   - generation guide
-   - pilot scenarios
-   - example artifacts
-   - alignment with Alpha 4 handoffs and the new work-slice layer
-3. keep the current Alpha 4 handoff baseline coherent
-   - concept doc
-   - generation guide
-   - handoff template
-   - project-level conventions
-   - handoff capture pattern
-   - compact restart-package examples
-4. keep the current Alpha 3 adoption baseline coherent
-   - getting started
-   - existing-project application
-   - contributor guidance
-   - project extension template
-5. keep the Alpha 2 bridge coherent while adoption grows
-   - preserve the Crisis Monitor pilot as the strongest current real-world validation lane
-   - keep the conversion path from pilot evidence to small framework improvements explicit
-6. continue validating the Crisis Monitor pilot and nearby real slices
-7. convert pilot learnings into framework updates
-8. keep Alpha 5 framed as experimental structured risk inference rather than strong formal verification
-9. keep Alpha 6 as a concrete distribution layer without distorting the framework core
-10. keep Alpha 7 optional, bounded, and clearly outside the core model
-11. shape future domain governance packs as reusable layers without moving them into the framework core
+1. remain provider-agnostic
+2. avoid collapsing into one product's operating residue
+3. prefer explicit contracts over hidden conventions
+4. keep learnings reviewable instead of informal
+5. improve through real pilots instead of theory alone
+6. keep delivery and tooling as delivery-layer concerns, not replacements for the core operating model
+7. treat project extension as the main place where local complexity should land


### PR DESCRIPTION
## Summary
- restructure the roadmap around established baseline, Alpha completion pass, and deferred post-1.0 tracks
- add a new 1.0 readiness gate doc that preserves previously discussed backlog as explicit completion-first and deferred queues
- update public surfaces to describe the current phase as late Alpha completion before 1.0

## Validation
- bash scripts/check-governance.sh