### PR TITLE
Add resource-aware examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- add bounded Phase F resource-aware examples for comparative review, constrained/local posture, and pilot conversion
+
 - add planning-depth profiles and a lightweight readiness-gates spec for the 1.2 resource-aware operations track
 
 - start the next 1.2 layer with advisory runtime/agent decision guidance and a lightweight example

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ It now also includes a first docs-first policy-signals layer that turns telemetr
 The next 1.2 step now begins to define a minimal provider-agnostic runtime adapter contract on top of those surfaces.
 It now also adds an advisory runtime/agent decision layer that helps teams reason about over-allocation and under-allocation without introducing auto-routing.
 The next 1.2 step now introduces lightweight planning-depth profiles and readiness gates so teams can judge how much structure a slice needs and whether it is healthy to continue.
+It now also adds the first bounded Phase F examples so the 1.2 track can compare postures, show constrained/local use, and demonstrate pilot conversion before any benchmark or learning layer.
 
 See also:
 
@@ -205,6 +206,9 @@ If this is your first time here, start with:
 1. `examples/resource-aware-operations/workflow-readiness-example.md`
 1. `examples/resource-aware-operations/agent-runtime-decision-example.md`
 1. `examples/resource-aware-operations/minimal-runtime-adapter-example.md`
+1. `examples/resource-aware-operations/comparative-review-example.md`
+1. `examples/resource-aware-operations/constrained-local-review-example.md`
+1. `examples/resource-aware-operations/bounded-pilot-conversion-loop.md`
 1. `docs/architecture.md`
 1. `docs/governance.md`
 1. `docs/token-policy.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -243,3 +243,11 @@ The next docs-first 1.2 layer after advisory runtime fit is a lightweight workfl
 - `examples/resource-aware-operations/workflow-readiness-example.md`
 
 This keeps AletheIA proportional by clarifying how much planning a slice needs and whether it is ready to continue without importing a full delivery methodology.
+
+The next docs-first 1.2 layer after workflow/readiness is a bounded examples-first closure through:
+
+- `examples/resource-aware-operations/comparative-review-example.md`
+- `examples/resource-aware-operations/constrained-local-review-example.md`
+- `examples/resource-aware-operations/bounded-pilot-conversion-loop.md`
+
+This keeps the track evidential and proportional before any benchmark or learning ambition.

--- a/docs/resource-aware-operations-roadmap.md
+++ b/docs/resource-aware-operations-roadmap.md
@@ -212,6 +212,12 @@ Before any benchmark or learning ambition, the framework should close the loop t
 
 The purpose is to prove that the operational surfaces help in real use before they become a bigger system.
 
+This phase now begins with:
+
+- `examples/resource-aware-operations/comparative-review-example.md`
+- `examples/resource-aware-operations/constrained-local-review-example.md`
+- `examples/resource-aware-operations/bounded-pilot-conversion-loop.md`
+
 ---
 
 ## What this track explicitly defers

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -255,9 +255,15 @@ The next docs-first layer now also begins with:
 - `docs/readiness-gates-spec.md`
 - `examples/resource-aware-operations/workflow-readiness-example.md`
 
+The next docs-first layer now also begins with:
+
+- `examples/resource-aware-operations/comparative-review-example.md`
+- `examples/resource-aware-operations/constrained-local-review-example.md`
+- `examples/resource-aware-operations/bounded-pilot-conversion-loop.md`
+
 Remaining backlog includes:
 
-- comparative examples and bounded pilot conversion after observability, signals, the minimal adapter contract, the advisory fit layer, and workflow/readiness surfaces are legible
+- stronger bounded real-world conversions before any benchmark or learning ambition
 
 ### 1.3+ — Benchmark and comparative evaluation
 

--- a/examples/resource-aware-operations/README.md
+++ b/examples/resource-aware-operations/README.md
@@ -10,3 +10,6 @@ The first examples stay docs-first and intentionally small.
 - `minimal-runtime-adapter-example.md`
 - `agent-runtime-decision-example.md`
 - `workflow-readiness-example.md`
+- `comparative-review-example.md`
+- `constrained-local-review-example.md`
+- `bounded-pilot-conversion-loop.md`

--- a/examples/resource-aware-operations/bounded-pilot-conversion-loop.md
+++ b/examples/resource-aware-operations/bounded-pilot-conversion-loop.md
@@ -1,0 +1,67 @@
+# Bounded Pilot Conversion Loop
+
+## Goal
+
+Show one small loop where resource-aware observations become a reviewable framework refinement candidate without jumping to learning-layer machinery.
+
+---
+
+## Pilot context
+
+A small pilot repeatedly showed the same pattern:
+
+- slices began acceptably
+- retries rose late in the round
+- the review burden spiked only near closure
+- handoffs were still possible, but later than ideal
+
+---
+
+## What the team used
+
+The team applied:
+
+- telemetry fields for slice and handoff weight
+- waste heuristics for retry and context drag
+- progressive policy signals
+- planning depth and readiness review
+
+---
+
+## What became visible
+
+The pattern was not:
+
+- missing capability in the framework core
+- a need for immediate benchmark infrastructure
+- a need for learning-layer automation
+
+The pattern was:
+
+- readiness review was happening too late
+- retry growth should have triggered an earlier review pause
+
+---
+
+## Reviewable pilot conclusion
+
+A healthy pilot conclusion could be:
+
+- keep the current 1.2 surfaces
+- reinforce earlier use of readiness review on retry growth
+- add a better example before adding a bigger system
+
+That is a valid pilot-conversion outcome because it says:
+
+- the framework learned something useful
+- but the right next move is still proportional
+
+---
+
+## Why this matters
+
+This is how AletheIA should mature:
+
+- examples first
+- bounded pilot conversion second
+- benchmark and learning only after repeated evidence justifies them

--- a/examples/resource-aware-operations/comparative-review-example.md
+++ b/examples/resource-aware-operations/comparative-review-example.md
@@ -1,0 +1,87 @@
+# Comparative Review Example
+
+## Goal
+
+Show how a team can compare two slice postures without turning AletheIA into a benchmark system.
+
+This example stays qualitative and review-oriented.
+
+---
+
+## Scenario
+
+Two teams handled a similar bounded implementation slice.
+
+Both had:
+
+- the same broad objective
+- a similar trust posture
+- comparable scope
+
+The difference was operational discipline.
+
+### Slice A
+
+Used:
+
+- bounded context selection
+- explicit expansion rationale
+- one compact handoff
+- one readiness review before the final push
+
+### Slice B
+
+Used:
+
+- larger inherited context without clear trimming
+- retries without a clear change in strategy
+- a looser handoff recap
+- no explicit readiness pause before final continuation
+
+---
+
+## Comparative read
+
+### Slice A
+
+Healthy signals:
+
+- context stayed proportional
+- the handoff remained resumable
+- runtime fit stayed acceptable
+- review effort remained bounded
+
+### Slice B
+
+Warning signals:
+
+- context inflation was tolerated too long
+- retries increased without changing the slice posture
+- the handoff carried more narrative weight than restart value
+- final review effort became heavier than the slice deserved
+
+---
+
+## What this comparison is for
+
+The point is not to score winners.
+
+The point is to ask:
+
+- which slice produced less operational waste?
+- which signals were visible early enough to help?
+- which posture should be repeated next time?
+
+---
+
+## Healthy conclusion
+
+AletheIA should prefer the posture behind Slice A because it kept:
+
+- lower context drag
+- clearer restartability
+- lower review burden
+- more proportional continuation
+
+That is enough for a comparative review example.
+It is **not** yet a benchmark layer.

--- a/examples/resource-aware-operations/constrained-local-review-example.md
+++ b/examples/resource-aware-operations/constrained-local-review-example.md
@@ -1,0 +1,70 @@
+# Constrained / Local Review Example
+
+## Goal
+
+Show how the 1.2 resource-aware surfaces can be used inside a locally constrained environment without moving trust-boundary specifics into the core.
+
+---
+
+## Context
+
+A project runs with:
+
+- hosted tools allowed only for low-sensitivity slices
+- stronger review expectations on restart packages
+- explicit local preference for tighter context before handoff
+
+The slice is a reviewable maintenance task.
+
+Initial posture:
+
+- planning depth -> `Standard`
+- runtime fit -> acceptable under local restrictions
+- handoff not yet required
+
+---
+
+## What changed
+
+During the slice:
+
+- the context started growing because related historical notes were repeatedly reattached
+- a likely handoff appeared because the next review would happen in a different lane
+- the trust posture itself did not change, but the restart package became more important
+
+---
+
+## Local read using 1.2 surfaces
+
+### Telemetry / waste read
+
+- handoff size is growing
+- cold restart burden is rising
+- context inflation is appearing even though the slice is still bounded
+
+### Policy-signal read
+
+Healthy warning:
+
+- the slice should justify further expansion or tighten the restart package first
+
+### Readiness read
+
+Best gate to inspect:
+
+- `handoff is usable enough`
+
+### Better next move
+
+- tighten the restart package
+- keep only the minimum context needed for the receiving lane
+- preserve the local trust posture instead of changing runtime by reflex
+
+---
+
+## Why this matters
+
+The useful lesson is:
+
+- a constrained environment does not automatically mean a different framework core
+- it often means the local project applies the same 1.2 surfaces with stricter thresholds and clearer stop lines

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -140,5 +140,8 @@ Read:
 - `docs/planning-depth-profiles.md`
 - `docs/readiness-gates-spec.md`
 - `examples/resource-aware-operations/README.md`
+- `examples/resource-aware-operations/comparative-review-example.md`
+- `examples/resource-aware-operations/constrained-local-review-example.md`
+- `examples/resource-aware-operations/bounded-pilot-conversion-loop.md`
 
 This future track should build on the current starter-pack surfaces rather than replace them.


### PR DESCRIPTION
## Summary
- add the first bounded Phase F examples for comparative review, constrained/local posture, and pilot conversion
- update the resource-aware roadmap to show the examples-first closure before benchmark or learning
- refresh README and public entrypoints so the new examples are visible in the reading order

## Testing
- bash scripts/check-governance.sh
- git diff --check