### PR TITLE
Add slice finalization and restart guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- add slice finalization and restart guidance with AI Fatigue control and a copyable restart-package pattern
+
 - add a 1.2 resource-aware operations review to make the current proof level and stop line explicit
 
 - add a resource-aware next-signals guide so the 1.2 track only reopens on stronger evidence

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ It now also adds a bounded pilot guide/checklist/template so real-world 1.2 vali
 It now also includes a bounded Crisis Monitor reference so the 1.2 track has one real-world pilot-shaped reading before any benchmark or learning move.
 It now also defines the next signals that would justify reopening the track for stronger comparative work instead of growing by inertia.
 It now also includes a short 1.2 review so the current scope, proof level, and stop line are explicit.
+It now also adds slice finalization and restart guidance so teams can reduce AI Fatigue through compact restart packages instead of transcript replay.
 
 See also:
 
@@ -220,6 +221,9 @@ If this is your first time here, start with:
 1. `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
 1. `docs/resource-aware-next-signals.md`
 1. `docs/resource-aware-operations-review.md`
+1. `docs/slice-finalization-and-restart.md`
+1. `starter-pack/templates/slice-finalization-review-template.md`
+1. `examples/resource-aware-operations/slice-finalization-reference.md`
 1. `docs/architecture.md`
 1. `docs/governance.md`
 1. `docs/token-policy.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -278,3 +278,11 @@ The final docs-first 1.2 closure layer now also includes:
 - `docs/resource-aware-operations-review.md`
 
 This gives the track a compact review artifact before any future 1.3 reopening.
+
+A focused operational bridge between Alpha 4 restart packages and the 1.2 resource-aware posture now also includes:
+
+- `docs/slice-finalization-and-restart.md`
+- `starter-pack/templates/slice-finalization-review-template.md`
+- `examples/resource-aware-operations/slice-finalization-reference.md`
+
+This keeps slice closure, clean restart, and AI Fatigue control explicit without introducing runtime-coupled reset behavior.

--- a/docs/resource-aware-operations-review.md
+++ b/docs/resource-aware-operations-review.md
@@ -24,6 +24,7 @@ The 1.2 track now has:
 - bounded pilot guidance
 - a real-world Crisis Monitor reference
 - an explicit next-signals stop line
+- slice finalization and restart guidance for reducing AI Fatigue without runtime-coupled reset logic
 
 ---
 
@@ -45,6 +46,7 @@ More specifically, it now proves that the framework can give teams a reviewable 
 - runtime fit
 - planning proportionality
 - readiness to continue, hand off, review, or stop
+- when a clean restart is healthier than continuing inside stale transcript context
 
 ---
 

--- a/docs/resource-aware-operations-roadmap.md
+++ b/docs/resource-aware-operations-roadmap.md
@@ -212,6 +212,12 @@ Before any benchmark or learning ambition, the framework should close the loop t
 
 The purpose is to prove that the operational surfaces help in real use before they become a bigger system.
 
