### PR TITLE
Add local trust-boundary posture guidance

### DIFF
--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -190,3 +190,10 @@ This layer makes the current baseline more tangible through:
 - advisory-only model strategy by task shape, capability profile, reasoning depth, and trust / hosting posture
 
 It remains useful precisely because it stays smaller than the core.
+
+
+The active 1.1 track now also includes a stronger local trust-boundary posture through:
+
+- `docs/local-trust-boundary-posture.md`
+- `starter-pack/templates/local-trust-boundary-template.md`
+- `examples/project-extension/local-trust-boundary-mapping.md`

--- a/docs/enterprise-readiness-roadmap.md
+++ b/docs/enterprise-readiness-roadmap.md
@@ -188,6 +188,12 @@ Strengthen the language that local trust and hosting posture should be handled i
 
 not in the framework core.
 
+This step now begins with:
+
+- `docs/local-trust-boundary-posture.md`
+- `starter-pack/templates/local-trust-boundary-template.md`
+- `examples/project-extension/local-trust-boundary-mapping.md`
+
 ### Step 4 — pilot in a constrained environment
 
 Use a bounded, reviewable lane before claiming broader readiness.

--- a/docs/local-trust-boundary-posture.md
+++ b/docs/local-trust-boundary-posture.md
@@ -1,0 +1,162 @@
+# Local Trust-Boundary Posture
+
+## Goal
+
+This document explains how a real project should make its trust-boundary posture explicit **without** turning that posture into framework truth.
+
+In AletheIA, trust-boundary posture is usually a **project-extension concern**.
+
+That means the framework should teach the pattern,
+while the exact posture remains local.
+
+---
+
+## Why this matters
+
+Constrained environments often need explicit answers to questions such as:
+
+- what context may leave the trust boundary?
+- which models are acceptable for which data classes?
+- which tools are allowed in which lanes?
+- which actions require human review regardless of model confidence?
+
+If those answers remain implicit, then:
+
+- reviews become inconsistent
+- approvals become harder to explain
+- hosted vs local model choices become fuzzy
+- tool use may drift beyond what the team intended
+
+---
+
+## Core idea
+
+A local trust-boundary posture should define four things clearly:
+
+### 1. Data classes
+
+Examples:
+
+- public
+- internal
+- restricted
+- customer-sensitive
+- regulated
+
+The exact names may differ by project.
+What matters is that they are visible.
+
+### 2. Hosting posture
+
+Examples:
+
+- externally hosted models acceptable only for public or low-risk internal material
+- self-hosted or local runtime required for restricted material
+- no external tool calls in higher-risk lanes
+
+### 3. Tool posture
+
+Examples:
+
+- read tools broadly allowed
+- write tools allowed only in bounded lanes
+- outbound tools restricted by data class
+- destructive tools always human-gated
+
+### 4. Lane-specific review posture
+
+Examples:
+
+- normal bounded review
+- explicit local review before write
+- human approval required regardless of confidence
+- no execution, suggestion-only lane
+
+---
+
+## Recommended mapping sequence
+
+A practical local mapping sequence is:
+
+1. define data classes
+2. define hosting posture per class
+3. define tool allow / deny posture
+4. define human-gate rules
+5. bind the result to lane types or work slices
+6. record exceptions as durable local decisions
+
+This keeps the trust posture reviewable instead of anecdotal.
+
+---
+
+## Relationship to local model strategy
+
+A local trust-boundary posture should often be paired with:
+
+- `starter-pack/templates/project-model-strategy-template.md`
+
+Why:
+
+- model strategy says what the local fleet can do
+- trust-boundary posture says where each class of model is acceptable
+
+Those two things are related, but not identical.
+
+A project may have a powerful externally hosted model available and still forbid it for restricted work.
+That is why availability and allowability should remain separate.
+
+---
+
+## Relationship to risk-to-gate mapping
+
+A local trust-boundary posture should also be paired with:
+
+- `starter-pack/guides/risk-to-gate-mapping.md`
+
+Why:
+
+- trust posture shapes whether execution is allowed
+- risk-to-gate shapes how much review that execution requires
+
+The same task may therefore be:
+
+- allowed with a bounded hosted model for public material
+- allowed only with a local model for restricted material
+- or reduced to suggestion-only when neither posture is acceptable
+
+---
+
+## What belongs in local posture, not in the framework core
+
+Usually local posture should contain things such as:
+
+- data classes used by one organization
+- allowed providers
+- allowed hosting tiers
+- tool restrictions tied to one environment
+- lanes that require local approval regardless of confidence
+- explicit no-external-context rules
+
+Those may be rigorous.
+They just should not silently become universal AletheIA truth.
+
+---
+
+## Good signs
+
+A local trust-boundary posture is healthy when:
+
+- reviewers can explain why a model or tool was acceptable in that lane
+- hosted versus local choices are explicit
+- exceptions are visible instead of improvised
+- the framework remains provider-agnostic even though the project is not
+- the local rules can change without forcing a core rewrite
+
+---
+
+## Suggested next reading
+
+- `docs/enterprise-readiness-roadmap.md`
+- `starter-pack/guides/enterprise-adoption-considerations.md`
+- `starter-pack/templates/local-trust-boundary-template.md`
+- `examples/project-extension/local-trust-boundary-mapping.md`

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -219,7 +219,7 @@ Current low-regret hardening now begins with:
 
 Current backlog still includes:
 
