### PR TITLE
Add constrained adoption pilot guidance

### DIFF
--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -197,3 +197,9 @@ The active 1.1 track now also includes a stronger local trust-boundary posture t
 - `docs/local-trust-boundary-posture.md`
 - `starter-pack/templates/local-trust-boundary-template.md`
 - `examples/project-extension/local-trust-boundary-mapping.md`
+
+
+The active 1.1 track now also includes bounded pilot-evidence guidance for constrained adoption through:
+
+- `docs/constrained-adoption-pilot.md`
+- `examples/pilot-conversion/constrained-adoption-bounded-validation.md`

--- a/docs/constrained-adoption-pilot.md
+++ b/docs/constrained-adoption-pilot.md
@@ -1,0 +1,141 @@
+# Constrained Adoption Pilot
+
+## Goal
+
+This document explains how to run a **bounded pilot** for AletheIA in a constrained or regulated environment.
+
+The purpose is not broad rollout.
+The purpose is to create a reviewable proof chain that answers:
+
+- can the framework operate inside this trust posture?
+- can the local extension carry the constraints cleanly?
+- can the team explain why a lane was allowed, gated, or reduced to suggestion-only?
+
+---
+
+## Why bounded pilot evidence matters
+
+In constrained environments, adoption claims should not begin from theory alone.
+
+They should begin from a lane where the team can review:
+
+- local trust-boundary posture
+- local review requirements
+- local tool restrictions
+- minimum proof before closure
+- what was reusable versus what stayed local
+
+Without that bounded evidence, enterprise-readiness remains mostly rhetorical.
+
+---
+
+## Recommended pilot shape
+
+A constrained pilot should begin with:
+
+- one lane
+- one dominant ownership boundary
+- one local trust posture
+- one explicit risk-to-gate mapping
+- one bounded proof chain
+
+A good first lane is usually:
+
+- visible enough to teach something
+- reversible enough to stay safe
+- constrained enough to avoid broad rollout pressure
+- already carrying meaningful review expectations
+
+---
+
+## What the pilot should make explicit
+
+A healthy constrained pilot should make at least five things explicit.
+
+### 1. Local trust posture
+
+State clearly:
+
+- what data class the lane handles
+- what hosting posture is allowed
+- what tool classes are allowed or blocked
+- what actions require human gate regardless of confidence
+
+### 2. Lane boundary
+
+State clearly:
+
+- what enters this lane now
+- what remains outside
+- what would count as accidental scope inflation
+
+### 3. Risk-to-gate mapping
+
+State clearly:
+
+- what kind of review the lane requires
+- whether the lane is suggestion-only, bounded execution, or human-gated execution
+- what would escalate the lane further
+
+### 4. Minimum proof
+
+State clearly:
+
+- what validation is sufficient before closure
+- what review artifact is expected
+- what would count as inadequate proof in this context
+
+### 5. Conversion boundary
+
+State clearly:
+
+- what learning might generalize back into AletheIA
+- what remains enterprise-local and should not enter the framework core
+
+---
+
+## Recommended output set
+
+A bounded constrained pilot usually benefits from these artifacts:
+
+- **task brief**
+- **local trust-boundary posture**
+- **risk-to-gate mapping**
+- **durable local decision** when something meaningful was chosen
+- **handoff** if another boundary must continue the work
+- **pilot review** describing what was proved and what stayed local
+
+That set is usually enough to create reviewability without inventing a new framework layer.
+
+---
+
+## What success looks like
+
+A constrained pilot is going well when:
+
+- the lane stays bounded
+- the trust posture is explicit
+- reviewers can explain why the lane was allowed or gated
+- proof stays proportional
+- reusable learning is extractable without carrying local residue into the framework core
+
+---
+
+## What failure looks like
+
+The pilot is going poorly when:
+
+- the team tries to roll out broadly before one lane is legible
+- enterprise-local rules leak into framework truth
+- trust posture remains implicit
+- proof is weaker than the lane's review demands
+- the pilot teaches nothing reusable and still expands anyway
+
+---
+
+## Suggested next reading
+
+- `docs/enterprise-readiness-roadmap.md`
+- `docs/local-trust-boundary-posture.md`
+- `starter-pack/guides/enterprise-adoption-considerations.md`
+- `examples/pilot-conversion/constrained-adoption-bounded-validation.md`

