### PR TITLE
Add resource-aware crisis reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- add a bounded Crisis Monitor reference for the 1.2 resource-aware operations pilot layer
+
 - add bounded real-world pilot guidance, checklist, and template for the 1.2 resource-aware operations track
 
 - add bounded Phase F resource-aware examples for comparative review, constrained/local posture, and pilot conversion

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ It now also adds an advisory runtime/agent decision layer that helps teams reaso
 The next 1.2 step now introduces lightweight planning-depth profiles and readiness gates so teams can judge how much structure a slice needs and whether it is healthy to continue.
 It now also adds the first bounded Phase F examples so the 1.2 track can compare postures, show constrained/local use, and demonstrate pilot conversion before any benchmark or learning layer.
 It now also adds a bounded pilot guide/checklist/template so real-world 1.2 validation can happen before any benchmark or learning-layer escalation.
+It now also includes a bounded Crisis Monitor reference so the 1.2 track has one real-world pilot-shaped reading before any benchmark or learning move.
 
 See also:
 
@@ -213,6 +214,8 @@ If this is your first time here, start with:
 1. `docs/resource-aware-bounded-pilot.md`
 1. `docs/resource-aware-pilot-review-checklist.md`
 1. `starter-pack/templates/resource-aware-pilot-review-template.md`
+1. `docs/resource-aware-crisis-monitor-reference.md`
+1. `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
 1. `docs/architecture.md`
 1. `docs/governance.md`
 1. `docs/token-policy.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -259,3 +259,10 @@ The next bounded 1.2 step after these examples is a real-world pilot layer throu
 - `starter-pack/templates/resource-aware-pilot-review-template.md`
 
 This keeps the next move operational and reviewable without reopening benchmark or learning work early.
+
+The next bounded 1.2 reference layer now also includes:
+
+- `docs/resource-aware-crisis-monitor-reference.md`
+- `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
+
+This keeps the track anchored in one believable real-world read without collapsing local product logic into the framework.

--- a/docs/resource-aware-crisis-monitor-reference.md
+++ b/docs/resource-aware-crisis-monitor-reference.md
@@ -1,0 +1,129 @@
+# Resource-Aware Crisis Monitor Reference
+
+## Goal
+
+Record a bounded real-world reference for the 1.2 Resource-Aware Operations track using the existing Crisis Monitor lane evidence.
+
+This is not a benchmark.
+This is not a learning-layer claim.
+It is a bounded operational reference.
+
+---
+
+## Why this reference exists
+
+The 1.2 track now has:
+
+- telemetry guidance
+- waste heuristics
+- policy signals
+- runtime-fit guidance
+- workflow/readiness guidance
+- bounded pilot guidance
+
+A real reference helps answer a simpler question:
+
+- do these surfaces describe something useful in real work without inflating the framework?
+
+---
+
+## Reference posture
+
+This reference uses a small lane where:
+
+- the work stayed bounded
+- explainability and review mattered
+- handoff and round closure mattered
+- the local product rules stayed outside the framework
+
+The point is not to claim that Crisis Monitor is now "running AletheIA telemetry."
+The point is that the lane provides a believable operational shape for the 1.2 surfaces.
+
+---
+
+## What the lane made visible
+
+### Slice shape
+
+The lane behaved like:
+
+- bounded execution
+- moderate semantic risk
+- likely review and closure boundaries
+
+That makes it a healthy fit for:
+
+- `Standard` planning depth
+- explicit checkpoint or readiness review before continuing blindly
+- compact restart-oriented closure rather than long recap
+
+### Resource-aware pressure
+
+The lane made these pressures legible:
+
+- if a round keeps going after the useful slice is closed, context drag rises
+- if the next step is not explicit, review burden rises later
+- if a textual clarification is local and small, the framework should not pretend a new large capability layer is needed
+
+### Healthier operational read
+
+The healthy read is not:
+
+- add benchmark machinery
+- add automatic routing
+- add learning-layer behavior
+
+The healthy read is:
+
+- keep the slice small
+- use review/checkpoint posture before drift grows
+- close with a compact handoff when another boundary should continue
+
+---
+
+## What this reinforces
+
+This reference reinforces that the 1.2 surfaces are most useful when they help teams ask:
+
+- is this slice still bounded?
+- should this pause for review now instead of later?
+- is the current runtime or boundary still proportional?
+- would a compact restart package be healthier than extending the same round?
+
+That is enough value for this stage.
+
+---
+
+## What remained local
+
+The Crisis Monitor reference still keeps these things local:
+
+- product semantics
+- local trust and approval rules
+- UX and content decisions tied to the product
+- local runtime preferences
+- product-specific thresholds
+
+This is important because the framework should learn the operating pattern, not absorb the product.
+
+---
+
+## Healthy result mode
+
+The best current result mode for this reference is:
+
+- `reinforced`
+
+Why:
+
+- the existing 1.2 surfaces already describe the useful operational reading
+- the main value is making that reading explicit
+- no benchmark or learning escalation is justified yet
+
+---
+
+## Suggested next reading
+
+- `docs/resource-aware-bounded-pilot.md`
+- `docs/resource-aware-pilot-review-checklist.md`
+- `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`

--- a/docs/resource-aware-operations-roadmap.md
+++ b/docs/resource-aware-operations-roadmap.md
@@ -220,6 +220,8 @@ This phase now begins with:
 - `docs/resource-aware-bounded-pilot.md`
 - `docs/resource-aware-pilot-review-checklist.md`
 - `starter-pack/templates/resource-aware-pilot-review-template.md`
+- `docs/resource-aware-crisis-monitor-reference.md`
+- `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
 
 ---
 

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -266,10 +266,12 @@ The next bounded 1.2 layer now also begins with:
 - `docs/resource-aware-bounded-pilot.md`
 - `docs/resource-aware-pilot-review-checklist.md`
 - `starter-pack/templates/resource-aware-pilot-review-template.md`
