### PR TITLE
Add resource-aware operations review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- add a 1.2 resource-aware operations review to make the current proof level and stop line explicit
+
 - add a resource-aware next-signals guide so the 1.2 track only reopens on stronger evidence
 
 - add a bounded Crisis Monitor reference for the 1.2 resource-aware operations pilot layer

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ It now also adds the first bounded Phase F examples so the 1.2 track can compare
 It now also adds a bounded pilot guide/checklist/template so real-world 1.2 validation can happen before any benchmark or learning-layer escalation.
 It now also includes a bounded Crisis Monitor reference so the 1.2 track has one real-world pilot-shaped reading before any benchmark or learning move.
 It now also defines the next signals that would justify reopening the track for stronger comparative work instead of growing by inertia.
+It now also includes a short 1.2 review so the current scope, proof level, and stop line are explicit.
 
 See also:
 
@@ -218,6 +219,7 @@ If this is your first time here, start with:
 1. `docs/resource-aware-crisis-monitor-reference.md`
 1. `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
 1. `docs/resource-aware-next-signals.md`
+1. `docs/resource-aware-operations-review.md`
 1. `docs/architecture.md`
 1. `docs/governance.md`
 1. `docs/token-policy.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -272,3 +272,9 @@ The next bounded 1.2 closure layer now also includes:
 - `docs/resource-aware-next-signals.md`
 
 This makes the stop line explicit so the track only reopens when evidence becomes stronger than one reference.
+
+The final docs-first 1.2 closure layer now also includes:
+
+- `docs/resource-aware-operations-review.md`
+
+This gives the track a compact review artifact before any future 1.3 reopening.

--- a/docs/resource-aware-operations-review.md
+++ b/docs/resource-aware-operations-review.md
@@ -1,0 +1,117 @@
+# Resource-Aware Operations Review
+
+## Goal
+
+Consolidate what the 1.2 Resource-Aware Operations track now proves, what it does not prove, and what should remain deferred.
+
+This document exists to close the docs-first pass cleanly.
+
+---
+
+## What 1.2 now includes
+
+The 1.2 track now has:
+
+- context / resource telemetry guidance
+- slice telemetry fields
+- waste heuristics
+- progressive policy signals
+- a minimal runtime adapter contract
+- advisory runtime / agent fit guidance
+- planning-depth profiles
+- readiness gates
+- bounded examples
+- bounded pilot guidance
+- a real-world Crisis Monitor reference
+- an explicit next-signals stop line
+
+---
+
+## What this proves
+
+The track now proves that AletheIA can describe a resource-aware operating posture without becoming:
+
+- a benchmark framework
+- a vendor-ranking layer
+- an auto-router
+- a learning-layer system
+- a heavyweight orchestration product
+
+More specifically, it now proves that the framework can give teams a reviewable way to think about:
+
+- context drag
+- retry waste
+- handoff inflation
+- runtime fit
+- planning proportionality
+- readiness to continue, hand off, review, or stop
+
+---
+
+## What this does not prove yet
+
+The 1.2 track does **not** yet prove:
+
+- cross-project comparative evaluation
+- benchmark-ready comparability
+- score-based runtime selection
+- learning-layer adaptation
+- orchestration automation
+
+Those stay deferred because current evidence is still bounded and mostly illustrative.
+
+---
+
+## What was the right level of ambition
+
+The healthy 1.2 posture turned out to be:
+
+- docs-first
+- examples before benchmark
+- bounded pilot before stronger comparison
+- real-world reference before broader claims
+- explicit stop line before new expansion
+
+That is important because it kept the track proportional.
+
+---
+
+## What should remain local
+
+Even after this review, these things still belong outside the framework core:
+
+- project-specific trust thresholds
+- provider-specific defaults
+- local routing preferences
+- product-specific review and approval semantics
+- cost ceilings and procurement choices
+
+The framework should keep the operating pattern.
+Projects should keep their own local rules.
+
+---
+
+## Healthy current result
+
+The healthiest current result for 1.2 is:
+
+- `reinforced`
+
+Why:
+
+- the track is coherent
+- the surfaces connect well
+- the examples are sufficient for this stage
+- stronger claims still need stronger repeated evidence
+
+---
+
+## Recommended next move
+
+The healthiest next move is:
+
+- keep 1.2 stable
+- wait for repeated real-world signals
+- only then decide whether 1.3 comparative evaluation is justified
+
+That is enough for now.

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -269,6 +269,7 @@ The next bounded 1.2 layer now also begins with:
 - `docs/resource-aware-crisis-monitor-reference.md`
 - `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
 - `docs/resource-aware-next-signals.md`
+- `docs/resource-aware-operations-review.md`
 
 Remaining backlog includes:
 

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -149,5 +149,6 @@ Read:
 - `docs/resource-aware-crisis-monitor-reference.md`
 - `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
 - `docs/resource-aware-next-signals.md`
+- `docs/resource-aware-operations-review.md`
 
 This future track should build on the current starter-pack surfaces rather than replace them.


### PR DESCRIPTION
## Summary
- add a short 1.2 resource-aware operations review consolidating what the track now proves and defers
- update the README and public entrypoints so the review is visible in the reading order
- make the current proof level and stop line explicit before any future 1.3 reopening

## Testing
- bash scripts/check-governance.sh
- git diff --check