-- stronger local trust-boundary posture for constrained environments
+- stronger local trust-boundary posture for constrained environments (now started through docs/template/example)
 - bounded pilot evidence from a constrained environment
 - eventual regulated-domain guidance only if later justified
 

--- a/examples/project-extension/local-trust-boundary-mapping.md
+++ b/examples/project-extension/local-trust-boundary-mapping.md
@@ -1,0 +1,70 @@
+# Local Trust-Boundary Mapping Example
+
+## Goal
+
+This example shows a small local mapping for a constrained project.
+It demonstrates posture, not policy.
+
+---
+
+## Example posture
+
+### Data classes
+
+- public
+- internal
+- restricted
+
+### Model posture
+
+- hosted models allowed for public work
+- hosted models allowed for low-risk internal planning only
+- local runtime required for restricted context
+
+### Tool posture
+
+- read tools broadly allowed in bounded lanes
+- write tools restricted to approved execution lanes
+- outbound tools disabled for restricted context
+- destructive tools always require human gate
+
+---
+
+## Example lane mapping
+
+### Lane A — public planning
+
+- data class: public
+- hosted model allowed: yes
+- read tools allowed: yes
+- write tools allowed: no
+- review posture: bounded self-check
+
+### Lane B — internal review
+
+- data class: internal
+- hosted model allowed: maybe, if local posture permits
+- read tools allowed: yes
+- write tools allowed: only if the lane explicitly allows them
+- review posture: local review may be required depending on risk
+
+### Lane C — restricted execution
+
+- data class: restricted
+- hosted model allowed: no
+- local runtime required: yes
+- outbound tools allowed: no
+- human approval required: yes
+
+---
+
+## Why this example matters
+
+This kind of mapping makes it easier to answer:
+
+- why a given model was acceptable or not
+- why a tool was blocked or allowed
+- why the lane was suggestion-only instead of execution-capable
+
+That clarity is useful in constrained environments,
+but it still belongs in the local layer rather than the framework core.

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -105,3 +105,12 @@ If you are applying AletheIA in an environment with heavier approvals, stricter 
 - `docs/enterprise-readiness-roadmap.md`
 - `starter-pack/guides/enterprise-adoption-considerations.md`
 - `examples/project-extension/restricted-enterprise-context.md`
+
+
+## 1.1 local trust-boundary posture
+
+If your constrained environment needs an explicit local trust and hosting posture, read:
+
+- `docs/local-trust-boundary-posture.md`
+- `starter-pack/templates/local-trust-boundary-template.md`
+- `examples/project-extension/local-trust-boundary-mapping.md`

--- a/starter-pack/templates/local-trust-boundary-template.md
+++ b/starter-pack/templates/local-trust-boundary-template.md
@@ -1,0 +1,89 @@
+# Local Trust-Boundary Template
+
+Use this template when a project needs to make local trust, hosting, and tool restrictions explicit.
+
+This template is **local by design**.
+It should not be copied back into framework truth unless a real pattern clearly generalizes.
+
+---
+
+## Project identity
+
+### Project name
+
+### Team or org scope
+
+### Last updated
+
+---
+
+## Data classes
+
+List the data classes that matter locally.
+
+| Data class | Short description | Example content | May leave trust boundary? |
+|---|---|---|---|
+| Public | Example | marketing copy, public docs | yes |
+| Internal | Example | internal planning notes | depends on project rule |
+| Restricted | Example | customer or regulated material | usually no |
+
+---
+
+## Model hosting posture
+
+| Model / runtime class | Hosting posture | Allowed data classes | Not allowed for | Notes |
+|---|---|---|---|---|
+| Externally hosted premium | hosted | public, maybe internal | restricted / regulated | Example only |
+| Local runtime | self-hosted | public, internal, restricted | depends on capability limits | Example only |
+
+---
+
+## Tool posture
+
+| Tool class | Default posture | Allowed lanes | Human gate required? | Notes |
+|---|---|---|---|---|
+| Read tools | allowed | bounded reading / review | no | Example only |
+| Write tools | restricted | approved execution lanes | often yes | Example only |
+| Outbound tools | tightly restricted | specific low-risk lanes only | maybe | Example only |
+| Destructive tools | exceptional | explicit high-control lanes only | yes | Example only |
+
+---
+
+## Lane mapping
+
+Describe how the posture changes by lane.
+
+| Lane / slice type | Data class | Allowed model posture | Allowed tools | Review posture |
+|---|---|---|---|---|
+| Planning | public / internal | hosted or local | read-only | bounded review |
+| Sensitive execution | restricted | local only | tightly restricted | human approval |
+
+---
+
+## Human-gate rules
+
+Examples:
+
+- destructive actions always require explicit human approval
+- restricted-context write actions never execute without local review
+- model confidence never overrides a blocked trust posture
+
+---
+
+## Exceptions and durable local decisions
+
+Record exceptions explicitly.
+
+Examples:
+
+- one externally hosted model may be used for a specific public-only lane
+- one tool is temporarily disabled pending review
+- one integration requires manual confirmation until verification improves
+
+---
+
+## Notes
+
+Keep this template local.
+It should describe the real trust posture of the project,
+not the idealized posture of the framework.


### PR DESCRIPTION
## Summary
- add local trust-boundary posture guidance for the 1.1 constrained-adoption track
- add a reusable local trust-boundary template and mapping example
- connect the new material back into the enterprise-readiness roadmap and public overview

## Validation
- bash scripts/check-governance.sh