### PR TITLE
Make Alpha 6 distribution more tangible

### DIFF
--- a/docs/adapter-taxonomy.md
+++ b/docs/adapter-taxonomy.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-This document defines a first future-facing taxonomy for AletheIA adapters.
+This document defines a first concrete taxonomy for AletheIA adapters.
 
 In simple terms:
 
@@ -188,6 +188,22 @@ This family should remain future-facing until Alpha 7 is active.
 
 ---
 
+## A tangible mapping example
+
+See:
+
+- `examples/distribution/constrained-adoption-mapping.md`
+
+That example shows how the same project can keep:
+
+- repo-native docs as the canonical surface
+- an agent-instruction surface as a compressed operational surface
+- project extension as the place where local constraints live
+
+without changing the meaning of the framework itself.
+
+---
+
 ## What an adapter should not do
 
 An adapter should not:
@@ -232,6 +248,6 @@ The adapter taxonomy is healthy when:
 
 - `docs/distribution-presets-adapters.md`
 - `docs/preset-taxonomy.md`
-- `docs/agent-handoffs.md`
-- `docs/structured-risk-inference.md`
+- `docs/adoption-mode-guidance.md`
+- `examples/distribution/constrained-adoption-mapping.md`
 - `docs/roadmap-alpha.md`

--- a/docs/adoption-mode-guidance.md
+++ b/docs/adoption-mode-guidance.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-This document defines a first future-facing guide for AletheIA adoption modes.
+This document defines a first concrete guide for AletheIA adoption modes.
 
 In simple terms:
 
@@ -158,6 +158,23 @@ Good selection signals include:
 
 ---
 
+## Selection sequence in practice
+
+A practical Alpha 6 read is:
+
+1. choose the **preset**
+2. choose the **adapter**
+3. choose the **adoption mode**
+4. freeze the **project extension boundary**
+
+See:
+
+- `examples/distribution/constrained-adoption-mapping.md`
+
+This keeps adoption mode from floating as a purely abstract label.
+
+---
+
 ## What adoption modes should not do
 
 Adoption modes should not:
@@ -208,5 +225,6 @@ The adoption mode model is healthy when:
 - `docs/distribution-presets-adapters.md`
 - `docs/preset-taxonomy.md`
 - `docs/adapter-taxonomy.md`
-- `docs/apply-to-existing-project.md`
+- `docs/project-extension-pattern.md`
+- `examples/distribution/constrained-adoption-mapping.md`
 - `docs/roadmap-alpha.md`

--- a/docs/delivery-mapping-examples.md
+++ b/docs/delivery-mapping-examples.md
@@ -2,12 +2,12 @@
 
 ## Goal
 
-This document provides first future-facing examples of how the same AletheIA meaning can be mapped across different delivery surfaces.
+This document provides first concrete examples of how the same AletheIA meaning can be mapped across different delivery surfaces.
 
 In simple terms:
 
 if Alpha 6 is about distribution without core distortion,
-it should show a few concrete examples of how one framework concept can appear in more than one surface without changing its meaning.
+it should show a few practical examples of how one framework concept can appear in more than one surface without changing its meaning.
 
 ---
 
@@ -180,6 +180,23 @@ A fuller operating surface might say:
 
 ---
 
+## Example 6 — Constrained local distribution
+
+See:
+
+- `examples/distribution/constrained-adoption-mapping.md`
+
+That example shows a tangible Alpha 6 combination:
+
+- **preset**: existing project adoption
+- **adapters**: repo-native + agent instruction
+- **adoption mode**: standard
+- **project extension**: local constraints kept outside framework core
+
+This helps make Alpha 6 easier to explain as plugable through local extension without claiming enterprise-readiness.
+
+---
+
 ## What these examples should not become
 
 These examples should not become:
@@ -211,4 +228,5 @@ The delivery mapping model is healthy when:
 - `docs/preset-taxonomy.md`
 - `docs/adapter-taxonomy.md`
 - `docs/adoption-mode-guidance.md`
+- `examples/distribution/constrained-adoption-mapping.md`
 - `docs/roadmap-alpha.md`

--- a/docs/distribution-presets-adapters.md
+++ b/docs/distribution-presets-adapters.md
@@ -2,12 +2,26 @@
 
 ## Goal
 
-This document explains the future Alpha 6 direction for AletheIA.
+This document explains the Alpha 6 direction for AletheIA.
 
 In simple terms:
 
 keep the framework core stable,
 but make it easier to package, deliver, and reuse across different project shapes and agent environments.
+
+---
+
+## Current status
+
+Alpha 6 now has a **baseline established, still open** posture.
+
+That means:
+
+- the conceptual model already exists
+- the packaging and delivery vocabulary is now public
+- the current gap is **tangibility**, not only theory
+
+Alpha 6 should therefore be read as a concrete distribution baseline that still needs stronger examples before it can be considered done enough for 1.0.
 
 ---
 
