### PR TITLE
Finalize AletheIA 1.0 baseline release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## 1.0.0 — 2026-04-09
+
+First public stable baseline of AletheIA.
+
+### Included baseline
+
+- Alpha 1 governance, token policy, durable decisions, enforcement boundaries, quality, and learnings baseline
+- Alpha 2 pilot, self-application, and project-extension baseline
+- Alpha 3 adoption and starter-pack baseline
+- Alpha 4 handoff and multi-boundary continuity baseline
+- Alpha 5 selective structured risk inference baseline
+- Alpha 6 distribution, presets, adapters, and adoption-mode baseline
+- Alpha 7 optional future-facing tooling-boundary baseline
+- operational-composition layer across work slices, risk-to-gate mapping, iterative maintenance, and model-strategy guidance
+
+### Notes
+
+- 1.0.0 marks the baseline as public and versioned
+- this release does **not** claim enterprise-readiness, completed domain governance packs, or active delivery tooling implementation
+- post-baseline work now continues through 1.1, 1.2, 1.3, and later roadmap tracks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for contributing to AletheIA.
 
-AletheIA is in a **late Alpha completion cycle before 1.0**, so the most valuable contributions right now are the ones that improve clarity, reviewability, reuse, and practical adoption **without opening new strategic tracks before the open Alpha work is sufficiently closed**.
+AletheIA is now in its **1.0 baseline phase**, so the most valuable contributions are the ones that improve clarity, reviewability, reuse, and practical adoption **without distorting the boundaries that made the baseline coherent enough for 1.0**.
 
 ---
 
@@ -18,7 +18,7 @@ Please prioritize contributions that improve:
 - quality baseline
 - starter-pack reuse
 - adoption without premature complexity
-- coherence of the open Alpha completion work
+- coherent post-1.0 evolution
 
 ---
 
@@ -31,13 +31,10 @@ Strong contribution areas right now include:
 - schemas
 - deterministic tests
 - starter-pack guides and templates
-- roadmap alignment
+- roadmap alignment for 1.1+
 - adoption guidance
 - pilot-to-framework learnings that clearly generalize
-- Alpha 4 handoff coherence
-- Alpha 5 inference hardening without over-expansion
-- Alpha 6 tangibility without premature enterprise claims
-- Alpha 7 boundary clarity without tooling inflation
+- hardening of the post-1.0 evolution tracks without inflating the core
 
 ---
 
@@ -51,7 +48,7 @@ Please make sure that:
 - tests still pass when relevant
 - public docs stay understandable for non-specialists
 - the change does not silently turn project-specific residue into framework core
-- the change does not pull deferred post-1.0 tracks into the current priority lane unless it directly helps Alpha completion
+- the change does not overclaim readiness beyond the current roadmap stage
 
 ---
 
@@ -64,12 +61,10 @@ Before opening a change, ask:
 - is this improving the reusable framework core?
 - is this a starter-pack improvement?
 - is this a pilot learning that really generalizes?
-- is this helping close an Alpha that is still open before 1.0?
+- is this part of the current 1.x roadmap?
 - is this still specific to one project and therefore better left out of the public core?
 
 If the answer is mostly project-specific, prefer keeping it local or documenting it as a project extension pattern instead of promoting it directly into the framework core.
-
-If the change mostly belongs to a deferred post-1.0 track, it is probably premature unless it also makes the current Alpha completion pass clearer or safer.
 
 ---
 
@@ -81,7 +76,7 @@ Framework-core contributions are a good fit when they are:
 - understandable without one product's vocabulary
 - about operating discipline, contracts, governance, validation, or learnings
 - helpful as a teaching artifact for adopters
-- aligned with the current completion-first roadmap
+- aligned with the current 1.x roadmap
 
 Examples:
 
@@ -89,7 +84,7 @@ Examples:
 - starter-pack patterns that generalize well
 - roadmap-aligned adoption docs
 - validation and test improvements for the framework itself
-- Alpha-completion hardening that improves coherence without inflating the core
+- bounded post-1.0 hardening that improves coherence without inflating the core
 
 ---
 
@@ -110,7 +105,7 @@ These may still be valuable as:
 - project extensions
 - pilot write-ups
 - future examples
-- deferred post-1.0 tracks
+- post-1.0 tracks
 
 ---
 
@@ -145,7 +140,7 @@ A good contribution should make it easy for a reviewer to answer:
 - what stays out of scope?
 - how was it validated?
 - what should a future contributor learn from this change?
-- does this help the current Alpha completion path, or is it better deferred?
+- is this aligned with the current 1.x roadmap?
 
 ---
 
@@ -177,7 +172,7 @@ Avoid:
 - hidden coupling
 - provider lock-in in the core
 - making the framework sound stronger than it currently is
-- opening post-1.0 roadmap scope before the current Alpha work is sufficiently closed
+- turning future tracks into implicit baseline requirements
 
 ---
 
@@ -185,6 +180,8 @@ Avoid:
 
 Before contributing, it may help to read:
 
+- `README.md`
+- `CHANGELOG.md`
 - `docs/getting-started.md`
 - `docs/roadmap-alpha.md`
 - `docs/release-1.0-readiness.md`

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ This means the framework helps answer questions such as:
 
 ---
 
-## What the current pre-1.0 repository proves
+## What AletheIA 1.0 proves
 
-The current public repository is meant to prove that:
+AletheIA 1.0 proves that:
 
 - an input can become a structured decision
 - governance can block unsafe or poorly framed closure
