### PR TITLE
Add resource-aware operations roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- add a Resource-Aware Operations roadmap as the queued 1.2+ track
+- reposition the post-1.0 roadmap so 1.1 stays constrained-adoption hardening while 1.2 becomes operationalization
+- defer benchmark and learning ambitions into later 1.3+ / 1.4+ tracks instead of treating them as active work now
+
 ## 1.0.0 — 2026-04-09
 
 First public stable baseline of AletheIA.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ AletheIA 1.0 does **not** claim:
 Those remain part of the post-1.0 roadmap.
 
 The first post-1.0 track now starts with enterprise-oriented hardening for constrained and regulated adoption, but still without claiming enterprise-ready packaging by default.
+The next queued post-1.0 track is resource-aware operations: a docs-first operationalization lane for observability, proportional context/capability allocation, and advisory runtime/agent fit.
 
 See also:
 
@@ -182,47 +183,48 @@ See also:
 If this is your first time here, start with:
 
 1. `docs/getting-started.md`
-2. `docs/00-overview.md`
-3. `docs/roadmap-alpha.md`
-4. `docs/release-1.0-readiness.md`
-5. `docs/enterprise-readiness-roadmap.md`
-5. `docs/architecture.md`
-6. `docs/governance.md`
-7. `docs/token-policy.md`
-8. `starter-pack/guides/model-strategy-by-task.md`
-9. `docs/durable-decisions.md`
-10. `docs/enforcement-boundaries.md`
-11. `docs/quality.md`
-12. `docs/self-application.md`
-13. `docs/pilot-crisis-monitor.md`
-14. `docs/pilot-conversion.md`
-15. `examples/pilot-conversion/crisis-monitor-real-world-validation.md`
-16. `docs/project-extension-pattern.md`
-17. `docs/apply-to-existing-project.md`
-18. `CONTRIBUTING.md`
-19. `starter-pack/README.md`
-20. `starter-pack/templates/project-extension-template.md`
-21. `starter-pack/templates/project-model-strategy-template.md`
-22. `docs/agent-handoffs.md`
-23. `starter-pack/guides/agent-handoff-generation.md`
-24. `starter-pack/templates/agent-handoff-template.md`
-25. `docs/project-handoff-conventions.md`
-26. `docs/handoff-capture-pattern.md`
-27. `docs/work-slice-pattern.md`
-28. `starter-pack/templates/work-slice-template.md`
-29. `starter-pack/guides/risk-to-gate-mapping.md`
-30. `docs/structured-risk-inference.md`
-31. `starter-pack/templates/inference-artifact-template.md`
-32. `starter-pack/guides/inference-trigger-guidance.md`
-33. `starter-pack/guides/inference-artifact-generation.md`
-34. `docs/inference-pilot-scenarios.md`
-35. `examples/work-slices/standard-slice/README.md`
-36. `examples/handoffs/compact-reviewable-handoff.md`
-37. `examples/handoffs/high-stakes-handoff.md`
-38. `examples/handoffs/multi-boundary-continuity.md`
-39. `examples/structured-risk-inference/README.md`
-40. `examples/distribution/constrained-adoption-mapping.md`
-41. `examples/delivery/reviewable-generated-bundle.md`
+1. `docs/00-overview.md`
+1. `docs/roadmap-alpha.md`
+1. `docs/release-1.0-readiness.md`
+1. `docs/enterprise-readiness-roadmap.md`
+1. `docs/resource-aware-operations-roadmap.md`
+1. `docs/architecture.md`
+1. `docs/governance.md`
+1. `docs/token-policy.md`
+1. `starter-pack/guides/model-strategy-by-task.md`
+1. `docs/durable-decisions.md`
+1. `docs/enforcement-boundaries.md`
+1. `docs/quality.md`
+1. `docs/self-application.md`
+1. `docs/pilot-crisis-monitor.md`
+1. `docs/pilot-conversion.md`
+1. `examples/pilot-conversion/crisis-monitor-real-world-validation.md`
+1. `docs/project-extension-pattern.md`
+1. `docs/apply-to-existing-project.md`
+1. `CONTRIBUTING.md`
+1. `starter-pack/README.md`
+1. `starter-pack/templates/project-extension-template.md`
+1. `starter-pack/templates/project-model-strategy-template.md`
+1. `docs/agent-handoffs.md`
+1. `starter-pack/guides/agent-handoff-generation.md`
+1. `starter-pack/templates/agent-handoff-template.md`
+1. `docs/project-handoff-conventions.md`
+1. `docs/handoff-capture-pattern.md`
+1. `docs/work-slice-pattern.md`
+1. `starter-pack/templates/work-slice-template.md`
+1. `starter-pack/guides/risk-to-gate-mapping.md`
+1. `docs/structured-risk-inference.md`
+1. `starter-pack/templates/inference-artifact-template.md`
+1. `starter-pack/guides/inference-trigger-guidance.md`
+1. `starter-pack/guides/inference-artifact-generation.md`
+1. `docs/inference-pilot-scenarios.md`
+1. `examples/work-slices/standard-slice/README.md`
+1. `examples/handoffs/compact-reviewable-handoff.md`
+1. `examples/handoffs/high-stakes-handoff.md`
+1. `examples/handoffs/multi-boundary-continuity.md`
+1. `examples/structured-risk-inference/README.md`
+1. `examples/distribution/constrained-adoption-mapping.md`
+1. `examples/delivery/reviewable-generated-bundle.md`
 
 ---
 