@@ -20,8 +34,8 @@ It already has:
 - a governance baseline
 - real pilot learnings
 - an adoption baseline
-- a model-agnostic handoff baseline
-- a future direction for structured risk inference
+- a handoff baseline
+- an experimental inference baseline
 
 The next gap is not primarily conceptual.
 
@@ -34,27 +48,6 @@ Today, AletheIA is easier to understand than to package consistently across:
 - lighter vs fuller adoption footprints
 
 Alpha 6 exists to improve that distribution layer without redefining the framework core.
-
----
-
-## Useful reference, limited influence
-
-Tools such as `maestro-bundle-cli` are useful references for this phase because they show a practical packaging mindset:
-
-- bundle a baseline
-- adapt it to different editors
-- offer lighter or fuller installation paths
-
-That is useful inspiration.
-
-But the lesson for AletheIA is specifically about:
-
-- packaging
-- delivery
-- presets
-- adapters
-
-It is not about replacing AletheIA's core operating model with a CLI-first or tool-specific worldview.
 
 ---
 
@@ -78,14 +71,15 @@ AletheIA should stay recognizable even if teams adopt it through different prese
 
 ### 1. Presets / Bundles
 
-AletheIA should eventually support curated packages for common project shapes.
+AletheIA should support curated packages for common project shapes.
 
 Examples:
 
-- web application preset
-- AI product preset
-- regulated-domain preset
-- lightweight starter preset
+- core starter preset
+- existing project adoption preset
+- multi-agent continuity preset
+- risk-aware delivery preset
+- security-sensitive preset
 
 The goal is not to create many bundles quickly.
 
@@ -93,10 +87,11 @@ The goal is to define a reusable preset model that can package the same core in 
 
 ### 2. Adapters
 
-AletheIA should eventually support delivery adapters for different editor and agent environments.
+AletheIA should support delivery adapters for different editor and agent environments.
 
 Examples:
 
+- repo-native delivery
 - AGENTS-style delivery
 - Claude-style delivery
 - Codex-oriented delivery
@@ -108,11 +103,12 @@ The goal is to preserve the same framework meaning across environments.
 
 ### 3. Adoption modes
 
-AletheIA should eventually support more than one installation footprint.
+AletheIA should support more than one installation footprint.
 
 Examples:
 
-- lightweight mode
+- lite mode
+- standard mode
 - fuller operating mode
 
 This helps teams adopt the framework with the right amount of structure for their context, instead of forcing one universal level of ceremony.
@@ -127,7 +123,8 @@ Alpha 6 is not about:
 - making one editor the canonical interface
 - introducing mandatory external integrations
 - promising a one-command bootstrap experience yet
-- replacing the roadmap Alpha 1 through Alpha 5 concepts with packaging concerns
+- replacing the Alpha 1 through Alpha 5 concepts with packaging concerns
+- claiming enterprise-readiness before the baseline is ready for that discussion
 
 This phase should stay clearly in the delivery layer.
 
@@ -135,13 +132,14 @@ This phase should stay clearly in the delivery layer.
 
 ## Current baseline artifacts
 
-The first concrete Alpha 6 baseline now includes:
+The current concrete Alpha 6 baseline includes:
 
 - `docs/distribution-presets-adapters.md`
 - `docs/preset-taxonomy.md`
 - `docs/adapter-taxonomy.md`
 - `docs/adoption-mode-guidance.md`
 - `docs/delivery-mapping-examples.md`
+- `examples/distribution/constrained-adoption-mapping.md`
 
 Together, these artifacts now define Alpha 6 as a model for:
 
@@ -149,9 +147,44 @@ Together, these artifacts now define Alpha 6 as a model for:
 - delivery surface
 - adoption depth
 - cross-surface meaning preservation
+- one more tangible example of local distribution choice in a constrained context
 
 before any heavier tooling is introduced.
 
+---
+
+## A practical Alpha 6 selection recipe
+
+When applying Alpha 6 to a real project, the smallest useful selection sequence is:
+
+1. choose the **preset**
+   - what kind of project or operating problem is this?
+2. choose the **adapter**
+   - in what surface should the framework be delivered first?
+3. choose the **adoption mode**
+   - how much operating depth is justified now?
+4. define the **project extension boundary**
+   - what remains framework-stable versus local?
+
+This is the smallest tangible move that turns Alpha 6 from vocabulary into packaging discipline.
+
+---
+
+## Relationship to project extension
+
+Alpha 6 becomes safer when it stays paired with project extension discipline.
+
+Why:
+
+- presets should not absorb local business rules
+- adapters should not absorb local trust posture
+- adoption modes should not redefine the framework core
+- local restrictions, model limits, approvals, and tool boundaries should still land in the project extension layer
+
+That is why Alpha 6 should be read together with:
+
+- `docs/project-extension-pattern.md`
+- `examples/distribution/constrained-adoption-mapping.md`
 
 ---
 