@@ -102,7 +102,10 @@ The current public repository is meant to prove that:
 - the framework can stay small, inspectable, and deterministic
 - the core can be reused outside its original pilot project
 - pilots can turn into reviewable framework improvements
-- the roadmap can distinguish baseline work from deferred evolution
+- handoffs can preserve restartable continuity across boundaries
+- structured risk inference can exist as a selective experimental layer rather than universal ceremony
+- distribution and delivery can be framed without distorting the core
+- the roadmap can distinguish baseline work from post-baseline evolution
 
 ---
 
@@ -114,7 +117,7 @@ The current public repository is meant to prove that:
 - `examples/` — canonical examples and golden fixtures
 - `tests/` — contract, golden, e2e, and learning-oriented checks
 - `starter-pack/` — reusable operating guides, checklists, and templates
-- `docs/` — architecture, roadmap, pilot narrative, and release-readiness notes
+- `docs/` — architecture, roadmap, pilot narrative, release-readiness notes, and future-facing delivery boundaries
 
 ---
 
@@ -143,32 +146,32 @@ The repository starts with a few small examples that make the framework tangible
 
 ## Current status
 
-AletheIA is still **pre-1.0**.
+This repository is now **AletheIA 1.0.0**.
 
-The repository is now in a **late Alpha completion cycle**:
-
-- **Alpha 1–3** are treated as complete enough for the current cycle
-- **Alpha 4–7** remain active completion or hardening lanes before the 1.0 gate
-- post-baseline tracks such as enterprise-readiness, stronger domain packs, and heavier tooling are preserved, but explicitly deferred until after 1.0
-
-Today, the public repository already contains:
+AletheIA 1.0 includes:
 
 - an Alpha 1 baseline for governance, token discipline, durable decisions, enforcement clarity, quality, and learnings
 - an Alpha 2 bridge for self-application, pilot conversion, and project extension, reinforced by real-world Crisis Monitor validation
 - an Alpha 3 adoption baseline for getting started, existing-project application, contribution guidance, and starter-pack reuse
-- an Alpha 4 handoff baseline for model-agnostic restart packages, project conventions, and semi-automated handoff capture
-- an Alpha 5 experimental baseline for structured risk inference in higher-risk work, including concrete example artifacts
-- an Alpha 6 distribution baseline for presets, adapters, adoption modes, and cross-surface delivery mappings
+- an Alpha 4 handoff baseline for model-agnostic restart packages, project conventions, capture patterns, and stronger multi-boundary continuity
+- an Alpha 5 experimental baseline for structured risk inference in higher-risk work, including stronger links to risk-to-gate mapping and iterative maintenance
+- an Alpha 6 distribution baseline for presets, adapters, adoption modes, cross-surface delivery mappings, and a constrained adoption example
+- an Alpha 7 tooling-boundary baseline for future bootstrap and delivery tooling that remains clearly optional and future-facing
 - a current operational-composition baseline for work slices, risk-to-gate mapping, stronger restart-package examples, round-based maintenance guidance, and optional filesystem context-routing experiments
-- an early Alpha 7 bootstrap-and-delivery baseline for future tooling contracts that remains clearly outside the core
 
-This repository is **not 1.0 yet**.
-The current priority is to close the remaining open Alpha work cleanly before pulling post-1.0 tracks into the main lane.
+AletheIA 1.0 does **not** claim:
+
+- enterprise-ready rollout by default
+- fully tooled bootstrap or delivery automation
+- completed domain governance packs
+
+Those remain part of the post-1.0 roadmap.
 
 See also:
 
 - `docs/roadmap-alpha.md`
 - `docs/release-1.0-readiness.md`
+- `CHANGELOG.md`
 
 ---
 
@@ -213,19 +216,22 @@ If this is your first time here, start with:
 35. `examples/work-slices/standard-slice/README.md`
 36. `examples/handoffs/compact-reviewable-handoff.md`
 37. `examples/handoffs/high-stakes-handoff.md`
-38. `examples/structured-risk-inference/README.md`
+38. `examples/handoffs/multi-boundary-continuity.md`
+39. `examples/structured-risk-inference/README.md`
+40. `examples/distribution/constrained-adoption-mapping.md`
+41. `examples/delivery/reviewable-generated-bundle.md`
 
 ---
 
 ## What happens after 1.0
 
-After the 1.0 gate is satisfied, the roadmap shifts from Alpha completion into **1.x evolution**.
+After the 1.0 baseline, the roadmap shifts into **1.x evolution**.
 
-The next planned lanes are already preserved as deferred tracks:
+The next planned lanes are:
 
 - **1.1** — enterprise-readiness / regulated adoption
 - **1.2** — pilot expansion / stronger real-world validation
 - **1.3** — distribution & delivery hardening
 - **1.4+** — domain governance packs hardening
 
-Those tracks remain valid, but they are intentionally not the current priority lane.
+Those tracks remain valid, but they are intentionally post-baseline work.

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -1,6 +1,6 @@
 # AletheIA Overview
 
-AletheIA is an operating framework for AI-assisted work with a decision kernel at its center.
+AletheIA 1.0 is an operating framework for AI-assisted work with a decision kernel at its center.
 
 The public repository is organized around four blocks:
 
@@ -28,16 +28,16 @@ The public repository is organized around four blocks:
    - how pilot learnings return into framework evolution
    - how self-application, pilot conversion, and project extension stay connected
 
