### PR TITLE
Harden Alpha 4 handoff continuity

### DIFF
--- a/docs/agent-handoffs.md
+++ b/docs/agent-handoffs.md
@@ -148,6 +148,62 @@ The important boundary is:
 
 ---
 
+## When the minimum structured record is enough
+
+A smaller handoff is usually enough when:
+
+- the next action is obvious
+- the receiving boundary is narrow
+- the files in scope are already stable
+- the main risk is execution, not reinterpretation
+- validation continuity can be stated in one compact line
+
+In those cases, AletheIA should prefer the minimum restart package over a heavier artifact.
+
+---
+
+## When to step up to the richer operational template
+
+Use the richer optional fields when one or more of these are true:
+
+- the work crosses a meaningful ownership boundary
+- the next agent could easily reinterpret the task as a different frontier
+- file scope must be frozen explicitly
+- there are semantic guardrails that matter more than raw file paths
+- acceptance criteria need to be preserved to avoid drift
+- the receiving agent should report back in a specific shape
+
+This is the practical boundary between **schema-enough continuity** and **richer operational continuity**.
+
+---
+
+## Multi-boundary continuity rule
+
+If work will cross more than one meaningful boundary, AletheIA should usually prefer:
+
+**a chain of compact handoffs**
+
+instead of:
+
+**one oversized handoff trying to predict every later step**
+
+Why:
+
+- each boundary can keep a narrower scope
+- validation can remain local to the current step
+- later agents receive fresher context
+- the artifact stays reviewable instead of turning into a transcript-shaped bundle
+
+A strong multi-boundary flow normally looks like:
+
+`boundary A -> restart package -> boundary B -> restart package -> boundary C`
+
+See:
+
+- `examples/handoffs/multi-boundary-continuity.md`
+
+---
+
 ## Low-bureaucracy rule
 
 A stronger handoff should reduce ambiguity, not increase ritual.
@@ -202,6 +258,7 @@ Alpha 4 is going well when:
 - scope drift is reduced
 - validation continuity is preserved across the handoff
 - the artifact still works even if the receiving agent changes provider
+- multi-boundary work can be continued through small restart packages instead of giant recaps
 - the handoff is rich enough to restart work, but still shorter than a transcript
 
 ---
@@ -214,6 +271,7 @@ Do not treat an agent handoff as:
 - a generic paragraph with no execution boundary
 - a provider-specific prompt recipe disguised as framework logic
 - a bureaucratic checklist that duplicates the entire task history
+- a single artifact trying to solve three later boundaries at once
 
 AletheIA should preserve the handoff as a reusable operating pattern.
 
@@ -227,6 +285,7 @@ AletheIA should preserve the handoff as a reusable operating pattern.
 - `starter-pack/templates/agent-handoff-template.md`
 - `examples/handoffs/compact-reviewable-handoff.md`
 - `examples/handoffs/high-stakes-handoff.md`
+- `examples/handoffs/multi-boundary-continuity.md`
 - `docs/work-slice-pattern.md`
 - `docs/project-handoff-conventions.md`
 - `docs/handoff-capture-pattern.md`

--- a/docs/handoff-capture-pattern.md
+++ b/docs/handoff-capture-pattern.md
@@ -118,6 +118,25 @@ The meaning of the output should remain stable.
 
 ---
 
+## When one handoff is not enough
+
+Sometimes the right output is not one handoff artifact, but a **chain of smaller handoffs**.
+
+This usually happens when:
+
+- the dominant frontier changes more than once
+- different boundaries need different validation expectations
+- one later boundary should not be pre-decided too early
+
+In those cases, the capture pattern should help generate:
+
+- a draft for the immediate next boundary first
+- and only then a later draft when the next boundary has actually been crossed
+
+This is safer than generating one artifact that pretends to know every later continuation already.
+
+---
+
 ## Manual vs semi-automated vs automated
 
 ### Manual
@@ -182,6 +201,7 @@ The capture pattern is healthy when:
 - handoff drafting becomes faster without becoming vague
 - the receiving agent needs less reconstruction work
 - scope boundaries are preserved better than in narrative-only recaps
