### PR TITLE
Add planning depth and readiness guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- add planning-depth profiles and a lightweight readiness-gates spec for the 1.2 resource-aware operations track
+
 - start the next 1.2 layer with advisory runtime/agent decision guidance and a lightweight example
 - start the next 1.2 layer with a minimal runtime adapter contract and lightweight example
 - start the next 1.2 layer with progressive policy signals and a lightweight review example

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ That 1.2 track now begins with telemetry and waste-reading surfaces rather than 
 It now also includes a first docs-first policy-signals layer that turns telemetry and waste patterns into reviewable advisory signals.
 The next 1.2 step now begins to define a minimal provider-agnostic runtime adapter contract on top of those surfaces.
 It now also adds an advisory runtime/agent decision layer that helps teams reason about over-allocation and under-allocation without introducing auto-routing.
+The next 1.2 step now introduces lightweight planning-depth profiles and readiness gates so teams can judge how much structure a slice needs and whether it is healthy to continue.
 
 See also:
 
@@ -198,7 +199,10 @@ If this is your first time here, start with:
 1. `docs/progressive-policy-signals.md`
 1. `docs/runtime-adapter-contract.md`
 1. `docs/agent-runtime-decision-guide.md`
+1. `docs/planning-depth-profiles.md`
+1. `docs/readiness-gates-spec.md`
 1. `examples/resource-aware-operations/README.md`