-4. **release-readiness framing**
-   - what is already baseline enough
-   - what still blocks 1.0
-   - what has been intentionally deferred until after 1.0
+4. **post-baseline framing**
+   - what is now part of the 1.0 baseline
+   - what remains future-facing but bounded
+   - what moves into 1.1, 1.2, 1.3, and later
 
 ---
 
 ## Current phase
 
-AletheIA is currently in a **late Alpha completion cycle before 1.0**.
+AletheIA is now in its **1.0 baseline phase**.
 
 That means the repository now distinguishes between:
 
@@ -45,21 +45,21 @@ That means the repository now distinguishes between:
   - Alpha 1
   - Alpha 2
   - Alpha 3
-- **Alpha completion pass**
   - Alpha 4
   - Alpha 5
   - Alpha 6
   - Alpha 7
-- **deferred until post-1.0**
+- **post-1.0 evolution tracks**
   - enterprise-readiness / regulated adoption
   - stronger pilot expansion
   - broader delivery hardening
   - domain governance packs hardening
 
-The roadmap and 1.0 gate are now read together through:
+The roadmap and release gate are now read together through:
 
 - `docs/roadmap-alpha.md`
 - `docs/release-1.0-readiness.md`
+- `CHANGELOG.md`
 
 ---
 
@@ -73,7 +73,7 @@ AletheIA should be reusable outside the original pilot while still preserving th
 
 That reuse depends on an explicit boundary between the framework core and each project's local extension layer.
 
-At this point, Alpha 2 is organized around four explicit bridge artifacts and is now supported by stronger real-world validation from the Crisis Monitor pilot:
+At this point, Alpha 2 is organized around four explicit bridge artifacts and is supported by stronger real-world validation from the Crisis Monitor pilot:
 
 - `docs/self-application.md`
 - `docs/pilot-crisis-monitor.md`
@@ -102,6 +102,7 @@ Anchored by:
 - `starter-pack/templates/agent-handoff-template.md`
 - `docs/project-handoff-conventions.md`
 - `docs/handoff-capture-pattern.md`
+- `examples/handoffs/multi-boundary-continuity.md`
 
 ### Alpha 5 experimental baseline
 
@@ -113,14 +114,15 @@ Anchored by:
 - `starter-pack/guides/inference-artifact-generation.md`
 - `docs/inference-pilot-scenarios.md`
 - `examples/structured-risk-inference/README.md`
+- `examples/structured-risk-inference/regression-round-inference.json`
 
 This means Alpha 5 can now be read across:
 
 - concept
-- template
 - trigger discipline
 - generation method
-- pilot posture
+- risk-to-gate fit
+- iterative-maintenance fit
 - concrete example artifacts
 
 ### Alpha 6 distribution baseline
@@ -132,6 +134,7 @@ Anchored by:
 - `docs/adapter-taxonomy.md`
 - `docs/adoption-mode-guidance.md`
 - `docs/delivery-mapping-examples.md`
+- `examples/distribution/constrained-adoption-mapping.md`
 
 This means Alpha 6 can now be read across:
 
@@ -139,8 +142,9 @@ This means Alpha 6 can now be read across:
 - delivery surface
 - adoption depth
 - cross-surface meaning preservation
+- plugability through project extension without overclaiming enterprise readiness
 
-### Alpha 7 future-facing tooling baseline
+### Alpha 7 future-facing tooling-boundary baseline
 
 Anchored by:
 
@@ -149,8 +153,9 @@ Anchored by:
 - `docs/bootstrap-output-examples.md`
 - `docs/bootstrap-generator-contract.md`
 - `docs/delivery-output-contract.md`
+- `examples/delivery/reviewable-generated-bundle.md`
 
-This is still a future-facing delivery layer, not an implemented tooling requirement for the 1.0 baseline.
+This is part of the 1.0 baseline because it is now clearly bounded as optional and future-facing, not because active tooling is required.
 
 ---
 
@@ -183,4 +188,4 @@ This layer makes the current baseline more tangible through:
 - regression-aware continuation and reusable learning across rounds
 - advisory-only model strategy by task shape, capability profile, reasoning depth, and trust / hosting posture
 
-This layer is useful, but it does **not** replace the need to close the open Alpha work before 1.0.
+It remains useful precisely because it stays smaller than the core.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,18 +10,19 @@ It is meant for readers who do not want to read the whole repository first.
 
 ## One orientation note before you start
 
-AletheIA is still **pre-1.0**.
+AletheIA is now **1.0.0**.
 
-The repository is in its **late Alpha completion cycle**, which means:
+That means:
 
-- Alpha 1–3 are already treated as complete enough for the current cycle
-- Alpha 4–7 still have explicit completion work before the 1.0 gate
-- post-1.0 tracks already exist, but they are intentionally deferred
+- the Alpha 1–7 baseline is considered done enough for public reuse
+- the framework now has a stable baseline reading path
+- future work now moves into **1.x evolution**, not more Alpha buildup
 
 If you want to understand that maturity map first, read:
 
 1. `docs/roadmap-alpha.md`
 2. `docs/release-1.0-readiness.md`
+3. `CHANGELOG.md`
 
 ---
 
@@ -80,7 +81,6 @@ If you only have a few minutes, look at:
 - `README.md`
 - `docs/00-overview.md`
 - `docs/roadmap-alpha.md`