+- multi-boundary work can be split into smaller restart packages when needed
 - the generated draft still works across different LLMs or execution tools
 
 ---
@@ -194,6 +214,7 @@ The main risks are:
 - false confidence in incomplete capture
 - over-automation for simple tasks
 - provider-specific assumptions leaking into the artifact
+- premature generation of later-boundary handoffs that should remain local until the next step is real
 
 ---
 
@@ -205,6 +226,7 @@ AletheIA should mitigate those risks by:
 - requiring editable fields for unknowns and semantic guardrails
 - keeping provider-specific prompt logic outside the framework structure
 - making missing fields explicit rather than inventing them
+- preferring immediate-boundary drafts over giant multi-step artifacts
 
 ---
 
@@ -228,4 +250,5 @@ But Alpha 4 does not need Alpha 5 in order to be useful.
 - `docs/agent-handoffs.md`
 - `starter-pack/guides/agent-handoff-generation.md`
 - `starter-pack/templates/agent-handoff-template.md`
+- `examples/handoffs/multi-boundary-continuity.md`
 - `docs/project-handoff-conventions.md`

--- a/docs/project-handoff-conventions.md
+++ b/docs/project-handoff-conventions.md
@@ -42,6 +42,7 @@ A project may customize:
 - naming patterns
 - validation expectations
 - handoff cadence
+- multi-boundary chain rules
 
 A project should not silently replace:
 
@@ -121,6 +122,21 @@ Examples:
 - execution summary + blockers + suggested follow-up
 - implementation status + out-of-scope notes
 
+### 7. Multi-boundary chain convention
+
+A project may define when one task should generate:
+
+- one operational handoff
+- or a sequence of smaller handoffs
+
+Examples:
+
+- implementation -> observability -> review
+- backend boundary -> UX writing boundary -> visual polish boundary
+- feature hardening -> security review -> release check
+
+The project may define naming or storage patterns for these chains, but the framework meaning should remain the same: each step is still a restart package with explicit scope and validation continuity.
+
 ---
 
 ## What should remain framework-stable
@@ -150,6 +166,7 @@ If a project wants handoffs to be consistent, it should make explicit:
 5. what proof is expected by default for each major frontier
 6. what response format the receiving agent should use
 7. when a handoff should be narrative vs operational
+8. when a multi-boundary chain is preferred over one larger artifact
 
 ---
 
@@ -173,6 +190,7 @@ Project-level handoff conventions are healthy when:
 - handoffs are easier to generate and easier to review
 - multiple agents can work in the same project without relying on hidden memory
 - the project can evolve local rules without forking the framework logic
+- multi-boundary chains remain smaller and more explicit than one oversized recap
 
 ---
 
@@ -184,6 +202,7 @@ Do not let project conventions turn into:
 - hidden assumptions not written anywhere
 - one team's habits masquerading as universal structure
 - prompts that only make sense in one agent shell
+- giant handoff bundles that hide the actual boundary transitions
 
 ---
 
@@ -192,4 +211,5 @@ Do not let project conventions turn into:
 - `docs/agent-handoffs.md`
 - `starter-pack/guides/agent-handoff-generation.md`
 - `starter-pack/templates/agent-handoff-template.md`
+- `examples/handoffs/multi-boundary-continuity.md`
 - `docs/project-extension-pattern.md`

