### PR TITLE
Add resource-aware bounded pilot guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- add bounded real-world pilot guidance, checklist, and template for the 1.2 resource-aware operations track
+
 - add bounded Phase F resource-aware examples for comparative review, constrained/local posture, and pilot conversion
 
 - add planning-depth profiles and a lightweight readiness-gates spec for the 1.2 resource-aware operations track

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ The next 1.2 step now begins to define a minimal provider-agnostic runtime adapt
 It now also adds an advisory runtime/agent decision layer that helps teams reason about over-allocation and under-allocation without introducing auto-routing.
 The next 1.2 step now introduces lightweight planning-depth profiles and readiness gates so teams can judge how much structure a slice needs and whether it is healthy to continue.
 It now also adds the first bounded Phase F examples so the 1.2 track can compare postures, show constrained/local use, and demonstrate pilot conversion before any benchmark or learning layer.
+It now also adds a bounded pilot guide/checklist/template so real-world 1.2 validation can happen before any benchmark or learning-layer escalation.
 
 See also:
 
@@ -209,6 +210,9 @@ If this is your first time here, start with:
 1. `examples/resource-aware-operations/comparative-review-example.md`
 1. `examples/resource-aware-operations/constrained-local-review-example.md`
 1. `examples/resource-aware-operations/bounded-pilot-conversion-loop.md`