+1. `examples/resource-aware-operations/workflow-readiness-example.md`
 1. `examples/resource-aware-operations/agent-runtime-decision-example.md`
 1. `examples/resource-aware-operations/minimal-runtime-adapter-example.md`
 1. `docs/architecture.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -235,3 +235,11 @@ The next docs-first 1.2 layer after the runtime adapter contract is advisory run
 - `examples/resource-aware-operations/agent-runtime-decision-example.md`
 
 This keeps the framework recommendation-oriented while making runtime fit more explicit across changing slice shapes.
+
+The next docs-first 1.2 layer after advisory runtime fit is a lightweight workflow/readiness surface through:
+
+- `docs/planning-depth-profiles.md`
+- `docs/readiness-gates-spec.md`
+- `examples/resource-aware-operations/workflow-readiness-example.md`
+
+This keeps AletheIA proportional by clarifying how much planning a slice needs and whether it is ready to continue without importing a full delivery methodology.

--- a/docs/planning-depth-profiles.md
+++ b/docs/planning-depth-profiles.md
@@ -1,0 +1,231 @@
+# Planning Depth Profiles
+
+## Goal
+
+Define a small, vendor-agnostic planning-depth layer for the 1.2 Resource-Aware Operations track.
+
+This document exists to help teams choose **how much planning structure** a slice really needs before execution.
+
+It should keep AletheIA proportional.
+It should not turn the framework into a heavyweight delivery lifecycle.
+
+---
+
+## Why this exists
+
+By the time a team reaches the later 1.2 track, AletheIA already has:
+
+- telemetry guidance
+- waste heuristics
+- progressive policy signals
+- a minimal runtime adapter contract
+- advisory runtime / agent fit guidance
+
+What still helps in practice is a simpler answer to:
+
+- how much upfront planning is justified here?
+- when is a lightweight slice enough?
+- when does the work deserve stronger readiness before execution?
+
+That is the purpose of planning-depth profiles.
+
+---
+
+## Core rule
+
+Choose the **smallest planning depth that still makes the next step reviewable**.
+
+Do not over-plan by habit.
+Do not under-plan when ambiguity, risk, or review burden are already visible.
+
+---
+
+## The three profiles
+
+### Lite
+
+Use `Lite` when the slice is:
+
+- narrow
+- reversible
+- locally understandable
+- easy to validate after execution
+
+Typical fit:
+
+- small bounded execution
+- straightforward maintenance work
+- local documentation or support changes
+- compact handoff packaging when the boundary is obvious
+
+What `Lite` should usually make explicit:
+
+- the immediate objective
+- what is in scope now
+- what success looks like
+- the next validation step
+
+What `Lite` should usually avoid:
+
+- deep decomposition
+- extended alternative analysis
+- heavy gate choreography
+
+### Standard
+
+Use `Standard` when the slice is:
+
+- meaningful but still bounded
+- somewhat ambiguous
+- touching more than one artifact or boundary
+- likely to need clearer review or handoff
+
+Typical fit:
+
+- implementation with moderate semantic risk
+- small cross-boundary work
+- reviewable change sets
+- planning that should survive restart or handoff
+
+What `Standard` should usually make explicit:
+
+- objective and scope
+- main non-goals
+- dominant risk posture
+- expected proof shape
+- whether a handoff or review boundary is likely
+
+What `Standard` should usually avoid:
+
+- turning into a full project plan
+- documenting every hypothetical branch before execution begins
+
+### High-Assurance
+
+Use `High-Assurance` when the slice is:
+
+- hard to reverse
+- trust-sensitive
+- semantically risky
+- difficult to validate after the fact
+- likely to require explicit review before execution or before closure
+
+Typical fit:
+
+- structured risk inference
+- higher-stakes review or critique
+- constrained-environment work with strong local rules
+- work where a bad shortcut creates expensive cleanup later
+
+What `High-Assurance` should usually make explicit:
+
+- objective, scope, and exclusions
+- mapped risk posture
+- review and approval expectations
+- validation boundary
+- handoff expectations if execution crosses lanes or runtimes
+
+What `High-Assurance` should still avoid:
+
+- becoming a universal ceremony for normal work
+- trying to predict the full lifecycle beyond the current slice
+
+---
+
+## Choosing a profile
+
+A healthy choice usually depends on five questions.
+
+### 1. How reversible is the work?
+
+- highly reversible -> `Lite`
+- bounded but meaningful -> `Standard`
+- hard to reverse -> `High-Assurance`
+
+### 2. How much ambiguity remains?
+
+- low ambiguity -> `Lite`
+- bounded ambiguity -> `Standard`
+- persistent ambiguity with meaningful downside -> `High-Assurance`
+
+### 3. How hard will review be?
+
+- easy to inspect after execution -> `Lite`
+- reviewable with some structure -> `Standard`
+- review-heavy or trust-sensitive -> `High-Assurance`
+
+### 4. How likely is a handoff?
+
+- no meaningful handoff expected -> `Lite`
+- a reviewable restart package may be needed -> `Standard`
+- handoff clarity is critical -> `High-Assurance`
+
+### 5. How constrained is the local environment?
+
+- ordinary posture -> `Lite` or `Standard`
+- explicit local constraints -> `Standard`
+- strong trust / hosting / approval constraints -> `High-Assurance`
+
+---
+
+## Quick comparison
+
+| Profile | Best fit | Main value | Main failure if underused | Main failure if overused |
+| --- | --- | --- | --- | --- |
+| `Lite` | narrow, reversible slices | speed with legibility | hidden ambiguity gets ignored | not enough structure for review or restart |
+| `Standard` | bounded but meaningful work | clearer reviewable planning | moderate risk is handled too casually | medium work gets treated like a project |
+| `High-Assurance` | trust-sensitive or hard-to-reverse work | explicit gates and proof posture | expensive ambiguity survives into execution | normal work gets buried in ceremony |
+
+---
+
+## Relationship to runtime fit
+
+Planning depth and runtime fit are related, but they are not the same thing.
+
+Examples:
+
+- a `Lite` slice may still need a strong runtime if the interpretation burden is high
+- a `High-Assurance` slice may still delegate some execution steps to a smaller runtime after the risky judgment is closed
+
+Healthy order:
+
+1. understand the slice shape
+2. choose planning depth
+3. choose runtime fit
+4. keep both reviewable as the slice evolves
+
+---
+
+## Relationship to readiness gates
+
+Planning depth explains **how much structure** a slice should receive.
+
+Readiness gates explain **whether the slice is ready enough to continue**.
+
+That means:
+
+- depth answers: `how much planning is justified?`
+- readiness answers: `is this planning sufficient to proceed?`
+
+---
+
+## What this is not
+
+Planning-depth profiles are not:
+
+- a mandatory process for every task
+- a new engine state machine
+- a replacement for local project operating rules
+- a delivery methodology imported wholesale from another framework
+
+They are a proportional planning aid.
+
+---
+
+## Suggested next reading
+
+- `docs/readiness-gates-spec.md`
+- `docs/work-slice-pattern.md`
+- `docs/progressive-policy-signals.md`
+- `docs/agent-runtime-decision-guide.md`
+- `examples/resource-aware-operations/workflow-readiness-example.md`

--- a/docs/readiness-gates-spec.md
+++ b/docs/readiness-gates-spec.md
@@ -1,0 +1,203 @@
+# Readiness Gates Spec
+
+## Goal
+
+Define a light readiness layer for the 1.2 Resource-Aware Operations track.
+
+These gates should help teams decide whether a slice is ready to continue, review, hand off, or stop.
+
+The intent is operational clarity.
+The intent is not rigid early blocking.
+
+---
+
+## Why this exists
+
+AletheIA already helps teams frame work, shape slices, reason about risk, and package handoffs.
+
+What still causes waste in real work is advancing when one of these is still weak:
+
+- context is insufficient
+- the decision is still blurry
+- risk is not really mapped
+- the handoff would not restart cleanly
+- the runtime fit is already wrong for the slice
+
+Readiness gates make those weak spots easier to notice.
+
+---
+
+## Core posture
+
+Readiness gates should begin as **advisory and reviewable**.
+
+They are here to produce better questions such as:
+
+- are we ready to continue?
+- should this pause for review?
+- should the slice be reframed or tightened first?
+- should the work be handed off instead of pushed further here?
+
+They should not start as a rigid enforcement system.
+
+---
+
+## Recommended gates
+
+### 1. Context minimum exists
+
+Ask:
+
+- is the minimum relevant context present?
+- is the context bounded enough for the current slice?
+- are we carrying obvious excess context that should be trimmed or handed off?
+
+Healthy outcome:
+
+- enough context to proceed without guessing
+- not so much context that the slice already carries avoidable inflation
+
+### 2. Decision is clear enough
+
+Ask:
+
+- is the next move explicit?
+- are scope and non-goals understandable?
+- is the reason for proceeding, reviewing, or stopping legible?
+
+Healthy outcome:
+
+- the slice can advance without hidden reinterpretation
+
+### 3. Risk is mapped enough
+
+Ask:
+
+- how wrong is it to be wrong here?
+- is the dominant risk posture explicit enough for this slice?
+- does the planning depth match the risk?
+
+Healthy outcome:
+
+- the slice is not pretending low risk when it is actually hard to reverse or hard to review
+
+### 4. Handoff is usable enough
+
+Ask:
+
+- if this crossed a boundary now, would the next reader be able to resume?
+- is the restart package shape clear enough?
+- would a handoff reduce ambiguity more than continuing here?
+
+Healthy outcome:
+
+- continuity remains possible without replaying the whole thread
+
+### 5. Runtime / agent fit is acceptable enough
+
+Ask:
+
+- is the current runtime still proportional to the slice?
+- are retries, review burden, or ambiguity signaling a mismatch?
+- is the local trust / hosting posture still acceptable?
+
+Healthy outcome:
+
+- the slice is not obviously over-allocated or under-allocated
+
+---
+
+## Gate outcomes
+
+A practical gate review may end in one of these outcomes:
+
+- `continue` -> current posture is acceptable
+- `tighten` -> reduce scope, context, or ambition before continuing
+- `review` -> pause for explicit inspection before proceeding
+- `handoff` -> continuity is healthier through another boundary
+- `escalate` -> stronger runtime, review posture, or approval is needed
+- `stop` -> the slice should not advance under current conditions
+
+These are operational outcomes, not new mandatory engine enums.
+
+---
+
+## Minimum by planning depth
+
+### Lite
+
+For `Lite`, the bar is usually:
+
+- context minimum exists
+- decision is clear enough
+- runtime fit is acceptable enough
+
+### Standard
+
+For `Standard`, the bar is usually:
+
+- context minimum exists
+- decision is clear enough
+- risk is mapped enough
+- runtime fit is acceptable enough
+
+### High-Assurance
+
+For `High-Assurance`, the bar is usually:
+
+- context minimum exists
+- decision is clear enough
+- risk is mapped enough
+- handoff is usable enough when a boundary is likely
+- runtime fit is acceptable enough
+
+---
+
+## Relationship to policy signals
+
+Progressive policy signals can feed gate review.
+
+Examples:
+
+- context inflation warning -> gate 1 deserves review
+- retry waste warning -> gate 5 deserves review
+- weak expansion rationale -> gates 1 and 2 deserve review
+- handoff inflation warning -> gate 4 deserves review
+
+Signals do not replace judgment.
+They help decide which gate needs inspection.
+
+---
+
+## Relationship to planning depth
+
+Readiness gates should not force every slice into the same ceremony.
+
+A healthy rule is:
+
+- `Lite` -> fewer gates need explicit discussion
+- `Standard` -> more gates should be legible
+- `High-Assurance` -> the gates should be explicitly reviewable
+
+---
+
+## What this is not
+
+This spec is not:
+
+- a blocking engine
+- a full approval workflow product
+- a replacement for project-local trust rules
+- a claim that every slice needs all gates at full depth
+
+It is a lightweight review surface.
+
+---
+
+## Suggested next reading
+
+- `docs/planning-depth-profiles.md`
+- `docs/progressive-policy-signals.md`
+- `docs/agent-handoffs.md`
+- `docs/agent-runtime-decision-guide.md`
+- `examples/resource-aware-operations/workflow-readiness-example.md`

--- a/docs/resource-aware-operations-roadmap.md
+++ b/docs/resource-aware-operations-roadmap.md
@@ -195,6 +195,12 @@ Expected outputs:
 - **Readiness Gates Spec**
 - lightweight workflow guide examples
 
+This phase now begins with:
+
+- `docs/planning-depth-profiles.md`
+- `docs/readiness-gates-spec.md`
+- `examples/resource-aware-operations/workflow-readiness-example.md`
+
 ### Phase F — examples before learning
 
 Before any benchmark or learning ambition, the framework should close the loop through:

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -249,9 +249,15 @@ The next docs-first layer now also begins with:
 - `docs/agent-runtime-decision-guide.md`
 - `examples/resource-aware-operations/agent-runtime-decision-example.md`
 
+The next docs-first layer now also begins with:
+
+- `docs/planning-depth-profiles.md`
+- `docs/readiness-gates-spec.md`
+- `examples/resource-aware-operations/workflow-readiness-example.md`
+
 Remaining backlog includes:
 
-- planning depth profiles and readiness gates only after observability, signals, the minimal adapter contract, and the advisory fit layer are legible
+- comparative examples and bounded pilot conversion after observability, signals, the minimal adapter contract, the advisory fit layer, and workflow/readiness surfaces are legible
 
 ### 1.3+ — Benchmark and comparative evaluation
 

--- a/examples/resource-aware-operations/README.md
+++ b/examples/resource-aware-operations/README.md
@@ -9,3 +9,4 @@ The first examples stay docs-first and intentionally small.
 - `policy-signals-review-example.md`
 - `minimal-runtime-adapter-example.md`
 - `agent-runtime-decision-example.md`
+- `workflow-readiness-example.md`

--- a/examples/resource-aware-operations/workflow-readiness-example.md
+++ b/examples/resource-aware-operations/workflow-readiness-example.md
@@ -1,0 +1,72 @@
+# Workflow / Readiness Example
+
+## Context
+
+A slice begins as a medium-sized implementation task with:
+
+- bounded execution
+- moderate semantic risk
+- a likely review step before closure
+
+Initial planning read:
+
+- planning depth -> `Standard`
+- runtime fit -> balanced executor
+
+## Quick readiness review before execution
+
+### Context minimum exists
+
+Pass.
+The slice has the relevant files, local objective, and known constraint boundary.
+
+### Decision is clear enough
+
+Pass.
+The next move and validation shape are explicit.
+
+### Risk is mapped enough
+
+Pass.
+The work is meaningful but still reviewable.
+
+### Handoff is usable enough
+
+Not yet needed.
+A handoff is possible, but not required before execution starts.
+
+### Runtime fit is acceptable enough
+
+Pass.
+The current runtime is proportional to the slice.
+
+## What changed mid-slice
+
+During execution:
+
+- ambiguity rose
+- retries increased
+- the likely review burden became heavier than expected
+
+## Better operational read
+
+The slice still exists, but the posture changed.
+
+Healthier next move:
+
+- keep the slice bounded
+- reconsider runtime fit
+- prepare a clearer review or handoff boundary before continuing
+
+That means the slice may now move from:
+
+- `Standard` planning depth with `continue`
+
+to:
+
+- `Standard` planning depth with a `review` or `handoff` outcome
+
+## Why this matters
+
+The value is not more ceremony.
+The value is noticing early that the work is no longer healthy to push forward in the same posture.

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -137,6 +137,8 @@ Read:
 - `docs/progressive-policy-signals.md`
 - `docs/runtime-adapter-contract.md`
 - `docs/agent-runtime-decision-guide.md`
+- `docs/planning-depth-profiles.md`
+- `docs/readiness-gates-spec.md`
 - `examples/resource-aware-operations/README.md`
 
 This future track should build on the current starter-pack surfaces rather than replace them.


### PR DESCRIPTION
## Summary
- add planning-depth profiles for Lite, Standard, and High-Assurance slices
- add a lightweight readiness-gates spec for continue/review/handoff decisions
- wire the new workflow/readiness layer into the 1.2 roadmap and examples

## Testing
- bash scripts/check-governance.sh
- git diff --check