--- a/examples/handoffs/multi-boundary-continuity.md
+++ b/examples/handoffs/multi-boundary-continuity.md
@@ -1,0 +1,205 @@
+# Multi-Boundary Continuity
+
+This example shows a pattern that becomes important once work crosses more than one meaningful boundary.
+
+Instead of one oversized handoff, AletheIA prefers a **chain of compact restart packages**.
+
+In this example, the flow is:
+
+`implementation -> observability -> review`
+
+The point is not the specific frontiers.
+The point is preserving continuity without forcing one artifact to predict every later step.
+
+---
+
+## Why this is stronger than one giant handoff
+
+A single oversized handoff would blur three different needs:
+
+- what the observability boundary should do now
+- what the review boundary should validate later
+- what is still unknown until the observability step actually lands
+
+So AletheIA treats this as:
+
+1. implementation handoff to observability
+2. observability handoff to reviewer
+
+Each one stays smaller, fresher, and easier to validate.
+
+---
+
+## Boundary 1 — implementation -> observability
+
+### Handoff type
+
+Operational handoff
+
+### Receiving agent role
+
+Observability implementer
+
+### Dominant frontier
+
+Metrics and observability
+
+### Cross-boundary reason
+
+The feature behavior already exists, but the next step is a different frontier: adding the canonical events and summary signals without reopening the feature semantics.
+
+### Status
+
+ready for continuation
+
+### What was completed
+
+- the feature slice was implemented
+- the user-facing behavior was validated locally
+- the dominant product rule was preserved
+
+### What remains pending
+
+- emit the canonical event for the new decision outcome
+- update the summary route or scorecard that depends on it
+- keep the feature semantics unchanged while adding observability
+
+### Next action
+
+Add the event and the smallest matching summary read without reopening the product contract.
+
+### Allowed files
+
+- event definitions
+- summary routes
+- observability helpers
+
+### Forbidden files
+
+- feature semantics
+- UI layout
+- policy core
+
+### Explicitly out of scope
+
+- redesigning the feature flow
+- renaming product states for analytics convenience
+- expanding the task into dashboard design
+
+### Relevant files
+
+- event contract file
+- summary route file
+- feature decision record
+
+### Semantic guardrails
+
+Observability should describe the existing feature behavior, not redefine it.
+
+### Validation expectation
+
+- diff inspection
+- targeted smoke for emitted signal
+- summary read showing the new field or count
+
+### Main risks
+
+- redefining the feature just to make tracking easier
+- adding noisy signals that do not match the existing decision layer
+
+---
+
+## Boundary 2 — observability -> review
+
+This second handoff only exists after the observability step is real.
+That is why it should be a separate artifact instead of being guessed too early.
+
+### Handoff type
+
+Operational handoff
+
+### Receiving agent role
+
+Review or QA boundary
+
+### Dominant frontier
+
+Validation and continuity review
+
+### Cross-boundary reason
+
+Implementation and observability are now in place, and the next step is to confirm that the new signals match the intended feature meaning before final closure.
+
+### Status
+
+ready for continuation
+
+### What was completed
+
+- the canonical event was emitted
+- the summary read now exposes the new signal
+- the implementation boundary was kept stable during the observability step
+
+### What remains pending
+
+- confirm the signal is reviewable and proportional
+- check whether the new metric actually helps continuity
+- decide whether any follow-up should remain local or return to the framework backlog
+
+### Next action
+
+Review the new observability layer for semantic match, proof quality, and follow-up scope.
+
+### Allowed files
+
+- summary docs
+- observability notes
+- review artifacts
+
+### Forbidden files
+
+- new runtime logic
+- broader framework changes
+- unrelated product expansion
+
+### Explicitly out of scope
+
+- inventing additional metrics without a clear decision need
+- reopening the completed implementation boundary
+- promoting local project residue into framework core
+
+### Relevant files
+
+- emitted event example
+- summary route output
+- decision or task brief that justified the signal
+
+### Acceptance criteria
+
+The reviewer should be able to explain:
+
+- what changed
+- why the new signal matters
+- what validation happened
+- whether any remaining follow-up belongs to product-local context or reusable framework learning
+
+### Validation expectation
+
+- review of the event shape
+- review of the summary output
+- clear next-step decision: close, local follow-up, or reusable learning
+
+### Main risks
+
+- local observability choices being mistaken for framework rules
+- review happening without enough evidence of the emitted signal
+
+---
+
+## What this example is teaching
+
+This example is mainly teaching three things:
+
+1. **one boundary at a time** is often safer than one oversized handoff
+2. **schema-level continuity is still compatible with richer operational fields** when the boundary needs them
+3. **multi-boundary work stays legible** when each restart package preserves its own scope, validation, and next action

--- a/starter-pack/guides/agent-handoff-generation.md
+++ b/starter-pack/guides/agent-handoff-generation.md
@@ -42,6 +42,42 @@ Not from:
 
 ---
 
