### PR TITLE
Start AletheIA 1.1 enterprise-readiness track

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ AletheIA 1.0 does **not** claim:
 
 Those remain part of the post-1.0 roadmap.
 
+The first post-1.0 track now starts with enterprise-oriented hardening for constrained and regulated adoption, but still without claiming enterprise-ready packaging by default.
+
 See also:
 
 - `docs/roadmap-alpha.md`
@@ -183,6 +185,7 @@ If this is your first time here, start with:
 2. `docs/00-overview.md`
 3. `docs/roadmap-alpha.md`
 4. `docs/release-1.0-readiness.md`
+5. `docs/enterprise-readiness-roadmap.md`
 5. `docs/architecture.md`
 6. `docs/governance.md`
 7. `docs/token-policy.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -50,7 +50,7 @@ That means the repository now distinguishes between:
   - Alpha 6
   - Alpha 7
 - **post-1.0 evolution tracks**
-  - enterprise-readiness / regulated adoption
+  - enterprise-readiness / regulated adoption (now the active 1.1 hardening track)
   - stronger pilot expansion
   - broader delivery hardening
   - domain governance packs hardening
@@ -59,6 +59,7 @@ The roadmap and release gate are now read together through:
 
 - `docs/roadmap-alpha.md`
 - `docs/release-1.0-readiness.md`
+- `docs/enterprise-readiness-roadmap.md`
 - `CHANGELOG.md`
 
 ---

--- a/docs/enterprise-readiness-roadmap.md
+++ b/docs/enterprise-readiness-roadmap.md
@@ -1,0 +1,243 @@
+# Enterprise-Readiness / Regulated Adoption Roadmap
+
+## Why this is now the 1.1 focus
+
+AletheIA 1.0 closed the baseline question.
+
+The next question is different:
+
+**how should a reusable operating framework become more usable inside constrained, bureaucratic, or regulated environments without inflating the core?**
+
+That is the purpose of the current 1.1 track.
+
+This track does **not** assume that AletheIA should become a banking framework, a compliance pack, or an enterprise product.
+It assumes something narrower:
+
+- the core is now stable enough
+- real projects may need stronger local operating posture
+- those constraints should land in the local layer first
+- the framework should become easier to adapt to those environments without pretending to encode every enterprise rule
+
+---
+
+## What enterprise-readiness means here
+
+In AletheIA, enterprise-readiness should be read as:
+
+- stronger adoption guidance for constrained environments
+- clearer mapping between framework artifacts and heavier local review/gate expectations
+- stronger examples of trust-boundary-aware project extension
+- stronger language for what stays local versus what belongs in the framework
+
+It does **not** mean:
+
+- enterprise-ready by default
+- finished regulated-domain packs
+- built-in SDLC automation for large organizations
+- a claim that one framework shape fits every enterprise environment
+
+The goal is to improve **regulated adoption readiness**, not to turn AletheIA into a fully packaged enterprise platform.
+
+---
+
+## What already helps
+
+AletheIA 1.0 already has several pieces that matter for constrained contexts.
+
+### 1. Project extension boundary
+
+The framework already distinguishes between:
+
+- reusable core
+- local extension
+
+This matters because enterprise restrictions usually depend on:
+
+- local org policy
+- local approval structure
+- local trust boundary
+- local allowed tools and model posture
+- local ownership maps
+
+Anchor:
+
+- `docs/project-extension-pattern.md`
+
+### 2. Adoption modes
+
+The framework already recognizes that not every context should start with the same operating depth.
+
+This matters because highly constrained environments often need:
+
+- more explicit review layers
+- but also bounded introduction
+- and a safer first lane instead of broad rollout
+
+Anchor:
+
+- `docs/adoption-mode-guidance.md`
+
+### 3. Distribution / preset / adapter framing
+
+The framework already separates:
+
+- preset
+- adapter
+- adoption mode
+- project extension boundary
+
+This matters because constrained environments often require a specific delivery surface, not a different framework truth.
+
+Anchor:
+
+- `docs/distribution-presets-adapters.md`
+
+### 4. Existing trust-boundary and governance direction
+
+The framework already contains future-facing material related to:
+
+- trust boundaries
+- prompt-injection posture
+- domain governance packs
+
+That means enterprise-readiness does not begin from zero.
+It begins from a baseline that already treats those topics as real.
+
+Anchors:
+
+- `docs/web-app-security-trust-boundaries.md`
+- `docs/ai-agent-security-prompt-injection.md`
+- `docs/domain-governance-packs.md`
+
+### 5. Operational-composition baseline
+
+The current operational-composition layer already helps constrained adoption through:
+
+- stronger work-slice discipline
+- risk-to-gate mapping
+- handoff continuity
+- advisory model strategy by trust / hosting posture
+
+That matters because many enterprise environments need stronger reviewability long before they need more automation.
+
+---
+
+## What is still missing
+
+The 1.1 track exists because the current baseline still has real gaps.
+
+### 1. No explicit enterprise adoption guide yet
+
+The framework baseline already explains many useful parts, but it still needs a direct guide that answers:
+
+- how to start in a constrained environment
+- how to keep the rollout bounded
+- how to treat local approvals, tool restrictions, and trust boundaries
+
+### 2. No restricted-environment extension example yet
+
+AletheIA teaches the extension pattern, but constrained environments benefit from a more explicit example showing:
+
+- what stays in the core
+- what becomes local rule
+- how local model/tool restrictions should be expressed
+
+### 3. No stronger mapping from framework artifacts to heavier local governance
+
+Many constrained environments need a practical mapping from:
+
+- task brief
+- risk-to-gate
+- handoff
+- validation
+- durable decision
+
+into a context where review and escalation are heavier than in a lightweight team.
+
+### 4. No finished domain pack for regulated contexts
+
+That is intentional.
+But it also means the framework still needs more intermediate guidance before a regulated-domain pack would be justified.
+
+---
+
+## Low-regret next steps
+
+The lowest-regret path for 1.1 is still documentation-first.
+
+### Step 1 — enterprise adoption guidance
+
+Create a practical guide for introducing AletheIA in environments with:
+
+- heavier approvals
+- stronger review layers
+- tighter trust boundaries
+- allowed / restricted tool posture
+
+### Step 2 — restricted enterprise extension example
+
+Show how a project can define a local enterprise integration layer without contaminating the framework core.
+
+### Step 3 — stronger trust-boundary posture in local mapping
+
+Strengthen the language that local trust and hosting posture should be handled in:
+
+- project extension
+- local model strategy
+- local tool allowlists
+
+not in the framework core.
+
+### Step 4 — pilot in a constrained environment
+
+Use a bounded, reviewable lane before claiming broader readiness.
+
+That means:
+
+- one lane
+- one local extension posture
+- one proof chain
+- one conversion loop back into the framework if it teaches something reusable
+
+---
+
+## Recommended boundaries for 1.1
+
+To keep the track healthy, AletheIA 1.1 should preserve a few boundaries.
+
+### Keep in the framework
+
+- reusable operating guidance
+- extension patterns
+- reviewable examples
+- trust-boundary-aware framing
+- adoption guidance for constrained contexts
+
+### Keep local to the project
+
+- org-specific approval chains
+- vendor allow / deny rules
+- compliance-specific review matrices
+- exact tool permissions
+- exact model hosting restrictions
+- branch and handoff rules tied to one team or one enterprise
+
+### Do not do yet
+
+- broad enterprise packaging claims
+- hard-coded regulated presets as if they were universal
+- CLI/bootstrap promises for constrained environments
+- one-size-fits-all compliance framing
+
+---
+
+## Current 1.1 deliverables
+
+This track currently begins with:
+
+- `docs/enterprise-readiness-roadmap.md`
+- `starter-pack/guides/enterprise-adoption-considerations.md`
+- `examples/project-extension/restricted-enterprise-context.md`
+
+These are meant to improve adoption posture first.
+They are not meant to close the whole enterprise-readiness track.

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -211,12 +211,17 @@ It remains smaller than the core and should continue evolving proportionally.
 
 ### 1.1 — Enterprise-readiness / regulated adoption
 
-Planned backlog includes:
+Current low-regret hardening now begins with:
 
-- enterprise-readiness / regulated adoption roadmap
-- enterprise adoption guidance
-- restricted enterprise extension example
+- `docs/enterprise-readiness-roadmap.md`
+- `starter-pack/guides/enterprise-adoption-considerations.md`
+- `examples/project-extension/restricted-enterprise-context.md`
+
+Current backlog still includes:
+
 - stronger local trust-boundary posture for constrained environments
+- bounded pilot evidence from a constrained environment
+- eventual regulated-domain guidance only if later justified
 
 ### 1.2 — Pilot expansion / stronger real-world validation
 

--- a/examples/project-extension/restricted-enterprise-context.md
+++ b/examples/project-extension/restricted-enterprise-context.md
@@ -1,0 +1,101 @@
+# Restricted Enterprise Context — Project Extension Example
+
+## Goal
+
+This example shows how a constrained enterprise project might apply AletheIA locally without turning enterprise-specific rules into framework truth.
+
+It is intentionally generic.
+It is not a banking policy pack.
+It is not a compliance template.
+It is a project-extension example.
+
+---
+
+## Local constraints
+
+A constrained enterprise project may have local conditions such as:
+
+- stronger review before write actions
+- restricted external model usage
+- trust-boundary limits on context sharing
+- explicit tool allowlists
+- formal change tracking expectations
+- branch, handoff, and approval rules tied to one org structure
+
+These conditions are real.
+But they are still local.
+
+---
+
+## What stays framework-core
+
+The framework core still provides things such as:
+
+- task framing discipline
+- risk-to-gate thinking
+- durable decision discipline
+- handoff patterns
+- quality and validation posture
+- reusable learning and pilot conversion logic
+
+These remain stable even when the enterprise project changes.
+
+---
+
+## What becomes project extension
+
+The project extension may define things such as:
+
+- local approval groups
+- local branch discipline
+- local trust / hosting posture
+- local allow / deny tool lists
+- local model fleet notes
+- local escalation rules for specific change classes
+- local ownership boundaries between teams or threads
+
+That is the correct place for enterprise-specific operating detail.
+
+---
+
+## Local model and trust posture
+
+A restricted project might define a local posture like this:
+
+- non-sensitive planning may use broader model options
+- sensitive reasoning stays inside the local trust boundary
+- external tools are disabled by default in higher-risk lanes
+- write actions require explicit human review regardless of model confidence
+
+The key point is not the exact rule.
+The key point is that the rule belongs to the **project extension layer**, not to AletheIA core.
+
+---
+
+## Local review and approval mapping
+
+A restricted project might map AletheIA artifacts like this:
+
+- **task brief**
+  - define exact intended change and out-of-scope boundary
+- **risk-to-gate mapping**
+  - define whether the lane needs local review, formal approval, or bounded self-check only
+- **durable decision**
+  - record the choices that affect later review or compliance interpretation
+- **handoff**
+  - package what another boundary must know without requiring hidden thread memory
+- **validation**
+  - define what proof counts as sufficient before closure in that lane
+
+This helps a constrained environment use AletheIA without treating the framework as its entire governance system.
+
+---
+
+## Why this does not belong in the framework core
+
+If these local rules moved into the framework core, two bad things would happen:
+
+1. the framework would start carrying one enterprise's residue
+2. lighter adopters would inherit constraints that are not theirs
+
+That is why AletheIA should teach the **pattern** of constrained adoption, while the exact operating rules remain local.

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -96,3 +96,12 @@ Taken together, the current starter-pack now covers both:
 If you want to test a filesystem-based context-routing pattern as a local experiment, read:
 
 - `starter-pack/experiments/workspace-context-routing/README.md`
+
+
+## 1.1 constrained adoption guidance
+
+If you are applying AletheIA in an environment with heavier approvals, stricter trust boundaries, or stronger local restrictions, read:
+
+- `docs/enterprise-readiness-roadmap.md`
+- `starter-pack/guides/enterprise-adoption-considerations.md`
+- `examples/project-extension/restricted-enterprise-context.md`

--- a/starter-pack/guides/enterprise-adoption-considerations.md
+++ b/starter-pack/guides/enterprise-adoption-considerations.md
@@ -1,0 +1,149 @@
+# Enterprise Adoption Considerations
+
+## Goal
+
+This guide helps teams introduce AletheIA inside environments with stronger constraints, including:
+
+- heavier approvals
+- stronger trust boundaries
+- tool restrictions
+- slower rollout expectations
+- more formal review paths
+
+The goal is **not** to install the whole framework at once.
+The goal is to introduce it in a bounded way without distorting the core.
+
+---
+
+## Start with a bounded lane
+
+Do not begin with broad rollout.
+
+Begin with:
+
+- one lane
+- one dominant ownership boundary
+- one reviewable proof chain
+- one local extension layer
+
+Good first lanes usually have:
+
+- bounded scope
+- visible decision points
+- existing review expectations
+- low enough blast radius to stay reversible
+
+---
+
+## Treat the project extension as the enterprise integration layer
+
+In constrained environments, the project extension should carry things such as:
+
+- local approval rules
+- allowed versus restricted tools
+- allowed versus restricted model posture
+- trust-boundary assumptions
+- local branch and handoff conventions
+- local escalation expectations
+
+Do **not** move those rules into the framework core unless they generalize clearly across contexts.
+
+---
+
+## Recommended introduction sequence
+
+A practical enterprise-oriented sequence is:
+
+1. choose the lane
+2. choose the adoption mode
+3. define the project extension boundary
+4. define the local trust / hosting posture
+5. map risk to gate
+6. define minimum proof
+7. run one bounded round
+8. convert only reusable learning back into the framework
+
+---
+
+## How to map local approvals
+
+In a constrained environment, approvals often already exist.
+
+AletheIA should not try to replace them.
+It should help make them more legible.
+
+Typical mapping:
+
+- **task brief**
+  - what is changing and what is out of scope
+- **risk-to-gate mapping**
+  - what kind of review the change should require
+- **durable decision**
+  - what was consciously chosen or deferred
+- **handoff**
+  - what another boundary must know to continue safely
+- **validation**
+  - what proof is sufficient before closure in this lane
+
+This keeps the framework useful without pretending to become the whole approval system.
+
+---
+
+## Trust-boundary posture
+
+Constrained environments should define locally:
+
+- what data may leave the trust boundary
+- what model providers are acceptable
+- when local or self-hosted models are preferred
+- what tool classes are allowed
+- what actions require human gate regardless of confidence
+
+This posture should usually live in:
+
+- project extension materials
+- local model strategy
+- local tool policy
+
+not in the framework core.
+
+---
+
+## Tool and model restrictions
+
+Treat these as explicit local constraints.
+
+Examples:
+
+- allowed tools only in specific lanes
+- external model use only for non-sensitive tasks
+- sensitive tasks require local-only model posture
+- destructive actions require review regardless of model confidence
+
+What matters is that the restriction is visible and reviewable.
+It does not need to become framework truth.
+
+---
+
+## What not to do
+
+Do not:
+
+- roll out the framework across the whole organization at once
+- encode local enterprise rules into the public core
+- confuse “heavier review” with “more artifacts everywhere”
+- assume constrained environments need maximum ceremony in every lane
+- claim enterprise readiness before bounded proof exists
+
+---
+
+## Good signs
+
+Enterprise-oriented adoption is going well when:
+
+- the first lane stays bounded
+- local restrictions are explicit instead of implicit
+- the project extension boundary stays clear
+- risk-to-gate mapping is understandable
+- proof remains proportional
+- reusable learning can be extracted without carrying enterprise residue into the core


### PR DESCRIPTION
## Summary
- start the 1.1 enterprise-readiness / regulated adoption track with docs-first hardening
- add a constrained-adoption guide to the starter-pack
- add a restricted enterprise project-extension example and update public roadmap framing

## Validation
- bash scripts/check-governance.sh