@@ -159,7 +192,7 @@ before any heavier tooling is introduced.
 
 Alpha 6 defines the model.
 
-Alpha 7 now begins to operationalize it through future-facing tooling contracts, but still without implementation.
+Alpha 7 may later operationalize it through future-facing tooling contracts, but still without implementation.
 
 That means Alpha 6 should answer questions such as:
 
@@ -167,21 +200,13 @@ That means Alpha 6 should answer questions such as:
 - what is an adapter?
 - what should vary by environment?
 - what must remain framework-stable?
-- what does lightweight vs fuller adoption mean?
+- what does lite vs standard vs fuller adoption mean?
 
 Only after those answers are stable should AletheIA seriously consider:
 
 - bootstrap tooling
 - installation automation
 - delivery CLI flows
-
-The current Alpha 7 baseline now starts that work through:
-
-- `docs/bootstrap-principles.md`
-- `docs/delivery-tooling-boundaries.md`
-- `docs/bootstrap-output-examples.md`
-- `docs/bootstrap-generator-contract.md`
-- `docs/delivery-output-contract.md`
 
 That later work still belongs to Alpha 7, not to Alpha 6.
 
@@ -192,8 +217,9 @@ That later work still belongs to Alpha 7, not to Alpha 6.
 Alpha 6 is going well when:
 
 - the framework becomes easier to package without becoming tool-dependent
-- teams can imagine different delivery forms without confusing them with framework truth
+- teams can describe different delivery forms without confusing them with framework truth
 - presets and adapters feel like delivery choices, not conceptual forks
+- plugability is easier to explain through concrete examples
 - AletheIA remains provider-agnostic and core-stable
 
 ---
@@ -206,6 +232,7 @@ The main risks are:
 - overpromising CLI or automation too early
 - importing tool-specific assumptions into the framework model
 - treating external integrations as mandatory before the distribution model is stable
+- using one constrained example as if it proved broad regulated readiness already
 
 ---
 
@@ -217,12 +244,15 @@ Alpha 6 should mitigate those risks by:
 - treating external integrations as out of scope for now
 - defining presets and adapters conceptually before automating them
 - keeping Alpha 7 as a later tooling phase rather than collapsing both phases together
+- showing concrete mappings without overstating readiness
 
 ---
 
 ## Suggested next reading
 
-- `docs/roadmap-alpha.md`
+- `docs/preset-taxonomy.md`
+- `docs/adapter-taxonomy.md`
+- `docs/adoption-mode-guidance.md`
+- `docs/delivery-mapping-examples.md`
 - `docs/project-extension-pattern.md`
-- `docs/agent-handoffs.md`
-- `docs/structured-risk-inference.md`
+- `examples/distribution/constrained-adoption-mapping.md`

--- a/docs/preset-taxonomy.md
+++ b/docs/preset-taxonomy.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-This document defines a first future-facing taxonomy for AletheIA presets.
+This document defines a first concrete taxonomy for AletheIA presets.
 
 In simple terms:
 
@@ -13,7 +13,7 @@ it needs a clearer idea of what kinds of preset should exist before any heavier 
 
 ## Why this matters
 
-AletheIA is already gaining a stronger core, better adoption materials, a handoff baseline, and an experimental inference baseline.
+AletheIA already has a stronger core, better adoption materials, a handoff baseline, and an experimental inference baseline.
 
 The next distribution question is not only:
 
@@ -60,7 +60,7 @@ Examples:
 
 - web application
 - AI product
-- regulated workflow
+- constrained workflow
 - lightweight internal tool
 
 ### 2. Operating depth
@@ -177,6 +177,22 @@ This preset should remain careful not to imply that those future packs are alrea
 
 ---
 
+## A tangible selection example
+
+See:
+
+- `examples/distribution/constrained-adoption-mapping.md`
+
+That example shows how a project can choose:
+
+- an **existing project adoption** preset
+- a **repo-native + agent-instruction** adapter combination
+- a **standard** adoption mode
+
+without treating those choices as a fork of the framework.
+
+---
+
 ## What a preset should not do
 
 A preset should not:
@@ -220,6 +236,7 @@ The preset taxonomy is healthy when:
 ## Suggested next reading
 
 - `docs/distribution-presets-adapters.md`
-- `docs/domain-governance-packs.md`
+- `docs/adoption-mode-guidance.md`
 - `docs/project-extension-pattern.md`