+## Decide whether this is one boundary or a chain
+
+Before filling the artifact, ask:
+
+- is there one receiving boundary?
+- or will the work cross two or more meaningful frontiers in sequence?
+
+If the work crosses more than one strong boundary, prefer:
+
+- **one compact handoff per boundary**
+
+instead of:
+
+- **one oversized artifact trying to anticipate every later continuation**
+
+This keeps each restart package smaller, fresher, and easier to validate.
+
+---
+
+## Generate the minimum first
+
+Start by drafting the minimum restart package:
+
+- status
+- completed work
+- remaining work
+- next action
+- main risks
+- validation expectation
+
+Then decide whether you need the richer optional fields.
+
+Use the richer fields only when they materially reduce drift for the next boundary.
+
+---
+
 ## Recommended generation order
 
 ### 1. Start from the receiving agent
@@ -100,11 +136,13 @@ Examples:
 - preserve existing UI layout while refining copy
 - do not expand the task into a redesign
 
-### 6. Make acceptance explicit
+### 6. Make acceptance explicit when needed
 
 Define what must be true for the receiving agent to count the task as complete.
 
 Good acceptance criteria reduce semantic drift and scope inflation.
+
+Skip this section when the minimum restart package is already sufficient.
 
 ### 7. End with the next action
 
@@ -121,10 +159,11 @@ A strong agent handoff usually has:
 - a clear dominant frontier
 - a narrow execution boundary
 - stable context instead of full transcript history
-- semantic guardrails
-- explicit acceptance criteria
+- semantic guardrails when they matter
+- acceptance criteria when they materially reduce drift
 - explicit validation expectation
 - a concrete next action
+- a compact chain shape when work crosses more than one boundary
 
 ---
 
@@ -136,9 +175,10 @@ A weak agent handoff usually looks like:
 - broad instructions like "continue the work"
 - no allowed/forbidden file distinction
 - hidden assumptions about contracts or data
-- no acceptance criteria
+- no acceptance criteria when the next step clearly needs them
 - no validation expectation
 - provider-specific prompt tricks replacing real scope definition
+- one giant artifact standing in for several later boundaries
 
 ---
 
@@ -174,3 +214,4 @@ This guide tells you how to derive those fields from real work.
 - `docs/agent-handoffs.md`
 - `starter-pack/guides/handoff-guide.md`
 - `starter-pack/templates/agent-handoff-template.md`
+- `examples/handoffs/multi-boundary-continuity.md`

--- a/starter-pack/templates/agent-handoff-template.md
+++ b/starter-pack/templates/agent-handoff-template.md
@@ -12,6 +12,38 @@ Use the optional sections when they reduce ambiguity for the next boundary.
 
 ---
 
+## Minimum-first rule
+
+Start with the smallest useful continuity record.
+
+The minimum restart package is usually:
+
+- `Status`
+- `What was completed`
+- `What remains pending`
+- `Next action`
+- `Relevant files`
+- `Validation expectation`
+- `Main risks`
+
+Then add richer operational fields only when they materially reduce drift.
+
+Examples of richer fields include:
+
+- `Receiving agent role`
+- `Dominant frontier`
+- `Cross-boundary reason`
+- `Allowed files`
+- `Forbidden files`
+- `Explicitly out of scope`
+- `Semantic guardrails`
+- `Acceptance criteria`
+- `Expected response format`
+
+If the work will cross more than one strong boundary, prefer a chain of compact handoffs over one oversized artifact.
+
+---
+
 ## Handoff type
 
 Narrative or operational.
@@ -29,7 +61,7 @@ Explain why this work is moving to another agent instead of continuing in the cu
 
 ## Current status
 
-These fields map closely to the minimum structured continuity record.
+These fields map most closely to the minimum structured continuity record.
 
 ### Status
 


### PR DESCRIPTION
## Summary
- clarify the boundary between minimum schema-backed continuity and richer operational handoff practice
- add multi-boundary chain guidance across the Alpha 4 docs, guide, template, and capture pattern
- add a stronger example showing why multi-boundary work should use a chain of compact handoffs

## Validation
- bash scripts/check-governance.sh