### PR TITLE
Add clean restart command adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- add docs-first clean-restart command adapters and a restart bootstrap prompt template on top of slice finalization guidance
+
 - add slice finalization and restart guidance with AI Fatigue control and a copyable restart-package pattern
 
 - add a 1.2 resource-aware operations review to make the current proof level and stop line explicit

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ It now also includes a bounded Crisis Monitor reference so the 1.2 track has one
 It now also defines the next signals that would justify reopening the track for stronger comparative work instead of growing by inertia.
 It now also includes a short 1.2 review so the current scope, proof level, and stop line are explicit.
 It now also adds slice finalization and restart guidance so teams can reduce AI Fatigue through compact restart packages instead of transcript replay.
+It now also adds a docs-first clean-restart command adapter layer so finalization, clean restart, and resume flows can be exposed through slash-command style adapters without turning AletheIA into a runtime platform.
 
 See also:
 
@@ -224,6 +225,9 @@ If this is your first time here, start with:
 1. `docs/slice-finalization-and-restart.md`
 1. `starter-pack/templates/slice-finalization-review-template.md`
 1. `examples/resource-aware-operations/slice-finalization-reference.md`
+1. `starter-pack/guides/clean-restart-command-adapters.md`
+1. `starter-pack/templates/restart-bootstrap-prompt-template.md`
+1. `examples/resource-aware-operations/clean-restart-command-adapter-example.md`
 1. `docs/architecture.md`
 1. `docs/governance.md`
 1. `docs/token-policy.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -286,3 +286,11 @@ A focused operational bridge between Alpha 4 restart packages and the 1.2 resour
 - `examples/resource-aware-operations/slice-finalization-reference.md`
 
 This keeps slice closure, clean restart, and AI Fatigue control explicit without introducing runtime-coupled reset behavior.
+
+The next bounded operator-facing adapter layer now also includes:
+
+- `starter-pack/guides/clean-restart-command-adapters.md`
+- `starter-pack/templates/restart-bootstrap-prompt-template.md`
+- `examples/resource-aware-operations/clean-restart-command-adapter-example.md`
+
+This keeps slash-command style delivery in the starter-pack layer while preserving the core as manual-first and runtime-agnostic.

--- a/docs/resource-aware-operations-review.md
+++ b/docs/resource-aware-operations-review.md
@@ -25,6 +25,7 @@ The 1.2 track now has:
 - a real-world Crisis Monitor reference
 - an explicit next-signals stop line
 - slice finalization and restart guidance for reducing AI Fatigue without runtime-coupled reset logic
+- a docs-first adapter layer for exposing finalization and clean restart through local slash-command style delivery
 
 ---
 

--- a/docs/resource-aware-operations-roadmap.md
+++ b/docs/resource-aware-operations-roadmap.md
@@ -217,6 +217,9 @@ A focused bridge between Alpha 4 handoffs and the 1.2 resource-aware posture now
 - `docs/slice-finalization-and-restart.md`
 - `starter-pack/templates/slice-finalization-review-template.md`
 - `examples/resource-aware-operations/slice-finalization-reference.md`
+- `starter-pack/guides/clean-restart-command-adapters.md`
+- `starter-pack/templates/restart-bootstrap-prompt-template.md`
+- `examples/resource-aware-operations/clean-restart-command-adapter-example.md`
 
 This phase now begins with:
 

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -273,6 +273,9 @@ The next bounded 1.2 layer now also begins with:
 - `docs/slice-finalization-and-restart.md`
 - `starter-pack/templates/slice-finalization-review-template.md`
 - `examples/resource-aware-operations/slice-finalization-reference.md`
+- `starter-pack/guides/clean-restart-command-adapters.md`
+- `starter-pack/templates/restart-bootstrap-prompt-template.md`
+- `examples/resource-aware-operations/clean-restart-command-adapter-example.md`
 
 Remaining backlog includes:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -65,6 +65,7 @@ O alpha agora já cobre:
 - iterative maintenance examples where regression changes the round gate instead of remaining only a final observation
 - pilot-conversion examples where real-world validation becomes a smaller framework improvement instead of core inflation
 - slice-finalization examples where restart packages reduce AI Fatigue without depending on transcript replay
+- clean-restart adapter examples where slash-command style delivery stays local to the adapter instead of becoming framework truth
 
 Together, these newer examples make the repo more practical in three directions:
 

--- a/examples/resource-aware-operations/README.md
+++ b/examples/resource-aware-operations/README.md
@@ -14,6 +14,7 @@ The first examples stay docs-first and intentionally small.
 - `constrained-local-review-example.md`
 - `bounded-pilot-conversion-loop.md`
 - `slice-finalization-reference.md`
+- `clean-restart-command-adapter-example.md`
 
 ## Related pilot support
 
@@ -24,3 +25,5 @@ The first examples stay docs-first and intentionally small.
 - `../../docs/resource-aware-crisis-monitor-reference.md`
 - `../../docs/slice-finalization-and-restart.md`
 - `../../starter-pack/templates/slice-finalization-review-template.md`
+- `../../starter-pack/guides/clean-restart-command-adapters.md`
+- `../../starter-pack/templates/restart-bootstrap-prompt-template.md`

--- a/examples/resource-aware-operations/clean-restart-command-adapter-example.md
+++ b/examples/resource-aware-operations/clean-restart-command-adapter-example.md
@@ -1,0 +1,93 @@
+# Clean Restart Command Adapter Example
+
+This example shows how a team may expose the existing slice-finalization flow through adapter-style commands without turning AletheIA into a runtime platform.
+
+---
+
+## Situation
+
+- the slice was validated
+- the next action is explicit
+- the restart package is compact
+- the next slice should not inherit stale execution context
+
+The finalization outcome is:
+
+- `recommend-clean-restart`
+
+---
+
+## Logical command sequence
+
+### 1. `/finalize-slice`
+
+Meaning:
+
+- fill the finalization review
+- emit the restart package
+- confirm that transcript replay is not needed
+
+Result:
+
+- finalization outcome = `recommend-clean-restart`
+
+### 2. `/clean-restart`
+
+Meaning:
+
+- the operator should now begin a fresh session rather than continue inside the stale thread
+
+### 3. `/resume-from-package`
+
+Meaning:
+
+- the next slice starts from the restart package only
+
+---
+
+## Codex-style mapping
+
+- `/finalize-slice` -> fill `starter-pack/templates/slice-finalization-review-template.md`
+- `/clean-restart` -> open a fresh session or use the runtime's clean-start action if available
+- `/resume-from-package` -> paste the restart package and a prompt based on `starter-pack/templates/restart-bootstrap-prompt-template.md`
+
+Illustrative note:
+
+- a local adapter may mention `/clear`, but the framework still treats that as runtime-local behavior
+
+---
+
+## Claude Code-style mapping
+
+- `/finalize-slice` -> fill the finalization review artifact
+- `/clean-restart` -> open a fresh session
+- `/resume-from-package` -> continue from the restart package and explicit entrypoint only
+
+---
+
+## No-slash fallback
+
+If the runtime has no slash-command support, the operator may execute the same flow as plain steps:
+
+1. finalize the slice
+2. inspect the outcome
+3. start a clean session if recommended
+4. resume from the restart package and bootstrap prompt only
+
+---
+
+## Example restart bootstrap prompt
+
+```text
+Continue the project from a clean session.
+
+Read only:
+- the restart package below
+- docs/feature-review-notes.md
+- docs/DECISIONS.md if referenced by the package
+
+Do not replay old transcript history unless the restart package proves insufficient.
+
+Objective:
+Start the review-only continuation of the next slice.
+```

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -153,5 +153,8 @@ Read:
 - `docs/slice-finalization-and-restart.md`
 - `starter-pack/templates/slice-finalization-review-template.md`
 - `examples/resource-aware-operations/slice-finalization-reference.md`
+- `starter-pack/guides/clean-restart-command-adapters.md`
+- `starter-pack/templates/restart-bootstrap-prompt-template.md`
+- `examples/resource-aware-operations/clean-restart-command-adapter-example.md`
 
 This future track should build on the current starter-pack surfaces rather than replace them.

--- a/starter-pack/guides/clean-restart-command-adapters.md
+++ b/starter-pack/guides/clean-restart-command-adapters.md
@@ -1,0 +1,178 @@
+# Clean Restart Command Adapters
+
+This guide adds a small operator-facing command vocabulary on top of the existing slice-finalization flow.
+
+It does **not** change the core framework contract.
+It only shows how a team may expose clean-restart behavior through lightweight slash-command style adapters.
+
+Use this guide together with:
+
+- `docs/slice-finalization-and-restart.md`
+- `starter-pack/templates/slice-finalization-review-template.md`
+- `starter-pack/templates/restart-bootstrap-prompt-template.md`
+
+---
+
+## Why this exists
+
+Many teams want a short operator command for:
+
+- closing a slice
+- deciding whether to restart cleanly
+- resuming from a compact restart package
+
+That is useful, but AletheIA should stay smaller than a CLI or runtime platform.
+
+So this guide defines a **logical command vocabulary**:
+
+- `/finalize-slice`
+- `/clean-restart`
+- `/resume-from-package`
+
+These commands are **adapter vocabulary only**.
+
+- if a runtime supports slash commands, an adapter may expose them that way
+- if it does not, the operator can run the same flow as a checklist with no semantic loss
+
+---
+
+## Command semantics
+
+### `/finalize-slice`
+
+Purpose:
+
+- run the slice-finalization review
+- fill the finalization template
+- emit a copyable restart package block
+- decide the finalization outcome
+
+Required result:
+
+- one of:
+  - `continue-in-session`
+  - `recommend-clean-restart`
+  - `review-required`
+  - `not-ready`
+
+Minimum operator inputs:
+
+- slice id
+- validation status
+- next action
+- resume entrypoint
+- AI Fatigue read
+
+### `/clean-restart`
+
+Purpose:
+
+- start a fresh session only after the slice is already closed cleanly
+
+Allowed only when:
+
+- finalization outcome is `recommend-clean-restart`
+
+Meaning:
+
+- the operator should begin a fresh session using:
+  - the restart package
+  - the resume entrypoint
+  - the minimal governing-context refs
+
+This command must **never** imply that AletheIA controls:
+
+- chat cache internals
+- runtime memory internals
+- hidden session state
+
+It only signals that a clean restart is now the healthier operating choice.
+
+### `/resume-from-package`
+
+Purpose:
+
+- resume work from the restart package only
+
+Meaning:
+
+- bootstrap the next slice from:
+  - the restart package
+  - the restart bootstrap prompt
+  - the explicit governing refs when present
+
+Default rule:
+
+- do **not** replay transcript history unless the restart package proves insufficient
+
+---
+
+## Runtime mappings
+
+These are illustrative mappings, not core framework requirements.
+
+### Codex-style clean start
+
+Possible mapping:
+
+- `/finalize-slice` -> fill `starter-pack/templates/slice-finalization-review-template.md`
+- `/clean-restart` -> operator opens a fresh session or uses the runtime's clean-start action if available
+- `/resume-from-package` -> operator pastes the restart package and a bootstrap prompt based on `starter-pack/templates/restart-bootstrap-prompt-template.md`
+
+Notes:
+
+- a Codex adapter may mention actions like “open a new thread” or `/clear`
+- the adapter must still describe these as **runtime-local**, not as AletheIA truth
+
+### Claude Code-style clean start
+
+Possible mapping:
+
+- `/finalize-slice` -> fill the finalization review artifact in repo-native form
+- `/clean-restart` -> operator starts a fresh session or uses the runtime's preferred clean-start action
+- `/resume-from-package` -> operator starts the next session from the restart package and explicit entrypoint
+
+Notes:
+
+- a Claude Code adapter may describe a fresh chat/session boundary
+- the adapter must not depend on runtime hooks or automation to preserve the meaning of the command
+
+### No slash-command support
+
+If the runtime has no slash-command surface, use the same sequence as an operator checklist:
+
+1. finalize the slice with the review template
+2. inspect the outcome
+3. if the outcome is `recommend-clean-restart`, start a fresh session manually
+4. resume from the restart package and bootstrap prompt only
+
+This fallback is equivalent in meaning to the slash-command variant.
+
+---
+
+## Recommended operator sequence
+
+1. `/finalize-slice`
+2. inspect the outcome
+3. if `recommend-clean-restart`, run `/clean-restart`
+4. begin the next slice with `/resume-from-package`
+
+If the outcome is:
+
+- `continue-in-session` -> stay in the current session
+- `review-required` -> resolve ambiguity before restart
+- `not-ready` -> finish validation or closure first
+
+---
+
+## What this guide does not do
+
+This guide does not:
+
+- define a CLI binary
+- define runtime hooks
+- define auto-reset behavior
+- guarantee native slash-command support
+- redefine slice finalization as a tooling problem
+
+It only provides a stable vocabulary for local delivery adapters.

--- a/starter-pack/templates/restart-bootstrap-prompt-template.md
+++ b/starter-pack/templates/restart-bootstrap-prompt-template.md
@@ -1,0 +1,44 @@
+# Restart Bootstrap Prompt
+
+Use this template after a slice closes with `recommend-clean-restart`.
+
+The prompt should rely on:
+
+- the restart package
+- the next action
+- the resume entrypoint
+- the governing-context refs when present
+
+It should **not** rely on transcript replay by default.
+
+---
+
+## Template
+
+```text
+Continue the project from a clean session.
+
+Read only:
+- the restart package below
+- the resume entrypoint
+- the governing-context refs listed in the package, if present
+
+Do not replay old transcript history unless the restart package proves insufficient.
+
+Objective:
+{{next_action}}
+
+Resume entrypoint:
+{{resume_entrypoint}}
+
+Restart package:
+{{restart_package_block}}
+```
+
+---
+
+## Notes
+
+- if the restart package is not self-contained enough, fix the package rather than normalizing transcript replay
+- if the package references governing-context docs, load only the minimum needed refs
+- if the previous slice ended with `review-required` or `not-ready`, do not use this template yet


### PR DESCRIPTION
## Summary\n- add a docs-first slash-command adapter guide for slice finalization, clean restart, and resume-from-package\n- add a restart bootstrap prompt template and a resource-aware example for clean-restart command mapping\n- wire the new adapter layer into the README, overview, roadmap, review, starter-pack, and examples reading order\n\n## Validation\n- bash scripts/check-governance.sh\n- git diff --check\n- git diff --cached --check