### PR TITLE
Add resource telemetry docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- define the first 1.2 telemetry surfaces for resource-aware operations
+- start the 1.2 track with context/resource telemetry, slice telemetry, and waste heuristics docs
 - add a Resource-Aware Operations roadmap as the queued 1.2+ track
 - reposition the post-1.0 roadmap so 1.1 stays constrained-adoption hardening while 1.2 becomes operationalization
 - defer benchmark and learning ambitions into later 1.3+ / 1.4+ tracks instead of treating them as active work now

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Those remain part of the post-1.0 roadmap.
 
 The first post-1.0 track now starts with enterprise-oriented hardening for constrained and regulated adoption, but still without claiming enterprise-ready packaging by default.
 The next queued post-1.0 track is resource-aware operations: a docs-first operationalization lane for observability, proportional context/capability allocation, and advisory runtime/agent fit.
+That 1.2 track now begins with telemetry and waste-reading surfaces rather than adapter or learning-layer work.
 
 See also:
 
@@ -188,6 +189,9 @@ If this is your first time here, start with:
 1. `docs/release-1.0-readiness.md`
 1. `docs/enterprise-readiness-roadmap.md`
 1. `docs/resource-aware-operations-roadmap.md`
+1. `docs/context-resource-telemetry-spec.md`
+1. `docs/slice-telemetry-model.md`
+1. `docs/waste-heuristics.md`
 1. `docs/architecture.md`
 1. `docs/governance.md`
 1. `docs/token-policy.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -206,3 +206,11 @@ The active 1.1 track now also includes bounded pilot-evidence guidance for const
 - `docs/constrained-pilot-review-checklist.md`
 - `starter-pack/templates/constrained-pilot-review-template.md`
 - `examples/pilot-conversion/constrained-adoption-bounded-validation.md`
+
+The queued 1.2 track now begins with early observability surfaces through:
+
+- `docs/context-resource-telemetry-spec.md`
+- `docs/slice-telemetry-model.md`
+- `docs/waste-heuristics.md`
+
+These are meant to operationalize the next questions around context growth, retry waste, handoff inflation, and runtime fit before adapters or learning-layer work.

--- a/docs/context-resource-telemetry-spec.md
+++ b/docs/context-resource-telemetry-spec.md
@@ -1,0 +1,266 @@
+# Context / Resource Telemetry Spec
+
+## Goal
+
+Define the first telemetry surface for the 1.2 Resource-Aware Operations track.
+
+This spec should help projects make context and resource use more visible **without** turning AletheIA into a heavyweight runtime platform.
+
+It is a framework-facing operating spec, not a mandatory engine feature.
+
+---
+
+## Why this exists
+
+AletheIA already teaches:
+
+- token discipline
+- bounded work slices
+- compact handoffs
+- advisory model strategy
+- stronger trust / hosting posture where needed
+
+What is still missing is a practical surface for answering questions such as:
+
+- where is context growing?
+- where is handoff weight inflating?
+- where are retries expensive but unhelpful?
+- where is the selected runtime or agent stronger or weaker than the task needs?
+
+This spec defines the first telemetry shape that later local adapters may emit.
+
+---
+
+## Design constraints
+
+The telemetry surface should remain:
+
+- provider-agnostic
+- advisory-first
+- reviewable
+- small enough for local adoption
+- compatible with manual, semi-automated, or runtime-assisted capture
+
+It should **not** assume:
+
+- one vendor pricing model
+- one token accounting backend
+- one runtime
+- one orchestration stack
+- one always-on agent platform
+
+---
+
+## Telemetry unit
+
+The main telemetry unit for this track is the **work slice**.
+
+A slice is the right unit because it already carries:
+
+- task boundary
+- decision posture
+- execution context
+- validation expectation
+- handoff or continuation meaning
+
+That makes telemetry legible in the same operating shape that AletheIA already uses.
+
+---
+
+## Core telemetry categories
+
+### 1. Context telemetry
+
+Capture signals such as:
+
+- cold boot size
+- exploration additions
+- explicit expansion events
+- delegated context size
+- handoff size
+
+Purpose:
+- show where context grows across the slice lifecycle
+
+### 2. Runtime / agent telemetry
+
+Capture:
+
+- runtime or agent used for the slice
+- capability profile if known
+- reasoning depth if relevant
+- trust / hosting posture when materially relevant
+
+Purpose:
+- compare task shape against execution fit
+
+### 3. Retry telemetry
+
+Capture:
+
+- retry count
+- whether retries changed strategy or only repeated work
+- whether retries followed failure, ambiguity, or governance stop
+
+Purpose:
+- distinguish useful iteration from wasteful repetition
+
+### 4. Handoff telemetry
+
+Capture:
+
+- whether a handoff happened
+- whether the handoff stayed compact
+- whether the next step required replay of prior context anyway
+
+Purpose:
+- measure restart quality instead of only handoff existence
+
+### 5. Human effort telemetry
+
+Capture only lightweight signals such as:
+
+- whether human review was required
+- whether manual rewrite or rescue was substantial
+- whether the final result needed heavy human correction
+
+Purpose:
+- avoid optimizing model/runtime selection while hiding human burden
+
+### 6. Optional cost / time telemetry
+
+If a project can estimate them safely, it may also record:
+
+- elapsed time
+- rough cost estimate
+- heavy tool-use count
+
+These fields should remain optional in the framework-facing spec.
+
+---
+
+## Required telemetry moments
+
+The first version should support these moments explicitly.
+
+### Cold boot
+
+Record the first relevant context load for the slice.
+
+### Exploration
+
+Record when context grows due to unresolved ambiguity.
+
+### Expansion
+
+Record when the slice stops being local enough and broader context is pulled in.
+
+### Delegation
+
+Record when a narrower or parallel execution pack is prepared.
+
+### Handoff
+
+Record what was preserved for restart and whether the restart stayed lightweight.
+
+These moments align intentionally with the existing token-policy reading of the work.
+
+---
+
+## Minimum field groups
+
+The telemetry spec should support at least these field groups.
+
+### Slice identity
+
+- slice identifier
+- project or example identifier
+- date or round
+- dominant task shape
+
+### Context fields
+
+- cold boot size class
+- exploration count or additions
+- explicit expansion count
+- expansion reason present or absent
+- handoff size class
+
+### Runtime fields
+
+- runtime / agent identity
+- capability profile if known
+- reasoning depth if used
+- trust / hosting posture if relevant
+
+### Outcome fields
+
+- validation outcome class
+- retry count
+- handoff required or not
+- human review required or not
+- heavy human rescue yes / no / unknown
+
+### Optional scalar fields
+
+- elapsed time
+- rough cost estimate
+- tool call count
+
+The framework should prefer **size classes and reviewable proxies** over pretending to require exact universal measurement on day one.
+
+---
+
+## Recommended value shapes
+
+Prefer simple, comparable value shapes in the first version.
+
+Examples:
+
+- size classes: `minimal`, `moderate`, `extended`
+- retry classes: `none`, `changed-strategy`, `repeated-without-change`
+- handoff quality: `not-needed`, `compact`, `inflated`, `restart-still-heavy`
+- human effort: `none`, `light-review`, `substantial-review`, `manual-rescue`
+
+This keeps the first telemetry layer usable even in local or semi-manual settings.
+
+---
+
+## What this spec should make possible later
+
+If adopted consistently, this telemetry surface should later support:
+
+- waste heuristics
+- progressive policy signals
+- runtime / agent fit review
+- comparative slice reviews
+- benchmark work in later tracks
+
+It should not require benchmark or learning layers to be useful.
+
+---
+
+## What this spec deliberately avoids
+
+This spec does not yet define:
+
+- one JSON schema as a required runtime contract
+- one canonical dashboard format
+- automatic scoring
+- vendor-specific cost math
+- framework-level auto-routing
+- learning-layer feedback loops
+
+Those belong later, after the basic surface is proven useful.
+
+---
+
+## Suggested next reading
+
+- `docs/resource-aware-operations-roadmap.md`
+- `docs/token-policy.md`
+- `docs/work-slice-pattern.md`
+- `docs/handoff-capture-pattern.md`
+- `starter-pack/guides/model-strategy-by-task.md`
+- `docs/slice-telemetry-model.md`
+- `docs/waste-heuristics.md`

--- a/docs/resource-aware-operations-roadmap.md
+++ b/docs/resource-aware-operations-roadmap.md
@@ -87,6 +87,12 @@ Expected outputs:
 - **minimal slice telemetry model**
 - **Waste Heuristics guide**
 
+This phase now begins with:
+
+- `docs/context-resource-telemetry-spec.md`
+- `docs/slice-telemetry-model.md`
+- `docs/waste-heuristics.md`
+
 ### Phase B — progressive policy signals
 
 Turn existing guidance into light operational signals:
@@ -256,3 +262,14 @@ This track is working if AletheIA can eventually help teams answer questions suc
 - where is human review effort too high for the value returned?
 
 without becoming a heavyweight orchestration product.
+
+## Current 1.2 deliverables
+
+This track now begins with:
+
+- `docs/resource-aware-operations-roadmap.md`
+- `docs/context-resource-telemetry-spec.md`
+- `docs/slice-telemetry-model.md`
+- `docs/waste-heuristics.md`
+
+These are meant to establish the first observability spine before any adapter, benchmark, or learning-layer work is attempted.

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -227,17 +227,19 @@ Current backlog still includes:
 
 This is the next queued operationalization track after the current 1.1 hardening pass.
 
-Planned backlog includes:
+The first docs-first 1.2 pass now begins with:
 
-- context and resource telemetry surfaces
-- lightweight waste heuristics and policy signals
+- `docs/resource-aware-operations-roadmap.md`
+- `docs/context-resource-telemetry-spec.md`
+- `docs/slice-telemetry-model.md`
+- `docs/waste-heuristics.md`
+
+Remaining backlog includes:
+
+- progressive policy signals built on those surfaces
 - minimal runtime adapter contract examples
 - advisory runtime / agent decision guidance
 - planning depth profiles and readiness gates only after observability is legible
-
-Anchor roadmap artifact:
-
-- `docs/resource-aware-operations-roadmap.md`
 
 ### 1.3+ — Benchmark and comparative evaluation
 

--- a/docs/slice-telemetry-model.md
+++ b/docs/slice-telemetry-model.md
@@ -1,0 +1,191 @@
+# Slice Telemetry Model
+
+## Goal
+
+Provide a minimal, framework-facing model for recording telemetry at the work-slice level.
+
+This is a **model shape**, not a required JSON contract.
+It exists so teams can record comparable signals before the AletheIA 1.2 track moves into adapters or stronger review layers.
+
+---
+
+## Minimal slice record
+
+A healthy first slice telemetry record should answer:
+
+- what slice was this?
+- what kind of work was it?
+- how much context growth happened?
+- what runtime or agent carried it?
+- how many retries happened?
+- what kind of handoff or restart burden remained?
+- how much human effort was required?
+
+---
+
+## Field groups
+
+### 1. Identity
+
+- `slice_id`
+- `project_id` or example id
+- `round_id` if relevant
+- `task_shape`
+- `risk_posture` when materially relevant
+
+### 2. Context usage
+
+- `cold_boot_budget`
+- `exploration_events`
+- `expansion_events`
+- `expansion_reason_present`
+- `delegation_events`
+- `handoff_size_class`
+
+### 3. Runtime / agent fit
+
+- `runtime_id`
+- `agent_class` when useful
+- `capability_profile`
+- `reasoning_depth`
+- `trust_hosting_posture` when relevant
+
+### 4. Retry and execution shape
+
+- `retry_count`
+- `retry_pattern`
+- `tool_use_class` optionally
+- `elapsed_time_class` optionally
+
+### 5. Review and human effort
+
+- `human_review_level`
+- `manual_rescue_required`
+- `validation_outcome`
+
+### 6. Restart quality
+
+- `handoff_required`
+- `handoff_quality`
+- `restart_burden`
+
+---
+
+## Example value vocabulary
+
+A small vocabulary is enough for the first version.
+
+### Context budget
+
+- `minimal`
+- `moderate`
+- `extended`
+
+### Retry pattern
+
+- `none`
+- `changed-strategy`
+- `repeated-without-change`
+
+### Human review level
+
+- `none`
+- `light-review`
+- `substantial-review`
+- `manual-rescue`
+
+### Validation outcome
+
+- `validated`
+- `review-required`
+- `blocked`
+- `escalated`
+- `incomplete`
+
+### Handoff quality
+
+- `not-needed`
+- `compact`
+- `inflated`
+- `restart-still-heavy`
+
+---
+
+## Minimal example
+
+```txt
+slice_id: cris-routing-approval-round-2
+project_id: crisis-monitor
+round_id: 2
+task_shape: bounded-execution
+cold_boot_budget: minimal
+exploration_events: 1
+expansion_events: 0
+expansion_reason_present: yes
+delegation_events: 0
+handoff_size_class: compact
+runtime_id: codex
+capability_profile: balanced-executor
+reasoning_depth: standard
+trust_hosting_posture: externally-hosted-allowed
+retry_count: 1
+retry_pattern: changed-strategy
+human_review_level: light-review
+manual_rescue_required: no
+validation_outcome: validated
+handoff_required: yes
+handoff_quality: compact
+restart_burden: low
+```
+
+This is only an example of shape.
+Projects may store the same meaning differently.
+
+---
+
+## Recommended first-use rules
+
+Use the model lightly at first:
+
+- one record per meaningful slice
+- prefer classes over fake precision
+- record reasons when expansion happened
+- record whether retries changed strategy
+- record whether the next round still needed heavy replay
+
+This is enough to support later review without pretending that the framework already has a full runtime layer.
+
+---
+
+## What good use looks like
+
+A healthy first-use pass should make it easier to compare:
+
+- one slice against another
+- one runtime choice against another
+- one handoff pattern against another
+- one retry posture against another
+
+without requiring perfect measurement.
+
+---
+
+## What not to do yet
+
+Do not treat this model as:
+
+- a hard schema requirement
+- a scoring engine
+- an automatic router input
+- a benchmark suite by itself
+- a substitute for human review
+
+Those belong later in the roadmap.
+
+---
+
+## Suggested next reading
+
+- `docs/context-resource-telemetry-spec.md`
+- `docs/waste-heuristics.md`
+- `docs/resource-aware-operations-roadmap.md`

--- a/docs/waste-heuristics.md
+++ b/docs/waste-heuristics.md
@@ -1,0 +1,141 @@
+# Waste Heuristics
+
+## Goal
+
+Give AletheIA a lightweight, reviewable way to talk about waste before stronger policy signals or benchmarking exist.
+
+This guide is not trying to optimize for token count alone.
+It is trying to distinguish **proportional effort** from **avoidable operational waste**.
+
+---
+
+## Waste versus healthy cost
+
+Not every expensive slice is wasteful.
+Not every cheap slice is efficient.
+
+A slice may be costly and still healthy when:
+
+- risk is real
+- ambiguity is high
+- validation needs depth
+- handoff quality matters
+- human review is proportionate to the stakes
+
+Waste appears when effort grows without proportional gain.
+
+---
+
+## Core waste patterns
+
+### 1. Context inflation
+
+Signals:
+
+- cold boot is larger than task shape suggests
+- exploration keeps growing without resolving the real uncertainty
+- expansion occurs without a clear reason
+
+### 2. Retry waste
+
+Signals:
+
+- multiple retries happen without changing strategy
+- retries repeat the same context posture and same failure pattern
+- retries add cost but not clarity
+
+### 3. Handoff inflation
+
+Signals:
+
+- handoff artifacts grow toward transcript replay
+- the next round still needs heavy reconstruction despite the handoff
+- restart burden stays high even after a handoff was written
+
+### 4. Capability mismatch
+
+Signals:
+
+- a high-capability runtime is used for clearly mechanical work
+- a low-capability runtime is kept on a slice that obviously needs deeper reasoning or review
+- the task shape and chosen runtime repeatedly misalign
+
+### 5. Hidden human rescue
+
+Signals:
+
+- the model output only becomes usable after heavy human rewrite
+- review time becomes large compared with the value of the slice
+- a result looks acceptable only because humans silently repaired it
+
+### 6. Slice creep
+
+Signals:
+
+- adjacent follow-up keeps entering the current round
+- the current slice loses its stop condition
+- checkpoint decisions are skipped even though the task changed shape
+
+---
+
+## Healthy counter-patterns
+
+A slice is usually healthy when it shows:
+
+- bounded cold boot
+- explicit reasons for expansion
+- retries that change strategy when needed
+- compact handoffs that really reduce restart burden
+- runtime fit that looks proportional to task shape and risk
+- human review that confirms quality instead of rescuing weak output
+
+---
+
+## First review questions
+
+Use these questions before claiming waste.
+
+1. Was the task genuinely high-ambiguity or high-risk?
+2. Did expansion have a real reason?
+3. Did retries change the operating approach?
+4. Did the handoff reduce restart burden or only document it?
+5. Did the selected runtime or agent fit the slice shape?
+6. Was human effort proportional, or was it hiding weak output quality?
+
+---
+
+## Recommended first-use posture
+
+Use these heuristics as:
+
+- a review lens
+- a policy-signal input later
+- a comparative discussion tool
+
+Do not use them yet as:
+
+- a rigid score
+- a hard blocker
+- a vendor ranking shortcut
+- a full performance benchmark
+
+---
+
+## Relationship to the 1.2 track
+
+These heuristics are intentionally early and lightweight.
+They are meant to support the first resource-aware operational questions:
+
+- where is the waste likely happening?
+- what kind of waste is it?
+- is the problem context, retries, handoff, runtime fit, or hidden human burden?
+
+That is enough to justify later policy signals without forcing premature automation.
+
+---
+
+## Suggested next reading
+
+- `docs/context-resource-telemetry-spec.md`
+- `docs/slice-telemetry-model.md`
+- `docs/resource-aware-operations-roadmap.md`

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -131,5 +131,8 @@ The next queued post-1.0 track is resource-aware operations.
 Read:
 
 - `docs/resource-aware-operations-roadmap.md`
+- `docs/context-resource-telemetry-spec.md`
+- `docs/slice-telemetry-model.md`
+- `docs/waste-heuristics.md`
 
 This future track should build on the current starter-pack surfaces rather than replace them.


### PR DESCRIPTION
## Summary
- start the active 1.2 Resource-Aware Operations track with observability-first docs
- add a context/resource telemetry spec, a slice telemetry model, and a waste heuristics guide
- wire the new Phase A surfaces into the roadmap and public entrypoints

## Testing
- bash scripts/check-governance.sh
- git diff --check