-- `docs/release-1.0-readiness.md`
 - `docs/governance.md`
 - `examples/hello-world/`
 - `scripts/check-governance.sh`
@@ -90,7 +90,7 @@ That gives you a compact sense of:
 - the problem AletheIA solves
 - the operating model
 - the governance baseline
-- the current maturity map
+- the maturity map behind 1.0
 - the smallest runnable proof
 
 ---
@@ -99,9 +99,9 @@ That gives you a compact sense of:
 
 If you want to test AletheIA in practice, start with one of these:
 
-### Option A — inspect the current pre-1.0 baseline
+### Option A — inspect the 1.0 baseline
 
-- read the overview, roadmap, and readiness gate
+- read the overview, roadmap, and readiness note
 - inspect the starter-pack
 - run the lightweight examples and tests
 
@@ -125,7 +125,7 @@ Do not start by:
 - trying to automate the entire framework at once
 - copying every artifact into your repo before one real pilot exists
 - assuming your local rules are already reusable framework rules
-- pulling post-1.0 ideas into your first bounded adoption slice
+- pulling post-1.0 tracks into your first bounded adoption slice
 
 AletheIA works best when adoption starts small and becomes more explicit through use.
 
@@ -139,4 +139,4 @@ After `getting-started.md`, choose one of these paths:
 - **pilot in an existing project** -> `docs/apply-to-existing-project.md`
 - **inspect the operating method** -> `starter-pack/README.md`
 - **understand the maturity path** -> `docs/roadmap-alpha.md`
-- **understand what still blocks 1.0** -> `docs/release-1.0-readiness.md`
+- **understand how 1.0 was framed** -> `docs/release-1.0-readiness.md`

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -12,7 +12,7 @@ This document exists to help present AletheIA clearly in public.
 
 ## 3. One-paragraph project description
 
-AletheIA is an operating framework for AI-assisted work. It helps teams structure context, decisions, governance, validation, and learnings before execution, so model output does not act directly on systems without control. The framework is provider-agnostic, deterministic at its core, and designed to be reusable across projects. The public repository is currently in a late Alpha completion cycle before 1.0.
+AletheIA 1.0 is an operating framework for AI-assisted work. It helps teams structure context, decisions, governance, validation, and learnings before execution, so model output does not act directly on systems without control. The framework is provider-agnostic, deterministic at its core, and designed to be reusable across projects.
 
 ## 4. Suggested GitHub topics
 
@@ -27,25 +27,25 @@ AletheIA is an operating framework for AI-assisted work. It helps teams structur
 - typescript
 - workflows
 
-## 5. Announcement copy — current phase
+## 5. Announcement copy — 1.0
 
 ### English
 
-AletheIA is in its final Alpha-completion phase before **1.0**.
+AletheIA 1.0 is now public.
 
 It is an operating framework for AI-assisted work that introduces an explicit layer between model output and execution, with structured decisions, governance, validation, and learnings.
 
-The current focus is to finish the open Alpha work cleanly before moving into the post-1.0 tracks.
+The 1.0 baseline closes the Alpha 1–7 maturity spine and moves the next roadmap into 1.1+ evolution.
 
 Repo: https://github.com/nevitonsantana/aletheia
 
 ### Português
 
-O AletheIA está em sua fase final de fechamento dos Alphas antes da **1.0**.
+O AletheIA 1.0 agora está público.
 
 Ele é um framework operacional para trabalho assistido por IA que introduz uma camada explícita entre output de modelo e execução, com decisão estruturada, governança, validação e learnings.
 
-O foco atual é fechar bem os Alphas ainda abertos antes de avançar para as trilhas pós-1.0.
+A baseline 1.0 fecha a espinha de maturidade Alpha 1–7 e move os próximos passos do roadmap para a evolução em 1.1+.
 
 Repo: https://github.com/nevitonsantana/aletheia
 
@@ -63,7 +63,7 @@ Instead of letting raw model output act directly on the system, AletheIA introdu
 - proportional validation
 - reusable learnings
 
-The public repository is still pre-1.0, but it now has an explicit completion path: finish the remaining Alpha work first, then move into versioned 1.x evolution.
+AletheIA 1.0 means the baseline is now public and coherent enough to teach, reuse, and evolve. It does **not** mean every post-baseline track is already finished.
 
 ### Português
 
@@ -77,4 +77,4 @@ Em vez de permitir que o output bruto do modelo aja diretamente no sistema, o Al
 - validação proporcional
 - learnings reutilizáveis
 
-O repositório público ainda está em fase pré-1.0, mas agora tem um caminho explícito de fechamento: concluir primeiro os Alphas ainda abertos e só depois entrar na evolução versionada em 1.x.
+AletheIA 1.0 significa que a baseline agora está pública e coerente o suficiente para ensinar, reutilizar e evoluir. Isso **não** significa que todas as trilhas pós-baseline já estejam concluídas.

--- a/docs/release-1.0-readiness.md
+++ b/docs/release-1.0-readiness.md
@@ -1,122 +1,102 @@
 # AletheIA 1.0 Readiness Gate
 
-This document exists to answer one question clearly:
+This document originally existed to answer one question clearly:
 
-**what still needs to be true before AletheIA can stop presenting itself as an alpha and become 1.0?**
+**what still needed to be true before AletheIA could stop presenting itself as an alpha and become 1.0?**
 
-The current rule is explicit:
+That gate is now satisfied.
 