+A focused bridge between Alpha 4 handoffs and the 1.2 resource-aware posture now also includes:
+
+- `docs/slice-finalization-and-restart.md`
+- `starter-pack/templates/slice-finalization-review-template.md`
+- `examples/resource-aware-operations/slice-finalization-reference.md`
+
 This phase now begins with:
 
 - `examples/resource-aware-operations/comparative-review-example.md`

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -270,6 +270,9 @@ The next bounded 1.2 layer now also begins with:
 - `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
 - `docs/resource-aware-next-signals.md`
 - `docs/resource-aware-operations-review.md`
+- `docs/slice-finalization-and-restart.md`
+- `starter-pack/templates/slice-finalization-review-template.md`
+- `examples/resource-aware-operations/slice-finalization-reference.md`
 
 Remaining backlog includes:
 

--- a/docs/slice-finalization-and-restart.md
+++ b/docs/slice-finalization-and-restart.md
@@ -1,0 +1,259 @@
+# Slice Finalization & Restart Guidance
+
+## Goal
+
+Define a manual-first way to close a work slice cleanly, preserve continuity through a compact restart package, and recommend a clean new session only when transcript replay is no longer needed.
+
+This is not a "clear chat" feature.
+It is a slice-finalization capability.
+
+---
+
+## Why this exists
+
+Long AI-assisted threads tend to accumulate stale context.
+That creates two related forms of avoidable fatigue.
+
+### 1. Human fatigue
+
+Examples:
+
+- heavy recap before the next step begins
+- repeated questions about decisions that were already settled
+- ambiguous reopen state after the useful part of the slice is already done
+
+### 2. Operational fatigue
+
+Examples:
+
+- context inflation from legacy material
+- retries that keep happening inside a slice that should already have closed
+- drift caused by continuing in the same session after the real boundary was already crossed
+
+AletheIA already has the right principle:
+
+**restart package, not transcript**
+
+This guide turns that principle into an explicit closure practice.
+
+---
+
+## Relationship to existing AletheIA surfaces
+
+This guide reuses existing surfaces.
+It does **not** replace them.
+
+It builds on:
+
+- `docs/agent-handoffs.md`
+- `docs/work-slice-pattern.md`
+- `docs/slice-telemetry-model.md`
+- `docs/progressive-policy-signals.md`
+- `docs/readiness-gates-spec.md`
+
+Use the existing handoff record as the structured continuity artifact.
+Use this guide as the operational review layer for deciding whether the slice is ready for healthy restart.
+
+---
+
+## Finalization flow
+
+A healthy slice finalization should follow this order:
+
+1. validation check
+2. handoff / restart check
+3. AI fatigue read
+4. finalization outcome
+5. optional clean-restart recommendation
+
+The goal is not to restart by habit.
+The goal is to restart when continuing in the same session would now carry more drag than value.
+
+---
+
+## Minimum finalization questions
+
+Before a slice closes, ask:
+
+### 1. Was the slice validated?
+
+If validation is still incomplete, the slice is not ready.
+
+### 2. Is the next action explicit?
+
+If the next action is unclear, clean restart is unsafe.
+The slice needs review first.
+
+### 3. Is a structured continuity artifact available?
+
+A compact handoff or restart package should exist whenever the next boundary matters.
+
+### 4. Does the next step still belong to the same slice?
+
+If yes, continuing in the same session may still be healthier.
+If not, a bounded restart may be healthier.
+
+### 5. Would the next session still depend on replaying transcript history?
+
+If yes, the slice has not closed cleanly enough.
+
+---
+
+## AI Fatigue Read
+
+A finalization review should explicitly read these fields:
+
+- `stale_context_risk`: `low | medium | high`
+- `transcript_replay_needed`: `yes | no`
+- `restart_burden`: `low | medium | high`
+- `handoff_size_class`: `compact | inflated | heavy`
+- `redundant_question_risk`: `low | medium | high`
+- `governing_context_changed`: `yes | no`
+- `governing_context_ref`: list of refs
+- `governing_context_summary`: short summary when changed
+
+### Hard rule
+
+If `transcript_replay_needed = yes`, the slice is **not** ready for healthy clean restart.
+
+That means the next boundary would still depend on hidden history instead of compact durable context.
+
+---
+
+## Finalization outcomes
+
+### `continue-in-session`
+
+Use when:
+
+- the next step still belongs to the same bounded slice
+- context carryover is still useful
+- fatigue signals are still low enough that continuing is healthier than resetting
+
+### `recommend-clean-restart`
+
+Use when:
+
+- the slice is validated
+- the next action is explicit
+- the restart package is compact
+- transcript replay is not needed
+- stale context risk for the next slice is `medium` or `high`
+
+### `review-required`
+
+Use when:
+
+- the next action is ambiguous
+- regression or fork is still open
+- the handoff is inflated
+- restarting now would carry confusion into the next session
+
+### `not-ready`
+
+Use when:
+
+- validation is incomplete
+- conflict or high-risk review is still open
+- the closure rule is not yet satisfied
+
+---
+
+## Restart package as a physical block
+
+Do not treat the restart package as only a loose summary inside the handoff.
+
+For this v1, the operator-facing artifact should include a **copyable markdown block**:
+
+```md
+<!-- RESTART_PACKAGE_BEGIN -->
+## Context for Clean Restart
+- **Slice ID:** ...
+- **Validation Status:** ...
+- **Mission Focus:** ...
+- **Active Spec / Entrypoint:** ...
+- **Last Handoff Summary:** ...
+- **Next Immediate Action:** ...
+- **Known Constraints:** ...
+- **Governing Context Version:** ...
+- **Governing Context Delta:** ...
+<!-- RESTART_PACKAGE_END -->
+```
+
+This block is meant to let the operator begin a new session with minimal noise.
+
+---
+
+## Project-local governing context
+
+Projects may define their own governing-context sources.
+
+Examples might include:
+
+- active feature or plan docs
+- project decision logs
+- project state summaries
+- local changelog entries
+
+This remains project-local.
+AletheIA should require the **meaning** of governing-context continuity, not one universal project file.
+
+---
+
+## Runtime boundary
+
+AletheIA does **not** depend on a runtime command such as `/clear` or `/new`.
+
+In this version:
+
+- runtime actions remain illustrative only
+- restart is still a local operator action
+- no runtime hooks or auto-reset behavior are part of the core
+
+The core capability is:
+
+- finish the slice
+- preserve continuity
+- detect fatigue risk
+- recommend restart when healthy
+
+---
+
+## Success read
+
+A healthy restart recommendation should usually imply:
+
+- `transcript_replay_needed = no`
+- `redundant_question_risk = low`
+- `restart_burden = low`
+
+A practical success proxy is:
+
+- **TRC (Time to Recover Context)** `< 2 interactions`
+
+If a restarted session needs more than two back-and-forth turns before it becomes productive, the restart package was not self-contained enough.
+
+---
+
+## What this is not
+
+This guide is not:
+
+- a new canonical reset schema
+- a runtime-hook system
+- a benchmark layer
+- a learning-layer capability
+- a promise of zero cognitive effort
+
+It is a bounded operational practice for reducing avoidable AI fatigue.
+
+---
+
+## Suggested next reading
+
+- `docs/agent-handoffs.md`
+- `docs/work-slice-pattern.md`
+- `docs/readiness-gates-spec.md`
+- `docs/slice-telemetry-model.md`
+- `starter-pack/templates/slice-finalization-review-template.md`
+- `examples/resource-aware-operations/slice-finalization-reference.md`

--- a/examples/README.md
+++ b/examples/README.md
@@ -64,6 +64,7 @@ O alpha agora já cobre:
 - advisory-only model-strategy examples for task-to-model-fit guidance
 - iterative maintenance examples where regression changes the round gate instead of remaining only a final observation
 - pilot-conversion examples where real-world validation becomes a smaller framework improvement instead of core inflation
+- slice-finalization examples where restart packages reduce AI Fatigue without depending on transcript replay
 
 Together, these newer examples make the repo more practical in three directions:
 

--- a/examples/resource-aware-operations/README.md
+++ b/examples/resource-aware-operations/README.md
@@ -13,6 +13,7 @@ The first examples stay docs-first and intentionally small.
 - `comparative-review-example.md`
 - `constrained-local-review-example.md`
 - `bounded-pilot-conversion-loop.md`
+- `slice-finalization-reference.md`
 
 ## Related pilot support
 
@@ -21,3 +22,5 @@ The first examples stay docs-first and intentionally small.
 - `../../starter-pack/templates/resource-aware-pilot-review-template.md`
 - `resource-aware-pilot-review-reference.md`
 - `../../docs/resource-aware-crisis-monitor-reference.md`
+- `../../docs/slice-finalization-and-restart.md`
+- `../../starter-pack/templates/slice-finalization-review-template.md`

--- a/examples/resource-aware-operations/slice-finalization-reference.md
+++ b/examples/resource-aware-operations/slice-finalization-reference.md
@@ -1,0 +1,51 @@
+# Slice Finalization Reference
+
+## Context
+
+A bounded slice finished its useful implementation work and passed the declared validation.
+
+The next step is a separate reviewable task rather than a continuation of the same slice.
+
+## Finalization read
+
+- Slice ID: `example-slice-finalization-001`
+- Validation status: `validated`
+- Handoff ref: `handoff-record.json`
+- Next action: `Start the next review slice using the restart package`
+- Resume entrypoint: `docs/feature-review-notes.md`
+
+## AI Fatigue Read
+
+- Stale context risk: `high`
+- Transcript replay needed: `no`
+- Restart burden: `low`
+- Handoff size class: `compact`
+- Redundant question risk: `low`
+- Governing context changed: `yes`
+- Governing context refs:
+  - `docs/feature-review-notes.md`
+  - `docs/DECISIONS.md`
+- Governing context summary: `The active direction narrowed from implementation to review-only closure after validation passed.`
+
+## Finalization outcome
+
+- Outcome: `recommend-clean-restart`
+- Reason: `The current slice is validated and complete, but the next task is a distinct review step that should not inherit stale execution context.`
+
+## Restart Package
+
+<!-- RESTART_PACKAGE_BEGIN -->
+## Context for Clean Restart
+- **Slice ID:** `example-slice-finalization-001`
+- **Validation Status:** `validated`
+- **Mission Focus:** Close the current slice and begin the review-only continuation with minimal inherited context.
+- **Active Spec / Entrypoint:** `docs/feature-review-notes.md`
+- **Last Handoff Summary:**
+  - implementation work was completed
+  - declared validation passed
+  - the next boundary is a review slice, not more execution in the same thread
+- **Next Immediate Action:** Open the review notes and continue from the explicit next action instead of replaying transcript history.
+- **Known Constraints:** Do not resume by scanning old transcript unless the restart package proves insufficient.
+- **Governing Context Version:** `review-direction-1`
+- **Governing Context Delta:** Shift from implementation mode to review-only closure after validation passed.
+<!-- RESTART_PACKAGE_END -->

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -150,5 +150,8 @@ Read:
 - `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
 - `docs/resource-aware-next-signals.md`
 - `docs/resource-aware-operations-review.md`