@@ -232,9 +234,9 @@ After the 1.0 baseline, the roadmap shifts into **1.x evolution**.
 
 The next planned lanes are:
 
-- **1.1** — enterprise-readiness / regulated adoption
-- **1.2** — pilot expansion / stronger real-world validation
-- **1.3** — distribution & delivery hardening
-- **1.4+** — domain governance packs hardening
+- **1.1** — enterprise-readiness / constrained adoption hardening
+- **1.2** — resource-aware operations
+- **1.3+** — benchmark and comparative evaluation
+- **1.4+** — learning layer, adaptive orchestration, and later domain governance hardening
 
 Those tracks remain valid, but they are intentionally post-baseline work.

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -50,16 +50,17 @@ That means the repository now distinguishes between:
   - Alpha 6
   - Alpha 7
 - **post-1.0 evolution tracks**
-  - enterprise-readiness / regulated adoption (now the active 1.1 hardening track)
-  - stronger pilot expansion
-  - broader delivery hardening
-  - domain governance packs hardening
+  - enterprise-readiness / constrained adoption (the active 1.1 hardening track)
+  - resource-aware operations (the queued 1.2 operationalization track)
+  - benchmark and comparative evaluation
+  - learning layer, adaptive orchestration, and later domain governance hardening
 
 The roadmap and release gate are now read together through:
 
 - `docs/roadmap-alpha.md`
 - `docs/release-1.0-readiness.md`
 - `docs/enterprise-readiness-roadmap.md`
+- `docs/resource-aware-operations-roadmap.md`
 - `CHANGELOG.md`
 
 ---

--- a/docs/enterprise-readiness-roadmap.md
+++ b/docs/enterprise-readiness-roadmap.md
@@ -254,3 +254,14 @@ This track currently begins with:
 
 These are meant to improve adoption posture first.
 They are not meant to close the whole enterprise-readiness track.
+
+## What follows 1.1
+
+This track should stay focused on constrained adoption and local trust posture.
+It should not become the place where AletheIA tries to solve broader resource-aware operations all at once.
+
+The next queued track after this one is:
+
+- `docs/resource-aware-operations-roadmap.md`
+
+That later track should build on the 1.1 posture work, but it should solve a different problem: making context and resource use more observable, comparable, and reviewable across real runtimes and agents.