+- `examples/distribution/constrained-adoption-mapping.md`
 - `docs/roadmap-alpha.md`

--- a/examples/distribution/constrained-adoption-mapping.md
+++ b/examples/distribution/constrained-adoption-mapping.md
@@ -1,0 +1,161 @@
+# Constrained Adoption Mapping
+
+This example makes Alpha 6 more tangible through one bounded scenario.
+
+The scenario is intentionally generic:
+
+- the team is adopting AletheIA inside an existing project
+- there is more than one working surface
+- there are local restrictions on tools, approvals, and model usage
+- the framework must remain stable while the project keeps its own local rules
+
+This is **not** an enterprise-ready pack.
+It is a concrete Alpha 6 example of packaging and delivery choice.
+
+---
+
+## 1. Selected preset
+
+### Preset
+
+**Existing Project Adoption preset**
+
+### Why
+
+The project already exists.
+The immediate need is not to bootstrap from zero.
+The immediate need is to:
+
+- introduce the operating layer incrementally
+- define the extension boundary clearly
+- avoid turning local restrictions into framework truth
+
+### What this preset emphasizes
+
+- `docs/apply-to-existing-project.md`
+- `docs/project-extension-pattern.md`
+- `starter-pack/README.md`
+- starter-pack templates for bounded work
+
+---
+
+## 2. Selected adapters
+
+### Canonical adapter
+
+**Repo-native adapter**
+
+The repository docs remain the canonical meaning source.
+
+### Operational adapter
+
+**Agent instruction adapter**
+
+A compressed operational surface may exist for agents working inside the project, but it must point back to the canonical docs for:
+
+- framework meaning
+- boundaries
+- validation expectations
+- handoff discipline
+
+### Why this combination works
+
+- the repo-native layer keeps the framework inspectable
+- the agent-oriented layer improves day-to-day operability
+- the compressed layer does not become a hidden fork because the canonical docs stay primary
+
+---
+
+## 3. Selected adoption mode
+
+### Mode
+
+**Standard mode**
+
+### Why
+
+The project is beyond a toy pilot, but it does not need every optional layer activated at once.
+
+Standard mode is enough to justify:
+
+- governance baseline
+- project extension discipline
+- reusable handoffs where more than one agent is involved
+- bounded validation discipline
+
+Standard mode still postpones:
+
+- broad mandatory inference usage
+- heavier delivery tooling
+- any claim that the framework is already packaged for highly regulated rollout
+
+---
+
+## 4. Project extension boundary
+
+### What stays framework-stable
+
+- operating loop
+- governance baseline
+- token policy
+- project-extension discipline
+- handoff structure
+- selective risk inference posture
+
+### What becomes project extension
+
+- allowed vs restricted model fleet
+- approval rules specific to the project
+- local tool allowlists
+- storage location for operational artifacts
+- local trust-boundary language
+- local review and escalation cadence
+
+### Why this matters
+
+This is the main Alpha 6 plugability rule:
+
+**distribution choices can be concrete without moving local restrictions into the framework core.**
+
+---
+
+## 5. Practical delivery read
+
+A practical read of this example is:
+
+1. the team reads the repo-native AletheIA docs as the canonical baseline
+2. the project creates a local extension doc for its restrictions and approvals
+3. an agent-instruction surface compresses the relevant operating rules for day-to-day work
+4. handoffs and risk artifacts remain optional but available when the local context justifies them
+
+This is enough to show packaging shape without requiring CLI tooling.
+
+---
+
+## 6. Why this helps Alpha 6
+
+This example makes three things more tangible:
+
+1. **preset choice** is about project shape, not ideology
+2. **adapter choice** is about delivery surface, not framework truth
+3. **adoption mode** is about operating depth, not framework versioning
+
+And it reinforces one important boundary:
+
+- local constraints belong in the project extension layer
+- they do not redefine the public framework core
+
+---
+
+## 7. Why this is not an enterprise-readiness claim
+
+This example is deliberately smaller than a true regulated-adoption package.
+
+It does **not** claim:
+
+- enterprise-ready rollout
+- regulated-domain completeness
+- finished trust-boundary starter packs
+- packaged support for complex corporate SDLCs
+
+It only proves that Alpha 6 can become more tangible without overclaiming readiness.


### PR DESCRIPTION
## Summary
- reframe Alpha 6 as a concrete baseline that is still open for tangibility rather than a purely future-facing theory layer
- add a practical preset-adapter-adoption-mode selection recipe and strengthen the docs around plugability through project extension
- add a constrained adoption mapping example that makes Alpha 6 easier to explain without overclaiming enterprise-readiness

## Validation
- bash scripts/check-governance.sh