### PR TITLE
Harden Alpha 5 inference discipline

### DIFF
--- a/docs/inference-pilot-scenarios.md
+++ b/docs/inference-pilot-scenarios.md
@@ -93,6 +93,23 @@ What to observe:
 - whether validation continuity improves
 - whether reasoning survives the handoff better than instruction alone
 
+### 5. Regression-aware maintenance round
+
+Use when a maintenance loop no longer looks trustworthy enough to continue on patch confidence alone.
+
+Good fit when:
+
+- a previously stable behavior regressed
+- a lane health read or alert suggests hidden degradation
+- the next round would otherwise continue on weak assumptions
+- the team needs to decide whether to widen the gate, stay blocked, or proceed with stronger proof
+
+What to observe:
+
+- whether the artifact clarifies why the current gate is too light or sufficient
+- whether the suggested tests target the real degradation surface
+- whether the round becomes easier to review and continue safely
+
 ---
 
 ## Scenarios to avoid first
@@ -117,7 +134,8 @@ For each pilot scenario, ask:
 2. Did it improve the validation plan?
 3. Did it reduce semantic ambiguity?
 4. Did it improve handoff clarity, if a handoff was involved?
-5. Was the extra overhead justified by the risk level?
+5. Did it improve gate selection or explain why the current gate was insufficient?
+6. Was the extra overhead justified by the risk level?
 
 ---
 
@@ -141,4 +159,5 @@ The goal is to find the first task shapes where the capability clearly earns its
 - `docs/structured-risk-inference.md`
 - `starter-pack/templates/inference-artifact-template.md`
 - `starter-pack/guides/inference-trigger-guidance.md`
+- `starter-pack/guides/risk-to-gate-mapping.md`
 - `examples/structured-risk-inference/README.md`

--- a/docs/structured-risk-inference.md
+++ b/docs/structured-risk-inference.md
@@ -1,16 +1,16 @@
-# Structured Risk Inference (Experimental)
+# Structured Risk Inference (Experimental Baseline)
 
 ## Status
 
-Proposed
+Experimental baseline established, still open for hardening before 1.0.
 
 ## Goal
 
-This document describes a possible future AletheIA capability for improving decision quality before execution.
+This document describes AletheIA's structured risk inference layer for cases where a decision needs more semantic scrutiny before execution.
 
 In simple terms:
 
-it adds a structured, evidence-oriented inference step for cases where the decision itself needs more semantic scrutiny before code or workflow execution proceeds.
+it adds a compact, evidence-oriented inference step for work where the decision itself needs to become more reviewable before code or workflow execution proceeds.
 
 ---
 
@@ -30,10 +30,11 @@ It is also growing stronger in:
 - adoption
 - inter-agent continuity
 - project extension boundaries
+- regression-aware iterative maintenance
 
-But one gap still remains in higher-risk work:
+But one gap still matters in higher-risk work:
 
-**how do we make the reasoning behind a decision more explicit before execution starts?**
+**how do we make the reasoning behind a decision more explicit before execution starts, especially when tests or confidence do not fully match the semantic risk?**
 
 Today, many AI-assisted systems can answer:
 
@@ -47,6 +48,7 @@ But they still struggle to answer in a structured, reviewable way:
 - what evidence supports the claim
 - which unknowns still remain
 - what tests would reduce the main risk
+- whether the current gate is too light for the downside involved
 
 ---
 
@@ -59,12 +61,14 @@ LLMs can propose changes and partially validate them, but several failure modes 
 - test suites may not cover the real risk surface
 - handoffs may preserve the instruction but lose the rationale
 - confidence may look stronger than the underlying evidence justifies
+- a maintenance round may appear successful while a silent degradation is already forming
 
 The result is often:
 
 - fragile confidence
 - reactive validation
 - hidden risk in apparently safe changes
+- gates that are too light for the actual uncertainty
 
 ---
 
@@ -77,6 +81,7 @@ This capability should **not** try to:
 - eliminate empirical validation
 - act as an oracle of truth
 - run on every small task by default
+- become a required ceremony for every maintenance round
 
 This is not formal verification.
 
@@ -86,7 +91,7 @@ It is a structured way of making risk-bearing inference more reviewable.
 
 ## Core concept
 
