### PR TITLE
Clarify Alpha 7 tooling boundaries

### DIFF
--- a/docs/bootstrap-generator-contract.md
+++ b/docs/bootstrap-generator-contract.md
@@ -11,6 +11,21 @@ it helps to define the contract of that generation before promising any implemen
 
 ---
 
+## Current status
+
+This is a **doc-level future contract**.
+
+It is:
+
+- illustrative
+- bounded
+- non-schema
+- not an active implementation requirement for 1.0
+
+The value of this contract today is boundary clarity.
+
+---
+
 ## Why this matters
 
 Bootstrap principles define posture.
@@ -216,6 +231,7 @@ A first Alpha 7 generator contract is healthy when:
 - it remains subordinate to Alpha 6 meaning
 - it does not assume one canonical environment
 - it still works as a contract without any implementation yet
+- it does not imply that implementation is required before 1.0
 
 ---
 
@@ -225,8 +241,5 @@ A first Alpha 7 generator contract is healthy when:
 - `docs/delivery-tooling-boundaries.md`
 - `docs/bootstrap-output-examples.md`
 - `docs/delivery-output-contract.md`
+- `examples/delivery/reviewable-generated-bundle.md`
 - `docs/distribution-presets-adapters.md`
-- `docs/preset-taxonomy.md`
-- `docs/adapter-taxonomy.md`
-- `docs/adoption-mode-guidance.md`
-- `docs/delivery-mapping-examples.md`

--- a/docs/bootstrap-output-examples.md
+++ b/docs/bootstrap-output-examples.md
@@ -2,12 +2,25 @@
 
 ## Goal
 
-This document provides first future-facing examples of what safe Alpha 7 bootstrap outputs could look like.
+This document provides first examples of what safe Alpha 7 bootstrap outputs could look like.
 
 In simple terms:
 
 if AletheIA eventually generates setup outputs,
 it helps to show a few examples of the output shape before any heavier tooling exists.
+
+---
+
+## Current status
+
+These examples are:
+
+- illustrative
+- future-facing
+- non-binding
+- not required for 1.0
+
+Their role is to clarify healthy output posture, not to announce active generator behavior.
 
 ---
 
@@ -167,6 +180,23 @@ A bootstrap helper might emit:
 
 ---
 
+## A reviewable sample package
+
+See:
+
+- `examples/delivery/reviewable-generated-bundle.md`
+
+That example is useful because it shows the intended **output posture** directly:
+
+- visible source choices
+- visible canonical references
+- visible boundary notes
+- explicit review status
+
+This helps clarify Alpha 7 without requiring any actual generator implementation.
+
+---
+
 ## What these outputs should not become
 
 These examples should not become:
@@ -197,9 +227,5 @@ Alpha 7 output examples are healthy when:
 - `docs/delivery-tooling-boundaries.md`
 - `docs/bootstrap-generator-contract.md`
 - `docs/delivery-output-contract.md`
+- `examples/delivery/reviewable-generated-bundle.md`
 - `docs/roadmap-alpha.md`
-- `docs/distribution-presets-adapters.md`
-- `docs/preset-taxonomy.md`
-- `docs/adapter-taxonomy.md`
-- `docs/adoption-mode-guidance.md`
-- `docs/delivery-mapping-examples.md`

--- a/docs/bootstrap-principles.md
+++ b/docs/bootstrap-principles.md
@@ -2,12 +2,28 @@
 
 ## Goal
 
-This document defines a first future-facing set of principles for Alpha 7 bootstrap and delivery tooling.
+This document defines the Alpha 7 bootstrap posture.
 
 In simple terms:
 
-if Alpha 7 is going to introduce tooling,
+if Alpha 7 is going to introduce tooling later,
 it should first make explicit what that tooling must preserve and what it must never distort.
+
+---
+
+## Current status
+
+Alpha 7 is currently:
+
+- **defined**
+- **optional**
+- **future-facing**
+- **not required for 1.0**
+
+That means these docs exist to remove ambiguity, not to announce active tooling work.
+
+AletheIA does **not** need a real bootstrap tool before 1.0.
+It needs a clear enough tooling boundary that later implementation cannot quietly distort the framework.
 
 ---
 
