### PR TITLE
Add resource-aware next signals guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- add a resource-aware next-signals guide so the 1.2 track only reopens on stronger evidence
+
 - add a bounded Crisis Monitor reference for the 1.2 resource-aware operations pilot layer
 
 - add bounded real-world pilot guidance, checklist, and template for the 1.2 resource-aware operations track

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ The next 1.2 step now introduces lightweight planning-depth profiles and readine
 It now also adds the first bounded Phase F examples so the 1.2 track can compare postures, show constrained/local use, and demonstrate pilot conversion before any benchmark or learning layer.
 It now also adds a bounded pilot guide/checklist/template so real-world 1.2 validation can happen before any benchmark or learning-layer escalation.
 It now also includes a bounded Crisis Monitor reference so the 1.2 track has one real-world pilot-shaped reading before any benchmark or learning move.
+It now also defines the next signals that would justify reopening the track for stronger comparative work instead of growing by inertia.
 
 See also:
 
@@ -216,6 +217,7 @@ If this is your first time here, start with:
 1. `starter-pack/templates/resource-aware-pilot-review-template.md`
 1. `docs/resource-aware-crisis-monitor-reference.md`
 1. `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
+1. `docs/resource-aware-next-signals.md`
 1. `docs/architecture.md`
 1. `docs/governance.md`
 1. `docs/token-policy.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -266,3 +266,9 @@ The next bounded 1.2 reference layer now also includes:
 - `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
 
 This keeps the track anchored in one believable real-world read without collapsing local product logic into the framework.
+
+The next bounded 1.2 closure layer now also includes:
+
+- `docs/resource-aware-next-signals.md`
+
+This makes the stop line explicit so the track only reopens when evidence becomes stronger than one reference.

--- a/docs/resource-aware-next-signals.md
+++ b/docs/resource-aware-next-signals.md
@@ -1,0 +1,144 @@
+# Resource-Aware Next Signals
+
+## Goal
+
+Define the signals that would justify reopening the AletheIA 1.2 Resource-Aware Operations track for stronger evidence work or for the start of 1.3+ comparative evaluation.
+
+This document exists to prevent growth by inertia.
+
+---
+
+## Why this exists
+
+The 1.2 track now has:
+
+- telemetry guidance
+- policy signals
+- runtime-fit guidance
+- planning-depth and readiness guidance
+- bounded examples
+- bounded pilot guidance
+- a real-world reference
+
+That means the next healthy question is no longer:
+
+- what other surface can we publish?
+
+It becomes:
+
+- what kind of real evidence would justify reopening the track?
+
+---
+
+## Core rule
+
+Do not reopen the track because the framework feels incomplete.
+
+Reopen it only when the evidence suggests one of these:
+
+- the current surfaces are repeatedly useful in comparable real work
+- the current surfaces are repeatedly insufficient in a similar way
+- a stronger comparative layer would now be reviewable instead of speculative
+
+---
+
+## Healthy signals to watch for
+
+### 1. Repeated comparable slices
+
+A stronger next step becomes healthier when multiple slices show:
+
+- similar shape
+- similar resource-aware pressure
+- similar review outcomes
+
+This is the earliest believable signal for future comparative evaluation.
+
+### 2. Repeated late-stage waste
+
+Watch for repeated cases where teams discover too late that:
+
+- context drag had already grown too far
+- retry growth should have triggered a review pause earlier
+- handoff inflation was visible but not acted on
+- runtime fit mismatch remained hidden until late review
+
+This can justify sharper guidance or example refinement.
+
+### 3. Repeated local translations of the same pattern
+
+If several projects keep creating similar local rules for:
+
+- restart-package tightening
+- review-pause timing
+- slice stopping criteria
+- runtime-fit reconsideration
+
+that may justify stronger cross-project comparison later.
+
+### 4. Stable reinforced outcomes across more than one project
+
+If multiple projects end with:
+
+- `reinforced`
+- or `no-change`
+
+for the same broad pattern, that is useful evidence too.
+
+It means the current surfaces are likely mature enough for the class of problem being observed.
+
+---
+
+## Signals that are not enough by themselves
+
+These should **not** trigger 1.3 on their own:
+
+- one interesting example
+- one unusually difficult slice
+- one project's local preference
+- one team's vendor choice
+- one isolated desire for benchmarking
+
+Those are inputs, not thresholds.
+
+---
+
+## What can justify 1.3+
+
+A healthy move toward 1.3+ comparative evaluation usually needs a combination such as:
+
+- more than one believable real-world slice
+- comparable review language across those slices
+- enough structure to compare without hiding important local differences
+- no need yet for learning-layer or auto-routing claims
+
+In simple terms:
+
+- repeated evidence first
+- comparative framing second
+- benchmark packaging only after that
+
+---
+
+## What should still stay deferred
+
+Even with stronger signals, these should stay deferred until much later unless the evidence becomes unusually strong:
+
+- vendor ranking as core truth
+- auto-routing claims
+- learning-layer behavior
+- orchestration-heavy policy machinery
+
+The framework should stay provider-agnostic and review-oriented.
+
+---
+
+## Healthy current posture
+
+The healthy posture right now is:
+
+- keep 1.2 stable
+- wait for repeated real-world evidence
+- reopen only when the signals become cross-slice or cross-project rather than anecdotal
+
+That is enough discipline for this stage.

--- a/docs/resource-aware-operations-roadmap.md
+++ b/docs/resource-aware-operations-roadmap.md
@@ -222,6 +222,7 @@ This phase now begins with:
 - `starter-pack/templates/resource-aware-pilot-review-template.md`
 - `docs/resource-aware-crisis-monitor-reference.md`
 - `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
+- `docs/resource-aware-next-signals.md`
 
 ---
 

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -268,6 +268,7 @@ The next bounded 1.2 layer now also begins with:
 - `starter-pack/templates/resource-aware-pilot-review-template.md`
 - `docs/resource-aware-crisis-monitor-reference.md`
 - `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
+- `docs/resource-aware-next-signals.md`
 
 Remaining backlog includes:
 

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -148,5 +148,6 @@ Read:
 - `starter-pack/templates/resource-aware-pilot-review-template.md`
 - `docs/resource-aware-crisis-monitor-reference.md`
 - `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
+- `docs/resource-aware-next-signals.md`
 
 This future track should build on the current starter-pack surfaces rather than replace them.


### PR DESCRIPTION
## Summary
- add a next-signals guide that defines when the 1.2 resource-aware track should reopen
- update the README and roadmap/public entrypoints so the stop line is explicit
- keep 1.3 comparative evaluation gated behind stronger repeated evidence

## Testing
- bash scripts/check-governance.sh
- git diff --check