+- `docs/slice-finalization-and-restart.md`
+- `starter-pack/templates/slice-finalization-review-template.md`
+- `examples/resource-aware-operations/slice-finalization-reference.md`
 
 This future track should build on the current starter-pack surfaces rather than replace them.

--- a/starter-pack/templates/slice-finalization-review-template.md
+++ b/starter-pack/templates/slice-finalization-review-template.md
@@ -1,0 +1,47 @@
+# Slice Finalization Review
+
+## Slice
+
+- Slice ID:
+- Validation status:
+- Handoff ref: (`not_needed` if not applicable)
+- Next action:
+- Resume entrypoint:
+
+## Finalization outcome
+
+- Finalization outcome: `continue-in-session | recommend-clean-restart | review-required | not-ready`
+- Reason:
+
+## AI Fatigue Read
+
+- Stale context risk: `low | medium | high`
+- Transcript replay needed: `yes | no`
+- Restart burden: `low | medium | high`
+- Handoff size class: `compact | inflated | heavy`
+- Redundant question risk: `low | medium | high`
+- Governing context changed: `yes | no`
+- Governing context refs:
+- Governing context summary:
+
+## Validation and continuity notes
+
+- What was delivered:
+- Evidence:
+- Known constraints:
+- Why the next step is still in-session or should restart cleanly:
+
+## Restart Package
+
+<!-- RESTART_PACKAGE_BEGIN -->
+## Context for Clean Restart
+- **Slice ID:**
+- **Validation Status:**
+- **Mission Focus:**
+- **Active Spec / Entrypoint:**
+- **Last Handoff Summary:**
+- **Next Immediate Action:**
+- **Known Constraints:**
+- **Governing Context Version:**
+- **Governing Context Delta:**
+<!-- RESTART_PACKAGE_END -->


### PR DESCRIPTION
## Summary
- add a manual-first slice finalization and restart guide focused on AI Fatigue reduction
- add a slice finalization review template with fatigue-read fields and a copyable restart package block
- add a reference example and wire the new surfaces into the README, roadmap, review, and starter-pack docs

## Validation
- bash scripts/check-governance.sh
- git diff --check