-The proposed capability is:
+The capability is:
 
 **structured risk inference**
 
@@ -134,11 +139,71 @@ Typical triggers include:
 - tests that appear insufficient for the semantic risk
 - low confidence from the executing agent
 - high-stakes inter-agent handoff
+- maintenance rounds where regression, health signals, or alerts suggest that the current validation plan may be too weak for the uncertainty involved
 
 For a more operational trigger guide, see:
 
 - `starter-pack/guides/inference-trigger-guidance.md`
 - `starter-pack/guides/inference-artifact-generation.md`
+- `starter-pack/guides/risk-to-gate-mapping.md`
+
+---
+
+## When inference earns its cost
+
+Inference is usually worth the extra step when it improves at least one of these:
+
+- the quality of the validation plan
+- the quality of the handoff rationale
+- the quality of the gate decision
+- the ability to explain why a regression risk is still unresolved
+
+If the artifact would only restate what the team already knows without changing proof depth, gate choice, or reviewability, it is probably unnecessary overhead.
+
+That is the most important Alpha 5 discipline.
+
+---
+
+## Relationship to risk-to-gate mapping
+
+Alpha 5 should not float separately from validation posture.
+
+A practical reading is:
+
+- **risk-to-gate** decides how much proof and what kind of gate the slice needs
+- **structured inference** helps when the team cannot justify that proof depth cleanly from the current evidence
+
+In other words, inference often becomes proportional when there is a mismatch such as:
+
+- medium-to-high downside with weak semantic proof
+- a likely regression surface with unclear test coverage
+- a high-stakes handoff where rationale must travel with the task
+- a maintenance lane where regression or alert signals suggest a hidden semantic issue
+
+This keeps Alpha 5 tied to governance rather than to abstract analysis.
+
+---
+
+## Relationship to iterative maintenance
+
+In iterative maintenance, inference should remain selective.
+
+It is usually most useful when:
+
+- a previously stable behavior regressed
+- the degradation is semantic rather than purely mechanical
+- health or alert signals suggest that a round is no longer as trustworthy as it looked
+- the next continuation would otherwise rely on confidence rather than reviewable rationale
+
+In those cases, the artifact can help answer:
+
+- what exactly are we assuming now?
+- what evidence do we actually have?
+- what test gap is still open?
+- should the round stay blocked, reviewed, or widened before continuing?
+
+This does **not** make observability or inference mandatory for every project.
+It simply makes Alpha 5 more concrete in important iterative loops.
 
 ---
 
@@ -147,7 +212,6 @@ For a more operational trigger guide, see:
 For a practical method for assembling this artifact from real work, see:
 
 - `starter-pack/guides/inference-artifact-generation.md`
