### PR TITLE
Add agent runtime decision guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- start the next 1.2 layer with advisory runtime/agent decision guidance and a lightweight example
 - start the next 1.2 layer with a minimal runtime adapter contract and lightweight example
 - start the next 1.2 layer with progressive policy signals and a lightweight review example
 - define the first 1.2 telemetry surfaces for resource-aware operations

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The next queued post-1.0 track is resource-aware operations: a docs-first operat
 That 1.2 track now begins with telemetry and waste-reading surfaces rather than adapter or learning-layer work.
 It now also includes a first docs-first policy-signals layer that turns telemetry and waste patterns into reviewable advisory signals.
 The next 1.2 step now begins to define a minimal provider-agnostic runtime adapter contract on top of those surfaces.
+It now also adds an advisory runtime/agent decision layer that helps teams reason about over-allocation and under-allocation without introducing auto-routing.
 
 See also:
 
@@ -196,7 +197,9 @@ If this is your first time here, start with:
 1. `docs/waste-heuristics.md`
 1. `docs/progressive-policy-signals.md`
 1. `docs/runtime-adapter-contract.md`
+1. `docs/agent-runtime-decision-guide.md`
 1. `examples/resource-aware-operations/README.md`
+1. `examples/resource-aware-operations/agent-runtime-decision-example.md`
 1. `examples/resource-aware-operations/minimal-runtime-adapter-example.md`
 1. `docs/architecture.md`
 1. `docs/governance.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -228,3 +228,10 @@ The next docs-first 1.2 layer after policy signals is a minimal runtime adapter 
 - `examples/resource-aware-operations/minimal-runtime-adapter-example.md`
 
 This keeps the track provider-agnostic while making the future adapter surface more concrete without turning AletheIA into a full orchestration platform.
+
+The next docs-first 1.2 layer after the runtime adapter contract is advisory runtime/agent decision guidance through:
+
+- `docs/agent-runtime-decision-guide.md`
+- `examples/resource-aware-operations/agent-runtime-decision-example.md`
+
+This keeps the framework recommendation-oriented while making runtime fit more explicit across changing slice shapes.

--- a/docs/agent-runtime-decision-guide.md
+++ b/docs/agent-runtime-decision-guide.md
@@ -1,0 +1,217 @@
+# Agent / Runtime Decision Guide
+
+## Goal
+
+Define the advisory decision layer for choosing between agents or runtimes in the 1.2 Resource-Aware Operations track.
+
+This guide should help teams make **proportional** choices without turning AletheIA into a rigid router.
+
+---
+
+## Why this exists
+
+AletheIA already has:
+
+- token discipline
+- work slices
+- trust / hosting posture
+- advisory model strategy by task
+- telemetry, waste heuristics, and policy signals in the early 1.2 track
+
+What is still useful is a clearer operational answer to:
+
+- when is a runtime stronger than the slice needs?
+- when is it weaker than the slice really needs?
+- when should a team stay with the current runtime versus change it?
+
+This guide is the advisory bridge between:
+
+- task shape
+- runtime fit
+- operational waste
+- local trust posture
+
+---
+
+## Core principle
+
+AletheIA should recommend the **smallest adequate fit**.
+
+That means:
+
+- do not spend a deep runtime on mechanical work by reflex
+- do not keep a weaker runtime on work that now clearly needs deeper review or reasoning
+- do not treat one runtime choice as universally correct
+
+The framework should suggest.
+The user or project still decides.
+
+---
+
+## Decision axes
+
+### 1. Task shape
+
+Start with the dominant slice shape:
+
+- housekeeping / support work
+- bounded execution
+- planning / decomposition
+- review / critique / validation
+- handoff / compression
+- structured risk inference
+
+### 2. Risk posture
+
+Ask how wrong it is to be wrong here.
+
+Examples:
+
+- low-risk and reversible
+- bounded but meaningful
+- high ambiguity or hard-to-validate
+- trust-sensitive or review-heavy
+
+### 3. Runtime capability fit
+
+Ask what kind of runtime is proportionate:
+
+- lightweight helper
+- balanced executor
+- deep planner / reviewer
+
+### 4. Trust / hosting fit
+
+Ask whether the runtime is acceptable for the material and lane:
+
+- externally hosted allowed
+- hosted but restricted
+- self-hosted preferred
+- self-hosted required
+
+### 5. Restart / handoff burden
+
+Ask whether the slice benefits from staying with the same runtime or would be healthier if handed off to a different fit.
+
+---
+
+## Recommended decision posture
+
+### Stay with the current runtime when:
+
+- the task shape is still aligned
+- retries are not wasteful
+- review burden is still proportional
+- trust posture is still acceptable
+
+### Reconsider the runtime when:
+
+- retries are rising without strategy change
+- the task became more semantic or higher-risk than expected
+- review effort is now heavy enough to signal a mismatch
+- the current runtime is overpowered for repetitive work
+- the current runtime is underpowered for ambiguity, review, or planning depth
+
+---
+
+## Over-allocation signals
+
+A runtime may be too strong for the slice when:
+
+- the task is mechanical and stable
+- the same result could be obtained with a smaller capability profile
+- human review is minimal and the work is easy to inspect
+- the current cost/effort profile is much higher than the value of the slice
+
+Healthy move:
+
+- de-escalate to a smaller adequate fit
+
+---
+
+## Under-allocation signals
+
+A runtime may be too weak for the slice when:
+
+- ambiguity remains high
+- retries are increasing without resolution
+- the work is semantically riskier than first expected
+- the review burden is large because the runtime keeps missing the real judgment problem
+- a compact handoff would be healthier than continuing with the same fit
+
+Healthy move:
+
+- escalate to a stronger fit
+- or hand off to a better-suited runtime or review lane
+
+---
+
+## Simple advisory matrix
+
+| Task shape | Default runtime fit | Escalate when | Reduce when |
+|---|---|---|---|
+| Housekeeping / support | lightweight helper | hidden ambiguity appears or the task stops being local | the work is clearly mechanical |
+| Bounded execution | balanced executor | the work becomes cross-boundary, semantically riskier, or harder to validate | execution becomes repetitive after the hard part is done |
+| Planning / decomposition | deep planner / reviewer | reversibility drops or ambiguity stays high | the planning question narrows into local execution |
+| Review / critique / validation | deep planner / reviewer | trust or semantic risk rises further | the review becomes narrow checklist work |
+| Handoff / compression | lightweight helper or balanced executor | interpretation burden rises or the context is more sensitive | the handoff is already narrow and obvious |
+| Structured risk inference | deep planner / reviewer | assumptions weaken or downside rises | the inference is no longer proportional to the slice |
+
+This matrix is advisory.
+It should not be treated as automatic routing truth.
+
+---
+
+## Relationship to policy signals
+
+The decision layer should listen to signals such as:
+
+- retry-pattern review
+- runtime-fit review
+- human-rescue warning
+- context-inflation warning
+
+These do not force a switch.
+They indicate that the current fit may deserve inspection.
+
+---
+
+## Relationship to local usage plans
+
+Projects may translate this guide into local usage plans.
+
+That is healthy when:
+
+- the defaults are explicit
+- trust posture is explicit
+- fallbacks are explicit
+- overrides are still allowed
+
+It is unhealthy when:
+
+- a local usage plan gets mistaken for framework truth
+- the framework silently becomes an auto-router
+
+---
+
+## What this guide is not
+
+This guide is not:
+
+- a vendor ranking
+- an automatic router
+- a benchmark scorecard
+- a hard policy pack
+- a replacement for local trust-boundary rules
+
+It is an operating guide for better proportionality.
+
+---
+
+## Suggested next reading
+
+- `starter-pack/guides/model-strategy-by-task.md`
+- `docs/progressive-policy-signals.md`
+- `docs/runtime-adapter-contract.md`
+- `examples/model-strategy/provider-agnostic-routing.md`
+- `examples/resource-aware-operations/agent-runtime-decision-example.md`

--- a/docs/resource-aware-operations-roadmap.md
+++ b/docs/resource-aware-operations-roadmap.md
@@ -162,6 +162,11 @@ Expected outputs:
 - **Agent / Runtime Decision Guide**
 - example decision matrix by task shape and risk posture
 
+This phase now begins with:
+
+- `docs/agent-runtime-decision-guide.md`
+- `examples/resource-aware-operations/agent-runtime-decision-example.md`
+
 ### Phase E — workflow guide and readiness layer
 
 Only after observability and adapter shape exist should AletheIA strengthen workflow guidance with:
@@ -285,5 +290,7 @@ This track now begins with:
 - `examples/resource-aware-operations/policy-signals-review-example.md`
 - `docs/runtime-adapter-contract.md`
 - `examples/resource-aware-operations/minimal-runtime-adapter-example.md`
+- `docs/agent-runtime-decision-guide.md`
+- `examples/resource-aware-operations/agent-runtime-decision-example.md`
 
-These are meant to establish the first observability spine, the first advisory signal layer, and a minimal runtime contract before any benchmark or learning-layer work is attempted.
+These are meant to establish the first observability spine, the first advisory signal layer, a minimal runtime contract, and an advisory fit layer before any benchmark or learning-layer work is attempted.

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -244,10 +244,14 @@ The next docs-first layer now also begins with:
 - `docs/runtime-adapter-contract.md`
 - `examples/resource-aware-operations/minimal-runtime-adapter-example.md`
 
+The next docs-first layer now also begins with:
+
+- `docs/agent-runtime-decision-guide.md`
+- `examples/resource-aware-operations/agent-runtime-decision-example.md`
+
 Remaining backlog includes:
 
-- advisory runtime / agent decision guidance
-- planning depth profiles and readiness gates only after observability, signals, and the minimal adapter contract are legible
+- planning depth profiles and readiness gates only after observability, signals, the minimal adapter contract, and the advisory fit layer are legible
 
 ### 1.3+ — Benchmark and comparative evaluation
 

--- a/examples/resource-aware-operations/README.md
+++ b/examples/resource-aware-operations/README.md
@@ -8,3 +8,4 @@ The first examples stay docs-first and intentionally small.
 
 - `policy-signals-review-example.md`
 - `minimal-runtime-adapter-example.md`
+- `agent-runtime-decision-example.md`

--- a/examples/resource-aware-operations/agent-runtime-decision-example.md
+++ b/examples/resource-aware-operations/agent-runtime-decision-example.md
@@ -1,0 +1,56 @@
+# Agent / Runtime Decision Example
+
+## Context
+
+A slice started as bounded execution in a coding runtime.
+
+Initial fit:
+
+- balanced executor
+- standard reasoning depth
+- externally hosted allowed
+
+## What changed
+
+During execution:
+
+- ambiguity stayed higher than expected
+- retries increased
+- the review burden rose because the core issue was no longer just implementation detail
+
+## Advisory read
+
+The current runtime is probably becoming under-allocated for the actual slice.
+
+Why:
+
+- the slice drifted toward planning/review work
+- retries are no longer buying clarity
+- the task now needs stronger decomposition or critique
+
+## Better next move
+
+A healthy next move could be:
+
+- hand off to a deeper planner / reviewer
+- or escalate the current work into a stronger review step
+
+The point is not that one vendor is always correct.
+The point is that the **fit changed** and the runtime choice should change with it.
+
+## Counter-example
+
+If the task had instead become repetitive and mechanical after the hard decision was closed, the healthier move would be the opposite:
+
+- keep the runtime smaller
+- or de-escalate to a lighter fit
+
+## Why this is still advisory-only
+
+This example does not require:
+
+- automatic runtime switching
+- hard blocking
+- universal cost scoring
+
+It only requires that the framework can explain why the current fit is no longer proportional.

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -136,6 +136,7 @@ Read:
 - `docs/waste-heuristics.md`
 - `docs/progressive-policy-signals.md`
 - `docs/runtime-adapter-contract.md`
+- `docs/agent-runtime-decision-guide.md`
 - `examples/resource-aware-operations/README.md`
 
 This future track should build on the current starter-pack surfaces rather than replace them.


### PR DESCRIPTION
## Summary
- add the advisory runtime/agent decision layer for the 1.2 resource-aware operations track
- add a lightweight example showing when a slice should reconsider runtime fit
- wire the new guide into the roadmap and public entrypoints

## Testing
- bash scripts/check-governance.sh
- git diff --check