-> **AletheIA reaches 1.0 when Alpha 1–7 are done enough for the baseline, not when every future track is finished.**
+> **AletheIA 1.0 is the point where Alpha 1–7 are done enough for the baseline, even though future tracks still remain open.**
 
 That means:
 
-- 1.0 is blocked by the **open Alpha completion work**
-- 1.0 is **not** blocked by enterprise-readiness, domain packs, or heavier tooling
-- those later tracks remain valid, but they move into **post-1.0 roadmap work**
+- the Alpha completion-first queue is now considered sufficiently closed for the baseline
+- 1.0 is **not** claiming enterprise-readiness, domain-pack completion, or active tooling implementation
+- those later tracks remain valid as **post-1.0 roadmap work**
 
 ---
 
-## Why 1.0 is gated by Alpha completion
+## Why 1.0 was gated by Alpha completion
 
-The Alpha roadmap is the backbone of the framework.
+The Alpha roadmap was the backbone of the framework.
 
-If AletheIA declared 1.0 before the open Alphas are sufficiently hardened, the framework would create avoidable ambiguity about:
+AletheIA only moved out of alpha framing after the open Alpha work was hardened enough to remove avoidable ambiguity about:
 
 - what is already stable enough to teach
-- what still needs operational hardening
-- what is intentionally future-facing
+- what remains future-facing but bounded
+- what should move into 1.1, 1.2, 1.3, and later
 
-So the 1.0 gate exists to make three things explicit:
+So 1.0 should be read as:
 
-1. **Alpha 1–3 are already complete enough** for the current cycle
-2. **Alpha 4–7 still need specific completion work**
-3. **post-1.0 tracks stay deferred until that completion work is done**
+- a **baseline release**
+- not the end of framework evolution
+- not a claim that every future track is complete
 
 ---
 
 ## Current Alpha status
 
-### Complete enough for the current cycle
+### Done enough for the 1.0 baseline
 
 - **Alpha 1** — core + governance baseline
 - **Alpha 2** — real pilots + self-application
 - **Alpha 3** — adoption + ecosystem baseline
-
-### Still open for the 1.0 gate
-
-- **Alpha 4** — baseline established, still open
-- **Alpha 5** — baseline established, still open
-- **Alpha 6** — baseline established, still open
-- **Alpha 7** — future-facing but bounded, still not 1.0-ready
-
-See also:
-
-- `docs/roadmap-alpha.md`
+- **Alpha 4** — handoff baseline hardened enough for restartable multi-boundary continuity
+- **Alpha 5** — structured risk inference hardened enough as a selective experimental baseline
+- **Alpha 6** — distribution baseline made tangible enough through presets, adapters, adoption modes, and a constrained mapping example
+- **Alpha 7** — tooling layer bounded clearly enough as optional and future-facing
 
 ---
 
-## Done-enough criteria by Alpha
+## What changed during the completion pass
 
-### Alpha 1 — done enough
+### Alpha 4
 
-Already sufficient for the current cycle.
-No new blocker is defined here beyond keeping the baseline coherent.
+Reached done-enough status through:
 
-### Alpha 2 — done enough
+- clearer boundary language between minimum schema-backed continuity and richer operational handoff
+- stronger multi-boundary continuity guidance
+- a stronger example showing chains of compact restart packages
 
-Already sufficient for the current cycle.
-No new blocker is defined here beyond keeping the pilot-to-framework bridge coherent.
+### Alpha 5
 
-### Alpha 3 — done enough
+Reached done-enough status through:
 
-Already sufficient for the current cycle.
-No new blocker is defined here beyond keeping adoption guidance and starter-pack clarity coherent.
+- clearer selective trigger posture
+- stronger connection to risk-to-gate mapping
+- stronger connection to iterative maintenance and regression-aware continuation
+- a near-real example showing when degradation signals justify inference
 
-### Alpha 4 — done enough when
+### Alpha 6
 
-- handoff docs, template, and examples are coherent without a meaningful gap between concept and use
-- the boundary between schema coverage and richer operational handoff practice is clear
-- at least one strong multi-boundary continuity example exists if the current examples still feel too light
+Reached done-enough status through:
 
-### Alpha 5 — done enough when
+- clearer preset / adapter / adoption-mode relationships
+- a practical selection recipe
+- a constrained adoption mapping example showing plugability through local extension without overclaiming readiness
 
-- it remains selective rather than universal
-- it has more tangible real or near-real evidence
-- it is better coupled to risk-to-gate and iterative maintenance
-- it is clearer when structured inference adds value and when it only adds overhead
+### Alpha 7
 
-### Alpha 6 — done enough when
+Reached done-enough status through:
 
-- presets, adapters, and adoption modes feel more tangible
-- at least one more concrete extension or distribution example exists
-- plugability is better explained without drifting into enterprise-readiness claims
-
-### Alpha 7 — done enough for 1.0 when
-
-- it remains explicitly optional and future-facing
-- generator, output, and tooling-boundary docs are coherent with each other
-- the roadmap no longer implies that 1.0 depends on real tooling implementation
-
-Important:
-
-**Alpha 7 does not need active tooling implementation before 1.0.**
-It only needs a clear, bounded, non-misleading definition.
+- consistent optional / future-facing wording
+- clearer tooling stop lines
+- clearer generator and output contracts as doc-level future contracts only
+- an illustrative reviewable output example that does not require implementation
 
 ---
 
-## 1.0 public-release checklist
+## 1.0 release checklist completed
 