@@ -137,6 +153,7 @@ Bootstrap tooling should not:
 - collapse docs, presets, adapters, and packs into one opaque artifact
 - produce outputs that are hard to inspect or revise
 - promise complete automation before the model is stable enough to justify it
+- be treated as a blocker for the 1.0 release
 
 ---
 
@@ -158,22 +175,22 @@ If tooling starts inventing meaning beyond those artifacts, it is no longer acti
 
 ## Good signs
 
-Alpha 7 is starting well when:
+Alpha 7 is clarified enough for 1.0 when:
 
 - tooling principles are clearer than tooling ambition
 - inspectability stays more important than cleverness
 - optionality stays explicit
 - generated outputs remain legible and reviewable
 - the framework still makes sense even without the tooling
+- the docs no longer imply that active tooling implementation is required before 1.0
 
 ---
 
 ## Suggested next reading
 
+- `docs/delivery-tooling-boundaries.md`
+- `docs/bootstrap-output-examples.md`
 - `docs/bootstrap-generator-contract.md`
+- `docs/delivery-output-contract.md`
+- `examples/delivery/reviewable-generated-bundle.md`
 - `docs/roadmap-alpha.md`
-- `docs/distribution-presets-adapters.md`
-- `docs/preset-taxonomy.md`
-- `docs/adapter-taxonomy.md`
-- `docs/adoption-mode-guidance.md`
-- `docs/delivery-mapping-examples.md`

--- a/docs/delivery-output-contract.md
+++ b/docs/delivery-output-contract.md
@@ -11,6 +11,14 @@ this document defines what that emitted package should make visible before a tea
 
 ---
 
+## Current status
+
+This is a **doc-level output contract**, not an active implementation schema.
+
+Its role today is to make Alpha 7 bounded enough for 1.0 by clarifying what a healthy emitted package would need to reveal.
+
+---
+
 ## Why this matters
 
 The bootstrap generator contract explains what a future generator may receive and emit.
@@ -156,6 +164,10 @@ A healthy delivery output should carry a visible review posture such as:
 
 This keeps adoption explicit instead of implied.
 
+See:
+
+- `examples/delivery/reviewable-generated-bundle.md`
+
 ---
 
 ## What this contract should not include yet
@@ -200,6 +212,7 @@ A first Alpha 7 delivery output contract is healthy when:
 - authority boundaries remain visible
 - review posture is explicit
 - the contract still makes sense without any implementation yet
+- the docs no longer imply that a real output generator must exist before 1.0
 
 ---
 
@@ -209,8 +222,5 @@ A first Alpha 7 delivery output contract is healthy when:
 - `docs/delivery-tooling-boundaries.md`
 - `docs/bootstrap-output-examples.md`
 - `docs/bootstrap-generator-contract.md`
+- `examples/delivery/reviewable-generated-bundle.md`
 - `docs/distribution-presets-adapters.md`
-- `docs/preset-taxonomy.md`
-- `docs/adapter-taxonomy.md`
-- `docs/adoption-mode-guidance.md`
-- `docs/delivery-mapping-examples.md`

--- a/docs/delivery-tooling-boundaries.md
+++ b/docs/delivery-tooling-boundaries.md
@@ -2,12 +2,26 @@
 
 ## Goal
 
-This document defines a first future-facing boundary model for Alpha 7 delivery tooling.
+This document defines the Alpha 7 delivery tooling boundary model.
 
 In simple terms:
 
 if AletheIA eventually gains bootstrap or delivery tooling,
 it needs a clearer idea of what that tooling may do, what it must not do, and where it should stop.
+
+---
+
+## Current status
+
+Alpha 7 is currently a **boundary-definition layer**, not an implementation lane.
+
+That means this document exists to clarify:
+
+- what tooling may do later
+- what tooling must not do later
+- why 1.0 does not depend on tooling implementation now
+
+This keeps Alpha 7 bounded enough for the baseline.
 
 ---
 
@@ -124,6 +138,10 @@ Tooling must not automate concepts that Alpha 6 has not clarified yet.
 
 If the only way to trust the output is to trust the tool blindly, the boundary has already been crossed.
 
