### PR TITLE
Add progressive policy signals docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- start the next 1.2 layer with progressive policy signals and a lightweight review example
 - define the first 1.2 telemetry surfaces for resource-aware operations
 - start the 1.2 track with context/resource telemetry, slice telemetry, and waste heuristics docs
 - add a Resource-Aware Operations roadmap as the queued 1.2+ track

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Those remain part of the post-1.0 roadmap.
 The first post-1.0 track now starts with enterprise-oriented hardening for constrained and regulated adoption, but still without claiming enterprise-ready packaging by default.
 The next queued post-1.0 track is resource-aware operations: a docs-first operationalization lane for observability, proportional context/capability allocation, and advisory runtime/agent fit.
 That 1.2 track now begins with telemetry and waste-reading surfaces rather than adapter or learning-layer work.
+It now also includes a first docs-first policy-signals layer that turns telemetry and waste patterns into reviewable advisory signals.
 
 See also:
 
@@ -192,6 +193,8 @@ If this is your first time here, start with:
 1. `docs/context-resource-telemetry-spec.md`
 1. `docs/slice-telemetry-model.md`
 1. `docs/waste-heuristics.md`
+1. `docs/progressive-policy-signals.md`
+1. `examples/resource-aware-operations/README.md`
 1. `docs/architecture.md`
 1. `docs/governance.md`
 1. `docs/token-policy.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -214,3 +214,10 @@ The queued 1.2 track now begins with early observability surfaces through:
 - `docs/waste-heuristics.md`
 
 These are meant to operationalize the next questions around context growth, retry waste, handoff inflation, and runtime fit before adapters or learning-layer work.
+
+The next docs-first 1.2 layer after telemetry is progressive policy signals through:
+
+- `docs/progressive-policy-signals.md`
+- `examples/resource-aware-operations/policy-signals-review-example.md`
+
+This keeps the framework in an advisory-first posture while making operational drift more reviewable.

--- a/docs/progressive-policy-signals.md
+++ b/docs/progressive-policy-signals.md
@@ -1,0 +1,261 @@
+# Progressive Policy Signals
+
+## Goal
+
+Define the next step after the first telemetry surfaces in the 1.2 Resource-Aware Operations track.
+
+This guide explains how AletheIA can turn context and resource guidance into **reviewable signals** without pretending that everything is already technically enforced.
+
+The purpose is to make waste and mismatch more visible early, not to create a hard blocking system immediately.
+
+---
+
+## Why this comes after telemetry
+
+AletheIA already had:
+
+- token policy
+- enforcement-boundary clarity
+- work-slice discipline
+- advisory model strategy
+
+The first 1.2 pass added:
+
+- context / resource telemetry
+- slice telemetry shape
+- waste heuristics
+
+The next low-regret step is not adapters or auto-routing.
+It is to define what kinds of **signals** the framework should surface once those telemetry concepts exist.
+
+---
+
+## Core principle
+
+AletheIA should begin with:
+
+- **advisory signals**
+- visible review prompts
+- explainable thresholds
+- soft escalation posture
+
+It should not begin with:
+
+- hard blocking by default
+- rigid scores
+- silent automatic routing
+- fake certainty about universal thresholds
+
+This keeps the framework honest about what is behavioral, what is reviewable, and what may later become technically enforceable.
+
+---
+
+## Signal types
+
+### 1. Context inflation signals
+
+Use when:
+
+- cold boot is larger than task shape suggests
+- exploration keeps expanding without resolving the uncertainty
+- expansion happened without a visible reason
+
+Healthy first output:
+
+- warning
+- review note
+- prompt to record expansion reason
+
+### 2. Retry waste signals
+
+Use when:
+
+- retries increase but strategy does not change
+- the same failure pattern repeats
+- retries are consuming effort without creating clarity
+
+Healthy first output:
+
+- warning
+- ask whether the slice should change strategy, stop, or escalate
+
+### 3. Handoff inflation signals
+
+Use when:
+
+- the handoff grows toward narrative replay
+- restart burden stays high after handoff
+- the next round still needs large reconstruction work
+
+Healthy first output:
+
+- review note
+- hint to shrink handoff to restart-package essentials
+
+### 4. Runtime / task-shape mismatch signals
+
+Use when:
+
+- a strong runtime is repeatedly used for mechanical work
+- a weaker runtime is stretched across work that obviously needs deeper reasoning or review
+- the same mismatch pattern repeats across slices
+
+Healthy first output:
+
+- advisory mismatch note
+- recommendation to revisit model strategy or local usage plan
+
+### 5. Hidden human rescue signals
+
+Use when:
+
+- manual rewrite is heavy
+- review effort is high compared with slice value
+- the result only becomes acceptable after human repair
+
+Healthy first output:
+
+- review note
+- prompt to reassess runtime fit or validation posture
+
+### 6. Slice-creep signals
+
+Use when:
+
+- adjacent work keeps entering the same slice
+- the stop condition disappears
+- checkpoint-like discipline was clearly skipped
+
+Healthy first output:
+
+- stop-and-review signal
+- recommendation to re-bound the slice before continuing
+
+---
+
+## Signal levels
+
+A simple three-level model is enough for the first version.
+
+### Level 1 — note
+
+Use when:
+
+- there is a mild signal
+- the work can continue safely
+- the main value is visibility
+
+### Level 2 — warning
+
+Use when:
+
+- waste or mismatch is becoming meaningful
+- the next step should be reviewed before continuing by habit
+- the operator should document a reason or change in posture
+
+### Level 3 — review-required
+
+Use when:
+
+- the signal suggests the current path may no longer be healthy
+- expansion, retries, or mismatch are clearly undermining the slice
+- continuing without explicit review would likely increase waste or ambiguity
+
+This is still not a hard block by default.
+It is a stronger request for visible inspection.
+
+---
+
+## Good first-use rules
+
+### Rule 1 — signals should be explainable in one sentence
+
+A signal is only useful if a reviewer can explain why it appeared.
+
+### Rule 2 — start with classes and review notes, not scores
+
+The first version should prefer:
+
+- `note`
+- `warning`
+- `review-required`
+
+instead of pretending to have a universal numeric scoring model.
+
+### Rule 3 — signals should point to an action
+
+A signal should help answer:
+
+- continue
+- shrink
+- change strategy
+- hand off
+- escalate
+- revisit runtime fit
+
+### Rule 4 — do not blur behavioral and technical enforcement
+
+A signal may be derived from telemetry or heuristics, but it should not overclaim that the framework has already enforced the right behavior technically.
+
+### Rule 5 — keep trust-boundary specifics local
+
+A signal may say that runtime fit or hosting posture should be reviewed.
+It should not silently encode one project's trust policy into the framework core.
+
+---
+
+## Example signal families
+
+A healthy first signal set could look like this:
+
+- `context-inflation-warning`
+- `expansion-reason-missing`
+- `retry-pattern-review`
+- `handoff-inflation-warning`
+- `runtime-fit-review`
+- `slice-creep-review`
+- `human-rescue-warning`
+
+These names are illustrative only.
+They are meant to show shape, not define a final API.
+
+---
+
+## Relationship to later 1.2 work
+
+These signals are meant to unlock the next steps safely.
+
+After signals are clearer, the framework can later discuss:
+
+- minimal runtime adapter contracts
+- advisory decision layers between agents/runtimes
+- readiness gates informed by real operational signals
+
+Signals therefore sit between:
+
+- telemetry surfaces
+- and stronger operational guidance
+
+They are the bridge, not the endpoint.
+
+---
+
+## What not to do yet
+
+Do not use policy signals yet as:
+
+- automatic hard-stop logic by default
+- vendor ranking shortcuts
+- pseudo-precise scoring systems
+- proof that a learning layer is ready
+- a replacement for human judgment on high-stakes work
+
+---
+
+## Suggested next reading
+
+- `docs/context-resource-telemetry-spec.md`
+- `docs/slice-telemetry-model.md`
+- `docs/waste-heuristics.md`
+- `docs/enforcement-boundaries.md`
+- `docs/resource-aware-operations-roadmap.md`

--- a/docs/resource-aware-operations-roadmap.md
+++ b/docs/resource-aware-operations-roadmap.md
@@ -114,6 +114,11 @@ Expected outputs:
 - **Progressive Policy Signals guide**
 - lightweight review examples of healthy versus unhealthy signals
 
+This phase now begins with:
+
+- `docs/progressive-policy-signals.md`
+- `examples/resource-aware-operations/policy-signals-review-example.md`
+
 ### Phase C — runtime adapter contract
 
 Only after the signals are legible should the framework define a runtime-facing contract.
@@ -271,5 +276,7 @@ This track now begins with:
 - `docs/context-resource-telemetry-spec.md`
 - `docs/slice-telemetry-model.md`
 - `docs/waste-heuristics.md`
+- `docs/progressive-policy-signals.md`
+- `examples/resource-aware-operations/policy-signals-review-example.md`
 
-These are meant to establish the first observability spine before any adapter, benchmark, or learning-layer work is attempted.
+These are meant to establish the first observability spine and the first advisory signal layer before any adapter, benchmark, or learning-layer work is attempted.

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -234,12 +234,16 @@ The first docs-first 1.2 pass now begins with:
 - `docs/slice-telemetry-model.md`
 - `docs/waste-heuristics.md`
 
+The next docs-first layer now also begins with:
+
+- `docs/progressive-policy-signals.md`
+- `examples/resource-aware-operations/policy-signals-review-example.md`
+
 Remaining backlog includes:
 
-- progressive policy signals built on those surfaces
 - minimal runtime adapter contract examples
 - advisory runtime / agent decision guidance
-- planning depth profiles and readiness gates only after observability is legible
+- planning depth profiles and readiness gates only after observability and signals are legible
 
 ### 1.3+ — Benchmark and comparative evaluation
 

--- a/examples/resource-aware-operations/README.md
+++ b/examples/resource-aware-operations/README.md
@@ -1,0 +1,9 @@
+# Resource-Aware Operations Examples
+
+This folder contains lightweight examples for the 1.2 Resource-Aware Operations track.
+
+The first examples stay docs-first and intentionally small.
+
+## Current examples
+
+- `policy-signals-review-example.md`

--- a/examples/resource-aware-operations/policy-signals-review-example.md
+++ b/examples/resource-aware-operations/policy-signals-review-example.md
@@ -1,0 +1,63 @@
+# Policy Signals Review Example
+
+## Context
+
+A bounded slice begins as a small implementation round, but the execution pattern starts drifting.
+
+Observed conditions:
+
+- cold boot stayed reasonable
+- exploration expanded twice
+- the second expansion had no explicit reason
+- two retries happened without a visible strategy change
+- the handoff draft started growing toward narrative replay
+
+## Useful signals
+
+### `expansion-reason-missing`
+
+Why it fires:
+
+- at least one meaningful expansion happened without an explicit reason
+
+What it should cause:
+
+- add a reason
+- or shrink the slice back to what is clearly justified
+
+### `retry-pattern-review`
+
+Why it fires:
+
+- retries are increasing without a change in operating approach
+
+What it should cause:
+
+- stop repeating the same attempt
+- decide whether to change strategy, hand off, or escalate
+
+### `handoff-inflation-warning`
+
+Why it fires:
+
+- the handoff is no longer a compact restart package
+
+What it should cause:
+
+- rewrite the handoff around what changed, what was proved, and what remains open
+
+## Why this is useful
+
+The point is not to block the slice automatically.
+The point is to make the unhealthy drift visible before the team keeps paying for it.
+
+## Why this is still only Phase B
+
+This example does not require:
+
+- a runtime adapter
+- scoring
+- benchmark infrastructure
+- learning-layer feedback
+
+It only requires that the framework can name the signal, explain it, and point to a healthier next move.

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -134,5 +134,7 @@ Read:
 - `docs/context-resource-telemetry-spec.md`
 - `docs/slice-telemetry-model.md`
 - `docs/waste-heuristics.md`
+- `docs/progressive-policy-signals.md`
+- `examples/resource-aware-operations/README.md`
 
 This future track should build on the current starter-pack surfaces rather than replace them.


### PR DESCRIPTION
## Summary
- start Phase B of the 1.2 Resource-Aware Operations track with advisory policy-signal guidance
- add a lightweight review example for progressive policy signals
- wire the new signal layer into the roadmap and public entrypoints

## Testing
- bash scripts/check-governance.sh
- git diff --check