-The 1.0 flip should happen only after the open Alpha criteria above are satisfied.
+The public 1.0 flip included:
 
-At that moment, the public release checklist is:
+- removing alpha framing from public-facing docs
+- updating central docs to say **AletheIA 1.0** clearly and consistently
+- adding `"version": "1.0.0"` to `package.json`
+- creating `CHANGELOG.md`
+- preparing the public versioned baseline for 1.x evolution
 
-- remove public-facing language that still frames the repo as an alpha or draft
-- update central docs to say **AletheIA 1.0** clearly and consistently
-- add `"version": "1.0.0"` to `package.json`
-- create `CHANGELOG.md`
-- prepare and publish the public tag/release `v1.0.0`
-
-### Public surfaces to update at the 1.0 flip
+### Public surfaces updated at the 1.0 flip
 
 - `README.md`
 - `docs/00-overview.md`
@@ -130,11 +110,11 @@ At that moment, the public release checklist is:
 
 ## What remains post-1.0
 
-These tracks remain real and already planned, but they are **not** part of the 1.0 gate.
+These tracks remain real and already planned, but they were **not** required for the 1.0 baseline.
 
 ### 1.1 — enterprise-readiness / regulated adoption
 
-Preserved backlog includes:
+Planned backlog includes:
 
 - enterprise-readiness / regulated adoption roadmap
 - enterprise adoption guidance
@@ -143,7 +123,7 @@ Preserved backlog includes:
 
 ### 1.2 — pilot expansion / stronger real-world validation
 
-Preserved backlog includes:
+Planned backlog includes:
 
 - expansion beyond the strongest current pilot lane
 - more real-world comparisons between extensions
@@ -151,15 +131,15 @@ Preserved backlog includes:
 
 ### 1.3 — distribution & delivery hardening
 
-Preserved backlog includes:
+Planned backlog includes:
 
-- broader distribution hardening beyond “done enough”
+- broader distribution hardening beyond the 1.0 baseline
 - stronger post-baseline preset and adapter material
 - more delivery-layer clarity once the baseline is already stable
 
 ### 1.4+ — domain governance packs hardening
 
-Preserved backlog includes:
+Planned backlog includes:
 
 - stronger domain governance packs
 - reusable trust-boundary and prompt-injection layers
@@ -167,32 +147,20 @@ Preserved backlog includes:
 
 ---
 
-## Completion-first queue before 1.0
+## What 1.0 means and does not mean
 
-The current pre-1.0 queue is:
-
-1. **Alpha 4 completion pass**
-2. **Alpha 5 hardening pass**
-3. **Alpha 6 tangibility pass**
-4. **Alpha 7 boundary clarification pass**
-
-Until this queue is sufficiently closed, these post-1.0 tracks remain deferred by design.
-
----
-
-## What 1.0 will and will not mean
-
-### 1.0 will mean
+### 1.0 means
 
 - the baseline roadmap is coherent enough to teach, reuse, and evolve publicly
 - Alpha 1–7 are done enough for the baseline
-- the framework can move from alpha framing into versioned 1.x evolution
+- the framework now moves into versioned **1.x evolution**
 
-### 1.0 will not mean
+### 1.0 does not mean
 
 - enterprise-ready by default
 - fully tooled bootstrap and delivery automation
 - every future domain pack already hardened
 - the end of framework evolution
 
-1.0 is the moment when the baseline stops being ambiguous, not the moment when every next track is finished.
+AletheIA 1.0 is the moment when the baseline stops being ambiguous.
+It is not the moment when every next track is finished.

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -1,45 +1,30 @@
-# AletheIA Roadmap — Alpha Completion First
+# AletheIA Roadmap — 1.0 Baseline and 1.x Evolution
 
-AletheIA still uses **Alpha 1–7** as its primary maturity map.
+AletheIA still uses **Alpha 1–7** as its maturity spine.
 
-The current roadmap rule is now explicit:
+The difference now is that the Alpha completion-first queue has been closed at a **done-enough baseline level**, so the framework has moved into **AletheIA 1.0**.
 
-1. **close the Alphas that are still open**
-2. **declare a formal 1.0 gate**
-3. **only then pull the post-1.0 tracks into priority**
+That means the roadmap now has two layers:
 
-This means previously discussed next steps are **not lost**.
-They are preserved below either as:
-
-- a **completion-first queue** that still blocks 1.0, or
-- **deferred until post-1.0** tracks that stay valid but must not compete with Alpha completion.
-
----
-
-## How to read this roadmap
-
-This roadmap is organized in three layers:
-
-1. **Established baseline**
-   - Alphas that are complete enough for the current cycle
-2. **Alpha completion pass**
-   - Alphas whose baseline exists but still needs hardening or clearer boundaries before 1.0
-3. **Deferred until post-1.0**
-   - valid tracks that remain intentionally out of the current priority lane
+1. **Established 1.0 baseline**
+   - what Alpha 1–7 already established
+2. **Post-1.0 evolution tracks**
+   - what now belongs to 1.1, 1.2, 1.3, and later
 
 See also:
 
 - `docs/release-1.0-readiness.md`
 - `docs/00-overview.md`
+- `CHANGELOG.md`
 
 ---
 
-## Established baseline
+## Established 1.0 baseline
 
 ### Alpha 1 — Core + Governance Baseline
-**Status:** complete enough for the current cycle
+**Status:** complete enough for 1.0
 
-What Alpha 1 already established:
+Established in the baseline:
 
 - framework core contracts
 - minimal deterministic kernel