+### 7. Become a hidden 1.0 dependency
+
+If the roadmap starts implying that tooling must exist before 1.0, the boundary has drifted.
+
 ---
 
 ## What should remain outside delivery tooling
@@ -165,17 +183,15 @@ Alpha 7 tooling boundaries are healthy when:
 - the canonical docs remain authoritative
 - teams can understand what was emitted and why
 - stopping points are explicit instead of implied
+- the framework remains fully teachable without active tooling
 
 ---
 
 ## Suggested next reading
 
 - `docs/bootstrap-principles.md`
+- `docs/bootstrap-output-examples.md`
 - `docs/bootstrap-generator-contract.md`
 - `docs/delivery-output-contract.md`
+- `examples/delivery/reviewable-generated-bundle.md`
 - `docs/roadmap-alpha.md`
-- `docs/distribution-presets-adapters.md`
-- `docs/preset-taxonomy.md`
-- `docs/adapter-taxonomy.md`
-- `docs/adoption-mode-guidance.md`
-- `docs/delivery-mapping-examples.md`

--- a/examples/delivery/reviewable-generated-bundle.md
+++ b/examples/delivery/reviewable-generated-bundle.md
@@ -1,0 +1,91 @@
+# Reviewable Generated Bundle
+
+This example shows the kind of Alpha 7 output posture the framework is describing.
+
+It is **illustrative only**.
+It is **not** the output of a real generator.
+It is **not** required for 1.0.
+
+The goal is simply to make the boundary clearer:
+
+if Alpha 7 ever emits a bundle, the bundle should still be inspectable, traceable, and obviously subordinate to the canonical docs.
+
+---
+
+## Output identity
+
+- **output_name**: `existing-project-standard-bundle`
+- **output_purpose**: `Provide a compact onboarding package for standard-mode adoption in an existing project`
+- **delivery_surface**: `repo-native plus instruction companion`
+
+---
+
+## Source choices
+
+- **preset**: `Existing Project Adoption`
+- **adoption_mode**: `Standard`
+- **delivery_surface**: `repo-native + agent instruction`
+
+These choices should remain visible in the output so the package never looks like an unexplained black box.
+
+---
+
+## Canonical references
+
+This sample bundle would still point back to:
+
+- `docs/distribution-presets-adapters.md`
+- `docs/adoption-mode-guidance.md`
+- `docs/project-extension-pattern.md`
+- `docs/agent-handoffs.md`
+
+These remain authoritative.
+The generated bundle is only a packaged derivative.
+
+---
+
+## Generated contents
+
+A small package like this might contain:
+
+- a short reading order
+- a starter-pack subset for bounded work
+- a note about when to use operational handoffs
+- a reminder that project-local restrictions belong in the extension layer
+
+That is enough to be useful without pretending to replace the canonical repo.
+
+---
+
+## Boundary notes
+
+A healthy generated bundle should say what it does **not** do.
+
+Example boundary notes:
+
+- does not replace the canonical repo-native docs
+- does not infer project-local rules automatically
+- does not activate future domain governance packs by default
+- does not imply that Alpha 7 tooling is required for understanding AletheIA
+
+---
+
+## Review posture
+
+A healthy output should make review posture explicit.
+
+For this sample bundle:
+
+- **review_status**: `illustrative only`
+- **review_notes**: `This package shape is an example of a safe Alpha 7 output posture. It should not be treated as an active generated artifact or as a requirement for the 1.0 baseline.`
+
+---
+
+## Why this example matters
+
+This example mainly clarifies four things:
+
+1. Alpha 7 output should still be readable without a generator
+2. source choices should remain visible
+3. canonical docs should remain authoritative
+4. the 1.0 baseline does not depend on active tooling implementation


### PR DESCRIPTION
## Summary
- make Alpha 7 consistently read as optional, future-facing, and non-blocking for the 1.0 baseline
- align bootstrap/output/generator docs around boundary clarity instead of implied implementation work
- add an illustrative reviewable-generated-bundle example to clarify output posture without introducing real tooling

## Validation
- bash scripts/check-governance.sh