-
 
 ```json
 {
@@ -191,7 +255,7 @@ For a practical method for assembling this artifact from real work, see:
 
 Alpha 4 improves inter-agent continuity.
 
-Alpha 5 would strengthen that continuity by making the rationale more portable.
+Alpha 5 strengthens that continuity by making the rationale more portable.
 
 Before:
 
@@ -199,7 +263,7 @@ Before:
 - instruction
 - scope
 
-After:
+After, when the trigger is justified:
 
 - context
 - instruction
@@ -225,7 +289,6 @@ For concrete example artifacts, see:
 
 - `examples/structured-risk-inference/README.md`
 
-
 ### 1. Patch review
 
 Compare likely before/after behavior without relying only on raw intuition.
@@ -242,6 +305,10 @@ Suggest tests based on risk concentration rather than coverage alone.
 
 Preserve semantic rationale across handoffs, not only execution instructions.
 
+### 5. Regression-aware maintenance rounds
+
+Surface why a round should stay blocked, widened, or selectively escalated when regression or health signals suggest that validation is underpowered.
+
 ---
 
 ## Risks
@@ -253,6 +320,7 @@ This capability also carries risks of its own:
 - overuse in simple tasks
 - artifacts that become verbose without adding clarity
 - confidence labels that appear more precise than they really are
+- using inference as a substitute for gate discipline instead of as support for it
 
 ---
 
@@ -262,8 +330,10 @@ To keep the capability proportional:
 
 - use explicit triggers
 - limit the depth of analysis
-- keep the prompt question bounded
+- keep the question bounded
 - always expose unknowns and assumptions
+- tie suggested tests back to the identified risk surface
+- connect the artifact to the actual gate decision
 - never treat the artifact as a substitute for empirical validation
 - avoid numeric confidence unless it is truly grounded
 
@@ -271,12 +341,13 @@ To keep the capability proportional:
 
 ## Success criteria
 
-Alpha 5 would be successful if it:
+Alpha 5 is getting stronger when it:
 
 - improves risk identification before execution
 - improves the quality of suggested tests in risky changes
-- reduces unexpected regressions in pilot scenarios
-- improves handoff clarity in high-stakes cases
+- reduces hidden ambiguity in high-stakes handoffs
+- helps explain why a gate should widen, stay blocked, or proceed
+- improves regression-aware reasoning in selective maintenance cases
 - is used selectively rather than becoming universal ceremony
 
 ---
@@ -286,25 +357,30 @@ Alpha 5 would be successful if it:
 - how should inference quality be evaluated?
 - how can verbosity stay bounded without losing value?
 - what trigger threshold is practical?
-- how should this connect to observability and post-execution signals?
+- how should this connect to observability and post-execution signals without making them universal requirements?
 - when should a risk inference become durable learning?
 
 ---
 
 ## Recommended starting position
 
-If this enters the roadmap, it should start as:
+Alpha 5 should remain:
 
 - experimental
 - selective
 - evidence-oriented
 - scoped primarily to code and semantic-risk tasks
+- connected to risk-to-gate and iterative-maintenance reading without becoming mandatory in either one
 
-It should not start as a mandatory core phase for every workflow.
+It should not become a mandatory core phase for every workflow.
 
 ---
 
 ## Suggested next reading
 
 - `starter-pack/templates/inference-artifact-template.md`
+- `starter-pack/guides/inference-trigger-guidance.md`
+- `starter-pack/guides/inference-artifact-generation.md`
+- `starter-pack/guides/risk-to-gate-mapping.md`
 - `docs/agent-handoffs.md`
+- `docs/iterative-maintenance-governance.md`

--- a/examples/structured-risk-inference/README.md
+++ b/examples/structured-risk-inference/README.md
@@ -51,6 +51,16 @@ This example shows:
 - contract stability called out as an invariant
 - validation priorities that should survive the handoff
 
+### 3. `regression-round-inference.json`
+
+A maintenance round where degradation signals suggest the current gate is too light.
+
+This example shows:
+
+- a lane-health premise entering the reasoning package
+- a test gap tied to silent regression risk
+- a next action that helps decide whether the round should stay blocked, widen, or continue
+
 ---
 
 ## What these examples are not
@@ -65,10 +75,24 @@ They are concrete examples for teaching what a healthy Alpha 5 artifact looks li
 
 ---
 
+## Reading rule
+
+A good Alpha 5 reading order is:
+
+1. understand the trigger
+2. inspect the premises and assumptions
+3. inspect the test gaps and suggested tests
+4. ask whether the artifact changed the gate, the handoff, or the validation plan enough to earn its cost
+
+If the answer is no, the artifact was probably unnecessary.
+
+---
+
 ## Suggested next reading
 
 - `docs/structured-risk-inference.md`
 - `starter-pack/templates/inference-artifact-template.md`
 - `starter-pack/guides/inference-trigger-guidance.md`
 - `starter-pack/guides/inference-artifact-generation.md`
+- `starter-pack/guides/risk-to-gate-mapping.md`
 - `docs/inference-pilot-scenarios.md`

--- a/examples/structured-risk-inference/regression-round-inference.json
+++ b/examples/structured-risk-inference/regression-round-inference.json
@@ -1,0 +1,45 @@
+{
+  "hypothesis": "The maintenance round should not continue on the current gate yet because the degraded explainability signal suggests a semantic regression risk that the existing proof does not adequately cover.",
+  "premises": [
+    "The lane summary shows explainability coverage has dropped below the team's healthy threshold.",
+    "A follow-up explainability gap event was emitted for a previously stable follow-up path.",
+    "Current proof only shows that the route still responds and the flow still completes, not that the explainability layer remains semantically coherent."
+  ],
+  "assumptions": [
+    "The degraded explainability signal reflects a real product-level loss of rationale rather than noise in the summary metric.",
+    "No other hidden contract changed between the last healthy round and the current degraded round."
+  ],
+  "impacted_paths": [
+    "decision output -> follow-up recommendation -> explainability summary -> lane health read"
+  ],
+  "invariants": [
+    "A previously stable follow-up path should continue to emit explainability data when the lane is healthy.",
+    "The route may remain functionally alive without being semantically healthy enough for a clean round closure."
+  ],
+  "risks": [
+    {
+      "description": "The round is treated as clean progress even though the explainability layer degraded in a way the current smoke does not catch.",
+      "likelihood": "medium",
+      "impact": "high"
+    },
+    {
+      "description": "The next maintenance round continues on weak assumptions and compounds the silent degradation.",
+      "likelihood": "medium",
+      "impact": "medium"
+    }
+  ],
+  "unknowns": [
+    "Whether the degraded coverage is caused by one path or a broader decision-layer mismatch.",
+    "Whether the current implementation still preserves the intended rationale for all emitted follow-ups."
+  ],
+  "test_gaps": [
+    "There is no targeted proof that the explainability payload remains present and coherent for the degraded path.",
+    "The current validation does not compare healthy-vs-degraded lane meaning before closing the round."
+  ],
+  "suggested_tests": [
+    "Add a targeted check that asserts explainability fields are still emitted for the affected follow-up path.",
+    "Review the degraded event together with the lane summary to confirm whether the gate should stay blocked or widen to review."
+  ],
+  "confidence_level": "medium",
+  "confidence_basis": "There is meaningful evidence of degradation from the lane summary and gap event, but the exact semantic cause is still under-demonstrated and targeted validation is missing."
+}

--- a/starter-pack/guides/inference-artifact-generation.md
+++ b/starter-pack/guides/inference-artifact-generation.md
@@ -44,6 +44,7 @@ The artifact should optimize for:
 - explicit assumptions
 - explicit unknowns
 - risk-focused validation guidance
+- clearer gate reasoning
 
 It should not try to replay every branch of analysis.
 
@@ -60,6 +61,7 @@ Typical cases include:
 - refactors with invisible regression risk
 - high-stakes patch review
 - high-stakes inter-agent handoff
+- regression-aware maintenance rounds where current proof looks too weak for the observed degradation
 
 If the task is still too small to justify the capability, do not force an artifact.
 
@@ -76,6 +78,7 @@ Examples:
 - what behavior is expected after this refactor?
 - what semantic regression is most likely here?
 - which business rule is at risk of being misapplied?
+- why is the current round no longer trustworthy enough to continue on confidence alone?
 
 The artifact should stay anchored to one dominant question, not many loose ones.
 
@@ -90,6 +93,7 @@ Good premises usually come from:
 - tests already present
 - contracts already defined
 - explicit product or governance rules
+- recent regression, health, or alert signals when the task is part of a maintenance loop
 
 Prefer fewer strong premises over many weak observations.
 
@@ -118,6 +122,7 @@ Good invariants are usually:
 - safety properties that must not regress
 - contract expectations that must remain stable
 - trust-boundary constraints that must continue to be enforced
+- lane meanings that should not degrade silently during iterative maintenance
 
 ### 6. Surface the main risks and unknowns
 
@@ -145,7 +150,19 @@ This is one of the main reasons the capability exists.
 The artifact should improve the validation plan,
 not only describe abstract risk.
 
-### 8. Assign confidence with a basis
+### 8. Connect the artifact to the gate
+
+Before finishing, make the gate implication visible.
+
+Examples:
+
+- current validation is sufficient after these suggested tests
+- the slice should stay in review until the main unknown is addressed
+- the round should remain blocked because the test gap is still too large
+
+If the artifact does not clarify the next gate or validation move, it is probably not strong enough yet.
+
+### 9. Assign confidence with a basis
 
 Use a qualitative confidence band such as:
 
@@ -173,6 +190,7 @@ The artifact is probably healthy when:
 - assumptions and unknowns are easy to spot
 - suggested tests are directly tied to the identified risk
 - a reviewer can challenge the reasoning without rereading the full work history
+- the gate implication is easier to explain after reading it
 
 ---
 
@@ -186,6 +204,7 @@ The artifact is probably weak when:
 - risks are generic and not tied to the change
 - suggested tests are not connected to the risk surface
 - confidence sounds stronger than the evidence justifies
+- it does not change the validation plan, handoff quality, or gate decision at all
 
 ---
 
@@ -210,4 +229,5 @@ without turning the restart package into a transcript dump.
 - `docs/structured-risk-inference.md`
 - `starter-pack/templates/inference-artifact-template.md`
 - `starter-pack/guides/inference-trigger-guidance.md`
+- `starter-pack/guides/risk-to-gate-mapping.md`
 - `docs/inference-pilot-scenarios.md`

--- a/starter-pack/guides/inference-trigger-guidance.md
+++ b/starter-pack/guides/inference-trigger-guidance.md
@@ -53,6 +53,16 @@ The agent can continue, but key assumptions still feel under-demonstrated.
 
 A downstream agent needs not only instructions, but also a portable rationale.
 
+### 8. Regression or health signal suggests hidden semantic risk
+
+A maintenance round appears shakier than the patch alone suggests.
+Examples:
+
+- a previously stable behavior regressed
+- a lane health signal degraded
+- an alert suggests explainability or continuity is eroding
+- the next round would otherwise continue on weak assumptions
+
 ---
 
 ## Weak trigger signals
@@ -64,6 +74,7 @@ Inference is usually not needed when:
 - existing tests already cover the meaningful risk surface
 - the work is mostly mechanical or formatting-oriented
 - the task does not introduce meaningful ambiguity or cross-boundary consequences
+- the artifact would not change the gate, the tests, or the rationale quality in practice
 
 ---
 
@@ -78,6 +89,10 @@ trigger inference when the cost of being semantically wrong is meaningfully high
 Another useful rule is:
 
 if the team would want a human reviewer to ask “what assumptions is this change relying on?”, the task is often a good inference candidate.
+
+And another practical rule is:
+
+if the artifact would not change proof depth, gate choice, or handoff quality, skip it.
 
 ---
 
@@ -97,6 +112,26 @@ Use the conditional loop:
 
 ---
 
+## Recommended pairings
+
+When inference is triggered, use it together with:
+
+- `starter-pack/templates/inference-artifact-template.md`
+- `docs/structured-risk-inference.md`
+- `starter-pack/guides/risk-to-gate-mapping.md`
+
+When a handoff is also involved, consider pairing it with:
+
+- `docs/agent-handoffs.md`
+- `starter-pack/templates/agent-handoff-template.md`
+
+When the trigger comes from an iterative round becoming less trustworthy, consider pairing it with:
+
+- `docs/iterative-maintenance-governance.md`
+- `starter-pack/guides/round-based-maintenance.md`
+
+---
+
 ## What to avoid
 
 Do not trigger inference just because:
@@ -110,20 +145,6 @@ This capability loses value quickly if it becomes universal ceremony.
 
 ---
 
-## Recommended pairings
-
-When inference is triggered, use it together with:
-
-- `starter-pack/templates/inference-artifact-template.md`
-- `docs/structured-risk-inference.md`
-
-When a handoff is also involved, consider pairing it with:
-
-- `docs/agent-handoffs.md`
-- `starter-pack/templates/agent-handoff-template.md`
-
----
-
 ## Good signs
 
 Trigger discipline is healthy when:
@@ -132,6 +153,7 @@ Trigger discipline is healthy when:
 - triggered artifacts actually change validation quality
 - unnecessary inference is rare
 - teams can explain why the artifact was needed
+- the artifact has a visible effect on proof depth, gate choice, or reasoning portability
 
 ---
 
@@ -139,4 +161,6 @@ Trigger discipline is healthy when:
 
 - `docs/structured-risk-inference.md`
 - `starter-pack/templates/inference-artifact-template.md`
+- `starter-pack/guides/inference-artifact-generation.md`
+- `starter-pack/guides/risk-to-gate-mapping.md`
 - `docs/agent-handoffs.md`


### PR DESCRIPTION
## Summary
- reframe Alpha 5 as an experimental baseline tied to risk-to-gate and iterative maintenance without making it universal
- clarify when structured inference actually earns its cost by changing the gate, tests, or rationale quality
- add a regression-round example showing how hidden degradation can justify selective inference

## Validation
- bash scripts/check-governance.sh