@@ -51,7 +36,7 @@ What Alpha 1 already established:
 - quality baseline
 - learning-from-failed-validation path
 
-Current anchor artifacts include:
+Anchor artifacts include:
 
 - `docs/token-policy.md`
 - `docs/durable-decisions.md`
@@ -60,16 +45,16 @@ Current anchor artifacts include:
 - `scripts/check-governance.sh`
 
 ### Alpha 2 — Real Pilots + Self-Application
-**Status:** complete enough for the current cycle
+**Status:** complete enough for 1.0
 
-What Alpha 2 already established:
+Established in the baseline:
 
 - real pilot grounding through Crisis Monitor
 - self-application of framework discipline to framework evolution
 - pilot-to-learning-to-framework conversion
 - project extension as a clean local layer
 
-Current anchor artifacts include:
+Anchor artifacts include:
 
 - `docs/self-application.md`
 - `docs/pilot-crisis-monitor.md`
@@ -78,9 +63,9 @@ Current anchor artifacts include:
 - `examples/pilot-conversion/crisis-monitor-real-world-validation.md`
 
 ### Alpha 3 — Adoption + Ecosystem
-**Status:** complete enough for the current cycle
+**Status:** complete enough for 1.0
 
-What Alpha 3 already established:
+Established in the baseline:
 
 - clearer onboarding
 - starter-pack reuse
@@ -88,7 +73,7 @@ What Alpha 3 already established:
 - existing-project application path
 - stronger separation between framework core and local extension
 
-Current anchor artifacts include:
+Anchor artifacts include:
 
 - `docs/getting-started.md`
 - `docs/apply-to-existing-project.md`
@@ -96,58 +81,41 @@ Current anchor artifacts include:
 - `starter-pack/README.md`
 - `starter-pack/templates/project-extension-template.md`
 
----
-
-## Alpha completion pass
-
-These Alphas are real baselines already, but they are **still open for the 1.0 gate**.
-
 ### Alpha 4 — Orchestrated Handoffs & Multi-Agent Continuity
-**Status:** baseline established, still open
+**Status:** complete enough for 1.0
 
-Alpha 4 already has:
+Established in the baseline:
 
 - handoff concept docs
 - generation guidance
-- starter-pack template
+- richer operational template over smaller schema-backed continuity
 - project-level conventions
 - handoff capture pattern
-- restart-package examples
+- stronger multi-boundary continuity example
 
-What still needs to feel done enough:
-
-- tighter coherence between doc, template, and examples
-- a clearer boundary between schema coverage and richer operational handoff practice
-- at least one stronger multi-boundary continuity example if the current examples still feel too light
-
-Current anchor artifacts include:
+Anchor artifacts include:
 
 - `docs/agent-handoffs.md`
 - `starter-pack/guides/agent-handoff-generation.md`
 - `starter-pack/templates/agent-handoff-template.md`
 - `docs/project-handoff-conventions.md`
 - `docs/handoff-capture-pattern.md`
+- `examples/handoffs/multi-boundary-continuity.md`
 
 ### Alpha 5 — Structured Risk Inference & Evidence-Oriented Validation
-**Status:** baseline established, still open
+**Status:** complete enough for 1.0 as an experimental selective baseline
 
-Alpha 5 already has:
+Established in the baseline:
 
 - concept framing
 - template
 - trigger guidance
 - generation guidance
-- pilot scenarios
-- example artifacts
+- stronger tie to risk-to-gate mapping
+- stronger tie to iterative maintenance
+- near-real example of regression-aware inference
 
-What still needs to feel done enough:
-
-- more tangible real or near-real evidence
-- a tighter connection to risk-to-gate and iterative maintenance
-- clearer guidance on when inference helps and when it becomes unnecessary overhead
-- continued selective positioning rather than universal ceremony
-
-Current anchor artifacts include:
+Anchor artifacts include:
 
 - `docs/structured-risk-inference.md`
 - `starter-pack/templates/inference-artifact-template.md`
@@ -155,63 +123,60 @@ Current anchor artifacts include:
 - `starter-pack/guides/inference-artifact-generation.md`
 - `docs/inference-pilot-scenarios.md`
 - `examples/structured-risk-inference/README.md`
+- `examples/structured-risk-inference/regression-round-inference.json`
 
 ### Alpha 6 — Distribution, Presets & Adapters
-**Status:** baseline established, still open
+**Status:** complete enough for 1.0
 
-Alpha 6 already has:
+Established in the baseline:
 
 - distribution architecture framing
 - preset taxonomy
 - adapter taxonomy
 - adoption modes
 - delivery mappings
+- a concrete constrained adoption mapping example
 
-What still needs to feel done enough:
-
-- more tangible presets, adapters, and adoption examples
-- at least one stronger local distribution or extension example in a demanding context
-- clearer communication of architectural plugability without claiming enterprise-readiness
-
-Current anchor artifacts include:
+Anchor artifacts include:
 
 - `docs/distribution-presets-adapters.md`
 - `docs/preset-taxonomy.md`
 - `docs/adapter-taxonomy.md`
 - `docs/adoption-mode-guidance.md`
 - `docs/delivery-mapping-examples.md`
+- `examples/distribution/constrained-adoption-mapping.md`
 
 ### Alpha 7 — Bootstrap & Delivery Tooling
-**Status:** baseline defined, still not 1.0-ready
+**Status:** complete enough for 1.0 as an optional future-facing boundary layer
 