+1. `docs/resource-aware-bounded-pilot.md`
+1. `docs/resource-aware-pilot-review-checklist.md`
+1. `starter-pack/templates/resource-aware-pilot-review-template.md`
 1. `docs/architecture.md`
 1. `docs/governance.md`
 1. `docs/token-policy.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -251,3 +251,11 @@ The next docs-first 1.2 layer after workflow/readiness is a bounded examples-fir
 - `examples/resource-aware-operations/bounded-pilot-conversion-loop.md`
 
 This keeps the track evidential and proportional before any benchmark or learning ambition.
+
+The next bounded 1.2 step after these examples is a real-world pilot layer through:
+
+- `docs/resource-aware-bounded-pilot.md`
+- `docs/resource-aware-pilot-review-checklist.md`
+- `starter-pack/templates/resource-aware-pilot-review-template.md`
+
+This keeps the next move operational and reviewable without reopening benchmark or learning work early.

--- a/docs/resource-aware-bounded-pilot.md
+++ b/docs/resource-aware-bounded-pilot.md
@@ -1,0 +1,163 @@
+# Resource-Aware Bounded Pilot
+
+## Goal
+
+Define the smallest healthy way to validate the 1.2 Resource-Aware Operations surfaces in a real project slice.
+
+This should happen before any benchmark or learning-layer ambition.
+
+---
+
+## Why this exists
+
+The 1.2 track now has:
+
+- telemetry guidance
+- waste heuristics
+- progressive policy signals
+- a runtime adapter shape
+- advisory runtime / agent fit guidance
+- planning-depth profiles
+- readiness gates
+- bounded examples
+
+What is still needed is a clearer answer to:
+
+- how should a team test these surfaces in real work?
+- what should a bounded pilot actually prove?
+- what should remain local instead of flowing back into the framework?
+
+---
+
+## Pilot posture
+
+A resource-aware pilot should be:
+
+- small
+- reviewable
+- reversible
+- evidence-oriented
+- local-first
+
+Do **not** begin with:
+
+- benchmark infrastructure
+- automatic routing
+- cost optimization dashboards
+- learning-layer claims
+
+---
+
+## Good pilot candidates
+
+A bounded pilot is healthiest when the slice already has at least one of these pressures:
+
+- growing context drag
+- repeated retries without new strategy
+- heavier review burden than expected
+- weak restart packages across a real handoff
+- runtime fit that looks too strong or too weak for the actual slice
+
+Good candidate shapes:
+
+- bounded implementation with one review boundary
+- constrained/local slice with stronger trust posture
+- repeated maintenance round with visible retry waste
+- cross-runtime or cross-lane handoff where restart quality matters
+
+---
+
+## What the pilot should instrument
+
+A small pilot should try to make at least these things legible:
+
+### 1. Slice shape
+
+- what kind of work this was
+- what planning depth was used
+- what runtime fit was chosen
+
+### 2. Resource posture
+
+- whether context stayed bounded
+- whether retries rose or stabilized
+- whether handoff size stayed proportional
+- whether review burden felt acceptable
+
+### 3. Gate posture
+
+- whether readiness gates were checked explicitly
+- whether the slice should have paused earlier
+- whether a handoff would have been healthier earlier
+
+### 4. Local constraints
+
+- what trust / hosting rules were local
+- what remained project-specific
+- what should not be generalized into the framework
+
+---
+
+## What the pilot should prove
+
+A bounded pilot does not need to prove everything.
+
+It is enough if it proves one or more of these:
+
+- the 1.2 surfaces helped detect avoidable waste earlier
+- the chosen planning depth was proportional or should have changed
+- the runtime fit was healthier after an explicit review
+- the restart package became clearer and smaller
+- the framework surfaces were useful without expanding the core
+
+---
+
+## Valid pilot outcomes
+
+A healthy resource-aware pilot may conclude with:
+
+- `reinforced` -> the current 1.2 surfaces were enough
+- `no-change` -> the issue was local, not a framework gap
+- `example-needed` -> the framework mainly needs a better worked example
+- `guidance-refinement` -> wording or ordering should improve
+- `future-benchmark-signal` -> repeated comparable patterns now exist, but benchmark is still deferred
+
+The point is not to force a framework change every time.
+
+---
+
+## What should remain local
+
+A pilot should usually keep these things out of the framework core:
+
+- provider-specific rules
+- exact trust-boundary thresholds
+- local routing defaults
+- local approval workflow details
+- local cost ceilings and procurement choices
+
+Those belong in the project extension layer or local operating rules.
+
+---
+
+## Healthy closure
+
+A bounded pilot closes well when it leaves behind:
+
+- a compact reviewable summary
+- what the framework helped with
+- what remained local
+- what, if anything, deserves another example or later track follow-up
+
+That is enough to mature the 1.2 track proportionally.
+
+---
+
+## Suggested next reading
+
+- `docs/resource-aware-operations-roadmap.md`
+- `docs/progressive-policy-signals.md`
+- `docs/planning-depth-profiles.md`
+- `docs/readiness-gates-spec.md`
+- `docs/resource-aware-pilot-review-checklist.md`
+- `starter-pack/templates/resource-aware-pilot-review-template.md`

--- a/docs/resource-aware-operations-roadmap.md
+++ b/docs/resource-aware-operations-roadmap.md
@@ -217,6 +217,9 @@ This phase now begins with:
 - `examples/resource-aware-operations/comparative-review-example.md`
 - `examples/resource-aware-operations/constrained-local-review-example.md`
 - `examples/resource-aware-operations/bounded-pilot-conversion-loop.md`
+- `docs/resource-aware-bounded-pilot.md`
+- `docs/resource-aware-pilot-review-checklist.md`
+- `starter-pack/templates/resource-aware-pilot-review-template.md`
 
 ---
 

--- a/docs/resource-aware-pilot-review-checklist.md
+++ b/docs/resource-aware-pilot-review-checklist.md
@@ -1,0 +1,41 @@
+# Resource-Aware Pilot Review Checklist
+
+## Goal
+
+Provide a short review checklist for bounded real-world pilots in the 1.2 Resource-Aware Operations track.
+
+---
+
+## Before the pilot
+
+- [ ] The slice is small enough to review without benchmark infrastructure
+- [ ] The slice has a visible resource-aware pressure (context drag, retries, handoff burden, or runtime-fit doubt)
+- [ ] Local trust / hosting posture is explicit
+- [ ] The team knows what should remain project-local
+
+## During the pilot
+
+- [ ] Slice shape is explicit
+- [ ] Planning depth is explicit
+- [ ] Runtime fit is explicit
+- [ ] At least one readiness review is performed
+- [ ] Context growth or retry growth is noted when it appears
+- [ ] Handoff quality is reviewed if a boundary is crossed
+
+## After the pilot
+
+- [ ] The pilot can explain whether the framework helped earlier than intuition alone
+- [ ] The result is classified as reinforced, no-change, example-needed, guidance-refinement, or future-benchmark-signal
+- [ ] Project-local rules are separated from framework-level learnings
+- [ ] Any follow-up recommendation stays proportional to the evidence
+
+## Healthy stop line
+
+If the pilot conclusion starts requiring:
+
+- benchmark scoring
+- auto-routing
+- vendor ranking as core truth
+- learning-layer machinery
+
+then the pilot should stop and record that the 1.2 evidence is not yet mature enough for that leap.

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -261,9 +261,15 @@ The next docs-first layer now also begins with:
 - `examples/resource-aware-operations/constrained-local-review-example.md`
 - `examples/resource-aware-operations/bounded-pilot-conversion-loop.md`
 
+The next bounded 1.2 layer now also begins with:
+
+- `docs/resource-aware-bounded-pilot.md`
+- `docs/resource-aware-pilot-review-checklist.md`
+- `starter-pack/templates/resource-aware-pilot-review-template.md`
+
 Remaining backlog includes:
 
-- stronger bounded real-world conversions before any benchmark or learning ambition
+- stronger real-world pilot evidence before any benchmark or learning ambition
 
 ### 1.3+ — Benchmark and comparative evaluation
 

--- a/examples/resource-aware-operations/README.md
+++ b/examples/resource-aware-operations/README.md
@@ -13,3 +13,9 @@ The first examples stay docs-first and intentionally small.
 - `comparative-review-example.md`
 - `constrained-local-review-example.md`
 - `bounded-pilot-conversion-loop.md`
+
+## Related pilot support
+
+- `../../docs/resource-aware-bounded-pilot.md`
+- `../../docs/resource-aware-pilot-review-checklist.md`
+- `../../starter-pack/templates/resource-aware-pilot-review-template.md`

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -143,5 +143,8 @@ Read:
 - `examples/resource-aware-operations/comparative-review-example.md`
 - `examples/resource-aware-operations/constrained-local-review-example.md`
 - `examples/resource-aware-operations/bounded-pilot-conversion-loop.md`
+- `docs/resource-aware-bounded-pilot.md`
+- `docs/resource-aware-pilot-review-checklist.md`
+- `starter-pack/templates/resource-aware-pilot-review-template.md`
 
 This future track should build on the current starter-pack surfaces rather than replace them.

--- a/starter-pack/templates/resource-aware-pilot-review-template.md
+++ b/starter-pack/templates/resource-aware-pilot-review-template.md
@@ -1,0 +1,34 @@
+# Resource-Aware Pilot Review
+
+## Slice
+
+- Slice shape:
+- Planning depth:
+- Runtime fit:
+- Local trust / hosting posture:
+
+## Observed pressure
+
+- Context drag:
+- Retry pattern:
+- Handoff burden:
+- Review burden:
+
+## What helped
+
+- Telemetry / heuristics:
+- Policy signals:
+- Runtime-fit guidance:
+- Readiness review:
+
+## What remained local
+
+- Local rules:
+- Local thresholds:
+- Local workflow details:
+
+## Outcome
+
+- Result mode:
+- Why:
+- Follow-up:


### PR DESCRIPTION
## Summary
- add bounded real-world pilot guidance for the 1.2 resource-aware operations track
- add a review checklist and starter-pack template for small real-world pilot reviews
- update the README and roadmap entrypoints so this next step is visible before benchmark or learning work

## Testing
- bash scripts/check-governance.sh
- git diff --check