--- a/docs/resource-aware-operations-roadmap.md
+++ b/docs/resource-aware-operations-roadmap.md
@@ -1,0 +1,258 @@
+# Resource-Aware Operations Roadmap
+
+## Why this is the 1.2 focus
+
+AletheIA 1.1 is already doing the right next job:
+
+- constrained adoption guidance
+- local trust-boundary posture
+- bounded pilot evidence for heavier environments
+
+The next question is different.
+
+It is no longer only:
+
+- how should the framework enter constrained environments safely?
+
+It becomes:
+
+- how should the framework make context and resource use more observable, comparable, and actionable across real agents and runtimes without inflating the core?
+
+That is the purpose of the 1.2 track.
+
+This track should be read as **resource-aware operations**, not as token optimization in disguise.
+
+---
+
+## What 1.2 builds on instead of replacing
+
+The 1.2 track should explicitly reuse what the repository already established.
+
+This includes:
+
+- `docs/token-policy.md`
+- `docs/agent-handoffs.md`
+- `docs/handoff-capture-pattern.md`
+- `docs/work-slice-pattern.md`
+- `starter-pack/guides/risk-to-gate-mapping.md`
+- `starter-pack/guides/model-strategy-by-task.md`
+- `docs/project-extension-pattern.md`
+- `docs/enterprise-readiness-roadmap.md`
+- `docs/local-trust-boundary-posture.md`
+
+The goal is not to restate these as fresh gaps.
+The goal is to operationalize them more concretely.
+
+---
+
+## What resource-aware means here
+
+Resource-aware operations should include proportional handling of:
+
+- context size
+- cold boot cost
+- restart and handoff weight
+- retry waste
+- slice expansion
+- runtime / agent fit
+- human review effort
+- optional time and cost signals
+
+This should remain:
+
+- vendor-agnostic
+- advisory-first
+- reviewable
+- smaller than a full orchestration platform
+
+---
+
+## Recommended implementation order
+
+### Phase A — observability first
+
+Start with the measurement spine:
+
+- context expansion
+- cold boot size
+- handoff size and inflation
+- retry patterns
+- slice cost proxies
+- basic human-review effort signals
+- runtime / agent used per slice
+
+Expected outputs:
+
+- **Context / Resource Telemetry Spec**
+- **minimal slice telemetry model**
+- **Waste Heuristics guide**
+
+### Phase B — progressive policy signals
+
+Turn existing guidance into light operational signals:
+
+- warnings
+- thresholds
+- expansion reason required
+- retry-waste hints
+- handoff-inflation hints
+- task-shape versus runtime mismatch hints
+
+Important boundary:
+
+Start advisory-only.
+Do not begin with rigid enforcement.
+
+Expected outputs:
+
+- **Progressive Policy Signals guide**
+- lightweight review examples of healthy versus unhealthy signals
+
+### Phase C — runtime adapter contract
+
+Only after the signals are legible should the framework define a runtime-facing contract.
+
+Keep the contract minimal and provider-agnostic.
+It should cover:
+
+- slice metadata
+- context budget metadata
+- expansion reason
+- handoff metadata
+- retry metadata
+- runtime / agent identity
+- optional time / cost fields
+
+Expected outputs:
+
+- **Runtime Adapter Contract**
+- one example adapter shape
+- one or two local runtime examples
+
+### Phase D — advisory multi-agent decision layer
+
+The framework may then publish an advisory layer for choosing between agents and runtimes.
+
+This should remain:
+
+- a decision guide
+- an advisory matrix
+- an example policy surface
+
+It should not become rigid core truth.
+
+Expected outputs:
+
+- **Agent / Runtime Decision Guide**
+- example decision matrix by task shape and risk posture
+
+### Phase E — workflow guide and readiness layer
+
+Only after observability and adapter shape exist should AletheIA strengthen workflow guidance with:
+
+- workflow guide layer
+- planning depth profiles
+- readiness gates
+
+Recommended profile shapes:
+
+- `Lite`
+- `Standard`
+- `High-Assurance`
+
+Recommended gate types:
+
+- context minimum exists
+- decision is clear enough
+- risk is mapped enough
+- handoff is usable enough
+- runtime / agent fit is acceptable enough
+
+Expected outputs:
+
+- **Planning Depth Profiles**
+- **Readiness Gates Spec**
+- lightweight workflow guide examples
+
+### Phase F — examples before learning
+
+Before any benchmark or learning ambition, the framework should close the loop through:
+
+- concrete examples
+- constrained / local examples
+- comparative review examples
+- one bounded real pilot conversion loop
+
+The purpose is to prove that the operational surfaces help in real use before they become a bigger system.
+
+---
+
+## What this track explicitly defers
+
+### 1.3+ — benchmark and comparative evaluation
+
+Benchmarking should wait until there is enough telemetry and adapter shape to compare real slices meaningfully.
+
+### 1.4+ — learning layer and adaptive orchestration
+
+Learning should wait until there is:
+
+- comparable telemetry
+- useful review signals
+- enough repeated evidence
+- a benchmark baseline worth optimizing against
+
+### Also not in scope now
+
+- vendor-specific model policy in the core
+- rigid persona catalogs from other frameworks
+- full delivery lifecycle orchestration
+- auto-evolution or RL-style behavior shaping in the core framework
+
+---
+
+## Reference posture
+
+This track may borrow useful ideas from references such as BMAD, Memento-Skills, and ART, but only selectively.
+
+Absorb now:
+
+- workflow guidance
+- readiness shaping
+- planning depth profiles
+- stronger operational surface design
+
+Do not absorb now:
+
+- rigid persona systems as core truth
+- full lifecycle delivery packaging
+- active autoevolution in the framework core
+- training-driven orchestration before measurement maturity
+
+---
+
+## Relationship to Adaptative Skills
+
+AletheIA 1.2 should stay complementary to the broader ecosystem.
+
+- **AletheIA** remains the macro layer for readiness, gates, continuity, and resource-aware operations
+- **Adaptative Skills** remains the micro layer for specialist execution
+- **Evolution Layer** remains the governed improvement path for the skill library
+- **Efficiency Layer** remains the transversal micro discipline for chunking, checkpointing, handoffs, and related operational fluency
+
+This means AletheIA should not absorb the skill library.
+It should make macro operating posture more explicit around it.
+
+---
+
+## Success condition for the 1.2 track
+
+This track is working if AletheIA can eventually help teams answer questions such as:
+
+- where is context inflating?
+- where are handoffs heavier than they should be?
+- where is retry behavior wasteful?
+- where is the chosen runtime stronger or weaker than the task really needs?
+- where is human review effort too high for the value returned?
+
+without becoming a heavyweight orchestration product.

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -223,29 +223,38 @@ Current backlog still includes:
 - bounded pilot evidence from a constrained environment (now started through docs/example)
 - eventual regulated-domain guidance only if later justified
 