--- a/docs/enterprise-readiness-roadmap.md
+++ b/docs/enterprise-readiness-roadmap.md
@@ -205,6 +205,11 @@ That means:
 - one proof chain
 - one conversion loop back into the framework if it teaches something reusable
 
+This step now begins with:
+
+- `docs/constrained-adoption-pilot.md`
+- `examples/pilot-conversion/constrained-adoption-bounded-validation.md`
+
 ---
 
 ## Recommended boundaries for 1.1

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -220,7 +220,7 @@ Current low-regret hardening now begins with:
 Current backlog still includes:
 
 - stronger local trust-boundary posture for constrained environments (now started through docs/template/example)
-- bounded pilot evidence from a constrained environment
+- bounded pilot evidence from a constrained environment (now started through docs/example)
 - eventual regulated-domain guidance only if later justified
 
 ### 1.2 — Pilot expansion / stronger real-world validation

--- a/examples/pilot-conversion/constrained-adoption-bounded-validation.md
+++ b/examples/pilot-conversion/constrained-adoption-bounded-validation.md
@@ -1,0 +1,76 @@
+# Constrained Adoption — Bounded Validation to Framework Learning
+
+## Pilot evidence shape
+
+A constrained-environment pilot should usually prove things in this order:
+
+1. the lane is bounded clearly enough to review
+2. the local trust-boundary posture is explicit
+3. the risk-to-gate mapping is understandable
+4. the validation is proportional to the lane's review posture
+5. the team can distinguish reusable learning from enterprise-local residue
+
+This matters because constrained adoption is not only about whether the lane “worked.”
+It is also about whether the lane stayed governable under local restrictions.
+
+---
+
+## What becomes visible
+
+A bounded constrained pilot should make visible:
+
+- whether hosted versus local model choices are explainable
+- whether tool restrictions are explicit enough
+- whether human-gate rules are consistent with the lane
+- whether local review pressure is causing useful discipline or unnecessary artifact inflation
+
+---
+
+## What may become reusable
+
+The reusable lesson is usually lighter than the local implementation.
+
+Examples of reusable learning:
+
+- clearer project-extension language
+- stronger trust-boundary posture guidance
+- better mapping from lane type to review posture
+- stronger examples showing what belongs in the local layer
+
+Examples of non-reusable residue:
+
+- one organization's exact approval matrix
+- one enterprise's provider allowlist
+- one team's branch conventions
+- one product's compliance-specific checklist
+
+---
+
+## What should change in AletheIA if the pilot succeeds
+
+Usually the right conversion is:
+
+- docs
+- starter-pack guidance
+- local template refinement
+- one more reviewable example
+
+Usually the right conversion is **not**:
+
+- core schema expansion
+- framework-level enterprise policy engine
+- universal regulated preset claims
+- mandatory heavier ceremony for all adopters
+
+---
+
+## Why this matters for 1.1
+
+This is the kind of evidence that can justify stronger enterprise-readiness posture in AletheIA 1.1.
+
+It strengthens the framework only when:
+
+- the lane was real
+- the posture was explicit
+- the proof was reviewable
+- the extracted learning is still reusable outside that one environment

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -114,3 +114,11 @@ If your constrained environment needs an explicit local trust and hosting postur
 - `docs/local-trust-boundary-posture.md`
 - `starter-pack/templates/local-trust-boundary-template.md`
 - `examples/project-extension/local-trust-boundary-mapping.md`
+
+
+## 1.1 bounded constrained pilot evidence
+
+If you want to run a bounded pilot in a constrained environment before broader rollout, read:
+
+- `docs/constrained-adoption-pilot.md`
+- `examples/pilot-conversion/constrained-adoption-bounded-validation.md`


### PR DESCRIPTION
## Summary
- add bounded constrained-pilot guidance for the 1.1 enterprise-readiness track
- add a pilot-conversion example for constrained adoption evidence
- connect the new material back into the 1.1 roadmap and overview

## Validation
- bash scripts/check-governance.sh