### PR TITLE
Add constrained pilot review checklist

### DIFF
--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -202,4 +202,6 @@ The active 1.1 track now also includes a stronger local trust-boundary posture t
 The active 1.1 track now also includes bounded pilot-evidence guidance for constrained adoption through:
 
 - `docs/constrained-adoption-pilot.md`
+- `docs/constrained-pilot-review-checklist.md`
+- `starter-pack/templates/constrained-pilot-review-template.md`
 - `examples/pilot-conversion/constrained-adoption-bounded-validation.md`

--- a/docs/constrained-pilot-review-checklist.md
+++ b/docs/constrained-pilot-review-checklist.md
@@ -1,0 +1,108 @@
+# Constrained Pilot Review Checklist
+
+## Goal
+
+This checklist helps teams review a **bounded constrained-adoption pilot** before they convert the result into a broader local pattern, a reusable example, or a framework learning.
+
+It is intentionally light.
+The goal is not to create a new governance layer.
+The goal is to make sure a constrained pilot is:
+
+- still bounded
+- still reviewable
+- explicit about local residue
+- honest about what actually became reusable
+
+---
+
+## When to use this checklist
+
+Use it after a constrained pilot has produced at least one meaningful proof chain and before you do any of the following:
+
+- expand the lane
+- treat the pilot as a broader adoption signal
+- convert the pilot into reusable local guidance
+- suggest that some learning belongs back in AletheIA
+
+Do **not** use this checklist as a gate for every normal task.
+It is for pilot review and conversion, not routine work execution.
+
+---
+
+## Checklist
+
+### 1. Boundary remained bounded
+
+Confirm that:
+
+- the lane stayed narrow enough to review clearly
+- no adjacent lane was silently pulled in
+- local restrictions remained explicit
+- the pilot did not turn into rollout by inertia
+
+### 2. Trust posture remained explicit
+
+Confirm that reviewers can state:
+
+- what data class the pilot touched
+- what hosting posture was assumed
+- what tools were allowed or blocked
+- what actions still required human gate
+
+### 3. Risk-to-gate posture remained proportional
+
+Confirm that:
+
+- the lane used a review posture that matched its risk
+- proof was not weaker than the lane's review demand
+- escalation triggers were visible
+- the team can explain why the pilot remained suggestion-only, bounded execution, or human-gated execution
+
+### 4. Proof was sufficient for the lane
+
+Confirm that:
+
+- minimum validation was actually present
+- the review artifacts are readable by another boundary
+- the closure is auditable enough for the environment
+- unresolved ambiguity is called out instead of buried
+
+### 5. Reusable learning is separated from local residue
+
+Confirm that:
+
+- reusable learning is identifiable in plain language
+- enterprise-local rules are not being promoted into framework truth
+- project-local approval residue is clearly marked as local
+- the team can name what should stay out of AletheIA
+
+### 6. Expansion has a real trigger
+
+Confirm that:
+
+- any proposed next step is tied to a real trigger
+- expansion is not happening just because the pilot succeeded once
+- the next lane, if any, is clearly justified
+- stopping is still considered a valid outcome
+
+---
+
+## Healthy review output
+
+A short pilot review is usually enough if it can answer:
+
+- what was actually proved
+- what stayed local
+- what became a reusable local pattern
+- what might be reusable for the framework
+- whether expansion is justified now, later, or not at all
+
+---
+
+## Related reading
+
+- `docs/constrained-adoption-pilot.md`
+- `docs/local-trust-boundary-posture.md`
+- `docs/enterprise-readiness-roadmap.md`
+- `starter-pack/templates/local-trust-boundary-template.md`
+- `starter-pack/templates/constrained-pilot-review-template.md`

--- a/docs/enterprise-readiness-roadmap.md
+++ b/docs/enterprise-readiness-roadmap.md
@@ -209,6 +209,8 @@ This step now begins with:
 
 - `docs/constrained-adoption-pilot.md`
 - `examples/pilot-conversion/constrained-adoption-bounded-validation.md`
+- `docs/constrained-pilot-review-checklist.md`
+- `starter-pack/templates/constrained-pilot-review-template.md`
 
 ---
 

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -121,4 +121,6 @@ If your constrained environment needs an explicit local trust and hosting postur
 If you want to run a bounded pilot in a constrained environment before broader rollout, read:
 
 - `docs/constrained-adoption-pilot.md`
+- `docs/constrained-pilot-review-checklist.md`
+- `starter-pack/templates/constrained-pilot-review-template.md`
 - `examples/pilot-conversion/constrained-adoption-bounded-validation.md`

--- a/starter-pack/templates/constrained-pilot-review-template.md
+++ b/starter-pack/templates/constrained-pilot-review-template.md
@@ -1,0 +1,24 @@
+# Constrained Pilot Review
+
+## Pilot scope
+- Lane:
+- Local trust posture reference:
+- Review posture:
+- Proof artifacts:
+
+## What was proved
+- 
+
+## What remained local
+- 
+
+## Reusable local pattern
+- 
+
+## Candidate reusable framework learning
+- 
+
+## Expansion decision
+- Expand now / Later / Not now
+- Reason:
+- Trigger required for next expansion:


### PR DESCRIPTION
## Summary\n- add a light constrained-pilot review checklist for AletheIA 1.1\n- add a starter-pack template for recording constrained pilot review outcomes\n- wire the new review surfaces into the roadmap, overview, and starter-pack docs\n\n## Validation\n- bash scripts/check-governance.sh\n