-Alpha 7 already has:
+Established in the baseline:
 
-- principles
-- tooling boundaries
-- bootstrap output examples
-- generator contract
-- delivery output contract
+- bootstrap posture
+- tooling stop lines
+- output examples
+- future generator contract
+- future output contract
+- illustrative reviewable bundle example
 
-What still needs to feel done enough for 1.0:
+Important boundary:
 
-- clearer boundary language so the tooling layer stays obviously optional and future-facing
-- coherence between generator, output, and boundary docs
-- no implication that 1.0 depends on real delivery tooling
+**Alpha 7 is part of the 1.0 baseline because its scope is now clearly bounded, not because active tooling exists.**
 
-Current anchor artifacts include:
+Anchor artifacts include:
 
 - `docs/bootstrap-principles.md`
 - `docs/delivery-tooling-boundaries.md`
 - `docs/bootstrap-output-examples.md`
 - `docs/bootstrap-generator-contract.md`
 - `docs/delivery-output-contract.md`
+- `examples/delivery/reviewable-generated-bundle.md`
 
 ---
 
 ## Current operational-composition baseline
 
-This is **not a new Alpha**.
-It is a proportional operating layer that makes the existing baselines easier to apply.
+This is still **not a new Alpha**.
+It remains a proportional operating layer that makes the established baseline easier to apply.
 
 Current artifacts in this layer include:
 
@@ -238,85 +203,50 @@ This layer currently strengthens:
 - regression-aware continuation and reusable learning across rounds
 - advisory-only model strategy by task shape, capability profile, reasoning depth, and trust / hosting posture
 
-It should remain smaller than the core and must not replace the Alpha completion pass.
+It remains smaller than the core and should continue evolving proportionally.
 
 ---
 
-## Completion-first queue
-
-These previously discussed moves remain **active** and are now the formal queue before 1.0:
-
-1. **Alpha 4 completion pass**
-2. **Alpha 5 hardening pass**
-3. **Alpha 6 tangibility pass**
-4. **Alpha 7 boundary clarification pass**
-
-This queue exists so that new strategic tracks do not compete with what still blocks a clean 1.0 baseline.
-
----
-
-## Deferred until post-1.0
-
-These tracks remain valid, but they are now explicitly **deferred until after the 1.0 gate**.
+## Post-1.0 evolution tracks
 
 ### 1.1 — Enterprise-readiness / regulated adoption
-Includes the previously discussed backlog items such as:
+
+Planned backlog includes:
 
 - enterprise-readiness / regulated adoption roadmap
 - enterprise adoption guidance
 - restricted enterprise extension example
-- stronger articulation of local trust-boundary posture in constrained environments
+- stronger local trust-boundary posture for constrained environments
 
 ### 1.2 — Pilot expansion / stronger real-world validation
-Includes:
+
+Planned backlog includes:
 
 - expansion beyond the strongest current pilot lane
 - more real-world comparisons between project extensions
 - stronger pilot-to-framework conversion evidence
 
 ### 1.3 — Distribution & delivery hardening
-Includes:
 
-- broader delivery and distribution hardening beyond “done enough”
-- stronger preset and adapter tangibility after the Alpha 6 pass
+Planned backlog includes:
+
+- broader distribution hardening beyond the 1.0 baseline
+- stronger preset and adapter tangibility after the baseline
 - additional delivery-layer material once the baseline is already stable
 
 ### 1.4+ — Domain governance packs hardening
-Includes:
+
+Planned backlog includes:
 
 - stronger domain governance packs
-- future trust-boundary and prompt-injection packs as harder reusable layers
-- heavier Alpha 7 tooling only after the baseline and post-1.0 priorities justify it
-
-These deferred tracks are preserved as backlog on purpose.
-They are not cancelled.
-They are simply not the current priority lane.
+- reusable trust-boundary and prompt-injection packs
+- heavier Alpha 7 tooling only after later priorities justify it
 
 ---
 
-## Sequence to 1.0
+## Cross-version principles
 
-The current order is now explicit:
-
-1. finish the **Alpha completion-first queue**
-2. run the **1.0 readiness check** in `docs/release-1.0-readiness.md`
-3. flip the public surfaces from late-alpha to **AletheIA 1.0**
-4. begin the **1.x roadmap**
-
-Until then, the repository should keep treating:
-
-- enterprise-readiness
-- stronger domain governance packs
-- heavier delivery tooling
-- broader post-baseline distribution work
-
-as **deferred tracks**, not current priorities.
-
----
-
-## Cross-Alpha principles
-
-Across all phases, AletheIA should preserve a few boundaries:
+Across the 1.x line, AletheIA should preserve a few boundaries:
 
 1. remain provider-agnostic
 2. avoid collapsing into one product's operating residue

--- a/package.json
+++ b/package.json
@@ -8,5 +8,6 @@
     "test:goldens": "tsx tests/goldens/test-goldens.ts",
     "test:e2e": "tsx tests/e2e/test-e2e.ts",
     "test:learnings": "tsx tests/learnings/test-learnings.ts"
-  }
+  },
+  "version": "1.0.0"
 }


### PR DESCRIPTION
## Summary
- flip the public repo framing from alpha baseline work to AletheIA 1.0
- mark the 1.0 readiness gate as satisfied and move roadmap framing to 1.x evolution tracks
- add version 1.0.0 and a first changelog entry

## Validation
- bash scripts/check-governance.sh