### PR TITLE
Add runtime adapter contract docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- start the next 1.2 layer with a minimal runtime adapter contract and lightweight example
 - start the next 1.2 layer with progressive policy signals and a lightweight review example
 - define the first 1.2 telemetry surfaces for resource-aware operations
 - start the 1.2 track with context/resource telemetry, slice telemetry, and waste heuristics docs

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The first post-1.0 track now starts with enterprise-oriented hardening for const
 The next queued post-1.0 track is resource-aware operations: a docs-first operationalization lane for observability, proportional context/capability allocation, and advisory runtime/agent fit.
 That 1.2 track now begins with telemetry and waste-reading surfaces rather than adapter or learning-layer work.
 It now also includes a first docs-first policy-signals layer that turns telemetry and waste patterns into reviewable advisory signals.
+The next 1.2 step now begins to define a minimal provider-agnostic runtime adapter contract on top of those surfaces.
 
 See also:
 
@@ -194,7 +195,9 @@ If this is your first time here, start with:
 1. `docs/slice-telemetry-model.md`
 1. `docs/waste-heuristics.md`
 1. `docs/progressive-policy-signals.md`
+1. `docs/runtime-adapter-contract.md`
 1. `examples/resource-aware-operations/README.md`
+1. `examples/resource-aware-operations/minimal-runtime-adapter-example.md`
 1. `docs/architecture.md`
 1. `docs/governance.md`
 1. `docs/token-policy.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -221,3 +221,10 @@ The next docs-first 1.2 layer after telemetry is progressive policy signals thro
 - `examples/resource-aware-operations/policy-signals-review-example.md`
 
 This keeps the framework in an advisory-first posture while making operational drift more reviewable.
+
+The next docs-first 1.2 layer after policy signals is a minimal runtime adapter contract through:
+
+- `docs/runtime-adapter-contract.md`
+- `examples/resource-aware-operations/minimal-runtime-adapter-example.md`
+
+This keeps the track provider-agnostic while making the future adapter surface more concrete without turning AletheIA into a full orchestration platform.

--- a/docs/resource-aware-operations-roadmap.md
+++ b/docs/resource-aware-operations-roadmap.md
@@ -140,6 +140,11 @@ Expected outputs:
 - one example adapter shape
 - one or two local runtime examples
 
+This phase now begins with:
+
+- `docs/runtime-adapter-contract.md`
+- `examples/resource-aware-operations/minimal-runtime-adapter-example.md`
+
 ### Phase D — advisory multi-agent decision layer
 
 The framework may then publish an advisory layer for choosing between agents and runtimes.
@@ -278,5 +283,7 @@ This track now begins with:
 - `docs/waste-heuristics.md`
 - `docs/progressive-policy-signals.md`
 - `examples/resource-aware-operations/policy-signals-review-example.md`
+- `docs/runtime-adapter-contract.md`
+- `examples/resource-aware-operations/minimal-runtime-adapter-example.md`
 
-These are meant to establish the first observability spine and the first advisory signal layer before any adapter, benchmark, or learning-layer work is attempted.
+These are meant to establish the first observability spine, the first advisory signal layer, and a minimal runtime contract before any benchmark or learning-layer work is attempted.

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -239,11 +239,15 @@ The next docs-first layer now also begins with:
 - `docs/progressive-policy-signals.md`
 - `examples/resource-aware-operations/policy-signals-review-example.md`
 
+The next docs-first layer now also begins with:
+
+- `docs/runtime-adapter-contract.md`
+- `examples/resource-aware-operations/minimal-runtime-adapter-example.md`
+
 Remaining backlog includes:
 
-- minimal runtime adapter contract examples
 - advisory runtime / agent decision guidance
-- planning depth profiles and readiness gates only after observability and signals are legible
+- planning depth profiles and readiness gates only after observability, signals, and the minimal adapter contract are legible
 
 ### 1.3+ — Benchmark and comparative evaluation
 

--- a/docs/runtime-adapter-contract.md
+++ b/docs/runtime-adapter-contract.md
@@ -1,0 +1,215 @@
+# Runtime Adapter Contract
+
+## Goal
+
+Define the first minimal runtime-facing contract for the 1.2 Resource-Aware Operations track.
+
+This contract should let a local runtime emit comparable slice-level operational signals **without** turning AletheIA into a full orchestration platform.
+
+It is intentionally narrower than the Alpha 6 adapter taxonomy.
+
+---
+
+## Why this exists
+
+Alpha 6 already explains adapters as delivery mappings across surfaces.
+
+The 1.2 track needs a different but related thing:
+
+- a minimal runtime contract for carrying resource-aware operational signals
+
+The goal is not to define every runtime integration.
+The goal is to define the smallest shared shape that later local adapters can map onto.
+
+---
+
+## Relationship to existing surfaces
+
+This contract builds directly on:
+
+- `docs/context-resource-telemetry-spec.md`
+- `docs/slice-telemetry-model.md`
+- `docs/waste-heuristics.md`
+- `docs/progressive-policy-signals.md`
+- `docs/adapter-taxonomy.md`
+
+The relationship is:
+
+- Alpha 6 adapter taxonomy explains **what kinds of delivery mappings exist**
+- this contract explains **what minimum operational fields a runtime-facing mapping should preserve**
+
+---
+
+## Design constraints
+
+The first runtime adapter contract should remain:
+
+- provider-agnostic
+- runtime-agnostic
+- advisory-first
+- compatible with manual or semi-automated local implementations
+- smaller than a full task-execution API
+
+It should not require:
+
+- a specific model vendor
+- a specific editor shell
+- exact token counts
+- exact cost accounting
+- automatic routing
+- automatic blocking
+
+---
+
+## Minimal contract scope
+
+A first adapter should be able to carry five groups of meaning.
+
+### 1. Slice identity
+
+A runtime-facing record should preserve:
+
+- slice identifier
+- project or lane identifier
+- round identifier when relevant
+- dominant task shape
+
+### 2. Context posture
+
+It should preserve:
+
+- cold boot size class
+- exploration event count or class
+- expansion event count
+- whether expansion reason was recorded
+- delegation event count when relevant
+- handoff size class when relevant
+
+### 3. Runtime / agent posture
+
+It should preserve:
+
+- runtime identity
+- agent class or role when relevant
+- capability profile if known
+- reasoning depth if known
+- trust / hosting posture when materially relevant
+
+### 4. Review / retry posture
+
+It should preserve:
+
+- retry count
+- retry pattern class
+- validation outcome class
+- human review level
+- manual rescue yes / no / unknown
+
+### 5. Restart posture
+
+It should preserve:
+
+- handoff required or not
+- handoff quality class
+- restart burden class
+
+Optional fields may later include time, cost, and tool-use proxies.
+
+---
+
+## Contract style
+
+The contract should be read as a **shape**, not as a required transport protocol.
+
+A local runtime may implement it through:
+
+- JSON
+- YAML
+- structured markdown frontmatter
+- local logs
+- handoff sidecar files
+- project-local telemetry sinks
+
+What matters is preserving the meaning of the fields, not forcing one storage format too early.
+
+---
+
+## Minimal example shape
+
+```txt
+slice_id: example-slice-001
+project_id: crisis-monitor
+round_id: 2
+task_shape: bounded-execution
+cold_boot_budget: minimal
+exploration_events: 1
+expansion_events: 1
+expansion_reason_present: yes
+delegation_events: 0
+runtime_id: codex
+agent_class: coding-agent
+capability_profile: balanced-executor
+reasoning_depth: standard
+trust_hosting_posture: externally-hosted-allowed
+retry_count: 1
+retry_pattern: changed-strategy
+validation_outcome: validated
+human_review_level: light-review
+manual_rescue_required: no
+handoff_required: yes
+handoff_quality: compact
+restart_burden: low
+```
+
+This is only an illustrative shape.
+A local adapter may serialize it differently.
+
+---
+
+## What a runtime adapter should do first
+
+A first local runtime adapter should be able to:
+
+1. capture a bounded slice record
+2. preserve the key context and retry signals
+3. preserve runtime identity and fit posture
+4. preserve handoff and restart quality signals
+5. keep the result reviewable by humans
+
+That is enough for the current track.
+
+---
+
+## What a runtime adapter should not do yet
+
+Do not require the first contract to:
+
+- execute routing automatically
+- block work by itself
+- compute universal scores
+- normalize all vendor metrics into one truth layer
+- become a benchmark system by accident
+
+Those belong later, after more evidence and comparison surfaces exist.
+
+---
+
+## First local implementation patterns
+
+Healthy first patterns include:
+
+- a markdown-frontmatter slice record
+- a local JSON sidecar written by a project-specific adapter
+- a reviewable artifact generated alongside a handoff package
+
+The first contract should make these possible without forcing one canonical runtime implementation.
+
+---
+
+## Suggested next reading
+
+- `docs/context-resource-telemetry-spec.md`
+- `docs/slice-telemetry-model.md`
+- `docs/progressive-policy-signals.md`
+- `docs/adapter-taxonomy.md`
+- `examples/resource-aware-operations/minimal-runtime-adapter-example.md`

--- a/examples/resource-aware-operations/README.md
+++ b/examples/resource-aware-operations/README.md
@@ -7,3 +7,4 @@ The first examples stay docs-first and intentionally small.
 ## Current examples
 
 - `policy-signals-review-example.md`
+- `minimal-runtime-adapter-example.md`

--- a/examples/resource-aware-operations/minimal-runtime-adapter-example.md
+++ b/examples/resource-aware-operations/minimal-runtime-adapter-example.md
@@ -1,0 +1,62 @@
+# Minimal Runtime Adapter Example
+
+## Goal
+
+Show what a very small local runtime adapter could preserve from one slice without pretending to be a full orchestration layer.
+
+## Example shape
+
+```yaml
+slice_id: cris-followup-round-1
+project_id: crisis-monitor
+round_id: 1
+task_shape: bounded-execution
+cold_boot_budget: minimal
+exploration_events: 1
+expansion_events: 0
+expansion_reason_present: yes
+delegation_events: 0
+runtime_id: codex
+agent_class: coding-agent
+capability_profile: balanced-executor
+reasoning_depth: standard
+trust_hosting_posture: externally-hosted-allowed
+retry_count: 0
+retry_pattern: none
+validation_outcome: validated
+human_review_level: light-review
+manual_rescue_required: no
+handoff_required: yes
+handoff_quality: compact
+restart_burden: low
+```
+
+## Why this is enough for now
+
+This shape is already enough to support:
+
+- slice-level review
+- future policy signals
+- later runtime-fit comparison
+- later benchmark work
+
+It is **not** trying to support:
+
+- automatic routing
+- scoring
+- blocking
+- vendor cost normalization
+
+## Healthy first implementation postures
+
+A local project could emit this record through:
+
+- a sidecar file next to a work slice
+- a local telemetry log
+- a generated review artifact
+- a handoff-adjacent record for later analysis
+
+## Boundary
+
+The adapter preserves operational meaning.
+It does not redefine the framework, and it does not replace human review.

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -135,6 +135,7 @@ Read:
 - `docs/slice-telemetry-model.md`
 - `docs/waste-heuristics.md`
 - `docs/progressive-policy-signals.md`
+- `docs/runtime-adapter-contract.md`
 - `examples/resource-aware-operations/README.md`
 
 This future track should build on the current starter-pack surfaces rather than replace them.


### PR DESCRIPTION
## Summary
- start Phase C of the 1.2 Resource-Aware Operations track with a minimal provider-agnostic runtime adapter contract
- add a lightweight runtime-adapter example under resource-aware operations examples
- wire the new contract into the roadmap and public entrypoints

## Testing
- bash scripts/check-governance.sh
- git diff --check