-### 1.2 — Pilot expansion / stronger real-world validation
+### 1.2 — Resource-aware operations
+
+This is the next queued operationalization track after the current 1.1 hardening pass.
 
 Planned backlog includes:
 
-- expansion beyond the strongest current pilot lane
-- more real-world comparisons between project extensions
-- stronger pilot-to-framework conversion evidence
+- context and resource telemetry surfaces
+- lightweight waste heuristics and policy signals
+- minimal runtime adapter contract examples
+- advisory runtime / agent decision guidance
+- planning depth profiles and readiness gates only after observability is legible
 
-### 1.3 — Distribution & delivery hardening
+Anchor roadmap artifact:
 
-Planned backlog includes:
+- `docs/resource-aware-operations-roadmap.md`
 
-- broader distribution hardening beyond the 1.0 baseline
-- stronger preset and adapter tangibility after the baseline
-- additional delivery-layer material once the baseline is already stable
-
-### 1.4+ — Domain governance packs hardening
+### 1.3+ — Benchmark and comparative evaluation
 
 Planned backlog includes:
 
-- stronger domain governance packs
-- reusable trust-boundary and prompt-injection packs
-- heavier Alpha 7 tooling only after later priorities justify it
+- comparative review of slices once telemetry exists
+- stronger benchmark material only after adapter and policy surfaces are real
+- cross-runtime or cross-project evaluation without collapsing into vendor truth
+
+### 1.4+ — Learning layer, adaptive orchestration, and later domain governance hardening
+
+Planned backlog includes:
+
+- learning-layer exploration only after measurement maturity
+- adaptive orchestration only after comparable signals exist
+- stronger domain governance packs later, not as a blocker for 1.2
+- reusable trust-boundary and prompt-injection packs when later priorities justify them
 
 ---
 

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -124,3 +124,12 @@ If you want to run a bounded pilot in a constrained environment before broader r
 - `docs/constrained-pilot-review-checklist.md`
 - `starter-pack/templates/constrained-pilot-review-template.md`
 - `examples/pilot-conversion/constrained-adoption-bounded-validation.md`
+
+## Queued 1.2 operationalization track
+
+The next queued post-1.0 track is resource-aware operations.
+Read:
+
+- `docs/resource-aware-operations-roadmap.md`
+
+This future track should build on the current starter-pack surfaces rather than replace them.


### PR DESCRIPTION
## Summary
- add a dedicated Resource-Aware Operations roadmap for the queued 1.2+ AletheIA track
- reposition the post-1.0 roadmap so 1.1 remains constrained-adoption hardening while 1.2 becomes operationalization
- defer benchmark and learning ambitions into later tracks instead of treating them as active work now

## Testing
- bash scripts/check-governance.sh
- git diff --check