+- `docs/resource-aware-crisis-monitor-reference.md`
+- `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
 
 Remaining backlog includes:
 
-- stronger real-world pilot evidence before any benchmark or learning ambition
+- stronger repeated real-world pilot evidence before any benchmark or learning ambition
 
 ### 1.3+ — Benchmark and comparative evaluation
 

--- a/examples/resource-aware-operations/README.md
+++ b/examples/resource-aware-operations/README.md
@@ -19,3 +19,5 @@ The first examples stay docs-first and intentionally small.
 - `../../docs/resource-aware-bounded-pilot.md`
 - `../../docs/resource-aware-pilot-review-checklist.md`
 - `../../starter-pack/templates/resource-aware-pilot-review-template.md`
+- `resource-aware-pilot-review-reference.md`
+- `../../docs/resource-aware-crisis-monitor-reference.md`

--- a/examples/resource-aware-operations/resource-aware-pilot-review-reference.md
+++ b/examples/resource-aware-operations/resource-aware-pilot-review-reference.md
@@ -1,0 +1,35 @@
+# Resource-Aware Pilot Review Reference
+
+## Slice
+
+- Slice shape: bounded execution with reviewable closure
+- Planning depth: `Standard`
+- Runtime fit: acceptable for bounded execution, with review/checkpoint help more important than escalation
+- Local trust / hosting posture: project-local and unchanged
+
+## Observed pressure
+
+- Context drag: would rise if the round kept expanding after the useful slice was closed
+- Retry pattern: manageable while the slice stayed narrow
+- Handoff burden: low when closure stayed compact; higher if continuation stayed implicit
+- Review burden: increased when the next step was not made explicit early enough
+
+## What helped
+
+- Policy signals: useful as a way to justify a pause before unnecessary continuation
+- Runtime-fit guidance: useful mainly to confirm no larger escalation was needed
+- Readiness review: useful to decide between continue, handoff, or closure
+- Compact handoff posture: useful to preserve restartability without replaying the whole thread
+
+## What remained local
+
+- Local product semantics
+- Product-specific approval logic
+- UX/content details tied to the product lane
+- Any local runtime preference or threshold
+
+## Outcome
+
+- Result mode: `reinforced`
+- Why: the current 1.2 surfaces already describe the healthiest operational read
+- Follow-up: wait for a genuinely stronger real-world signal before opening benchmark or learning-layer work

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -146,5 +146,7 @@ Read:
 - `docs/resource-aware-bounded-pilot.md`
 - `docs/resource-aware-pilot-review-checklist.md`
 - `starter-pack/templates/resource-aware-pilot-review-template.md`
+- `docs/resource-aware-crisis-monitor-reference.md`
+- `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
 
 This future track should build on the current starter-pack surfaces rather than replace them.


### PR DESCRIPTION
## Summary
- add a bounded Crisis Monitor reference for the 1.2 resource-aware operations track
- add a lightweight pilot review reference showing a reinforced outcome instead of benchmark escalation
- update the README and roadmap entrypoints so the real-world reference is visible

## Testing
- bash scripts/check-governance.sh
- git diff --check