### PR TITLE
Clarify project-local constitution context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- add a project-local Constitution context guide clarifying how stronger governing-context bootstraps can support clean restart without becoming framework core
+
 - add docs-first clean-restart command adapters and a restart bootstrap prompt template on top of slice finalization guidance
 
 - add slice finalization and restart guidance with AI Fatigue control and a copyable restart-package pattern

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ It now also defines the next signals that would justify reopening the track for 
 It now also includes a short 1.2 review so the current scope, proof level, and stop line are explicit.
 It now also adds slice finalization and restart guidance so teams can reduce AI Fatigue through compact restart packages instead of transcript replay.
 It now also adds a docs-first clean-restart command adapter layer so finalization, clean restart, and resume flows can be exposed through slash-command style adapters without turning AletheIA into a runtime platform.
+It now also clarifies how project-local Constitution layers can strengthen governing-context continuity without becoming framework core truth.
 
 See also:
 
@@ -228,6 +229,7 @@ If this is your first time here, start with:
 1. `starter-pack/guides/clean-restart-command-adapters.md`
 1. `starter-pack/templates/restart-bootstrap-prompt-template.md`
 1. `examples/resource-aware-operations/clean-restart-command-adapter-example.md`
+1. `docs/project-local-constitution-context.md`
 1. `docs/architecture.md`
 1. `docs/governance.md`
 1. `docs/token-policy.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -294,3 +294,9 @@ The next bounded operator-facing adapter layer now also includes:
 - `examples/resource-aware-operations/clean-restart-command-adapter-example.md`
 
 This keeps slash-command style delivery in the starter-pack layer while preserving the core as manual-first and runtime-agnostic.
+
+The next boundary clarification layer now also includes:
+
+- `docs/project-local-constitution-context.md`
+
+This makes it explicit that a project-local Constitution may strengthen governing-context reads and clean restarts without becoming a framework-level requirement.

--- a/docs/project-local-constitution-context.md
+++ b/docs/project-local-constitution-context.md
@@ -1,0 +1,144 @@
+# Project-Local Constitution Context
+
+## Goal
+
+Explain how a project-local constitution layer can strengthen AletheIA restart packages, clean restarts, and governing-context continuity **without** turning Constitution into AletheIA core truth.
+
+---
+
+## Why this exists
+
+Some projects accumulate durable context across many files:
+
+- project state
+- durable decisions
+- design-system doctrine
+- product roadmap
+- active planning material
+
+When that context is too distributed, a clean restart becomes harder.
+
+The restart package may still exist, but the next session may need to rediscover:
+
+- what currently governs the product direction
+- which docs are still authoritative
+- what changed during replanning
+
+A project-local constitution layer can reduce that burden.
+
+---
+
+## Core boundary
+
+AletheIA does **not** require a Constitution abstraction in the framework core.
+
+Instead:
+
+- the framework defines the need for **governing context**
+- each project may define a thinner local constitutional bootstrap if it helps
+
+This means Constitution remains:
+
+- optional
+- project-local
+- delivery-context specific
+
+It should not become mandatory framework vocabulary before repeated cross-project evidence exists.
+
+---
+
+## What a project-local constitution should do
+
+At minimum, a useful local constitution layer should:
+
+1. reduce bootstrap sprawl for a new slice
+2. summarize the most durable project direction
+3. point back to deeper source docs
+4. strengthen clean-restart alignment after replanning
+
+A project-local constitution is healthy when a new human or agent can read:
+
+- one constitution index
+- one active slice doc
+
+and start productively without transcript replay or broad repo rediscovery.
+
+---
+
+## Minimum recommended shape
+
+A small project-local constitution may include:
+
+- `index` — one-shot bootstrap entrypoint
+- `mission` — what the project is for and what it should not drift into
+- `stack` — durable technical baseline
+- `design-system` — interface doctrine when relevant
+- `roadmap` — durable active directions
+
+This layer should stay **reference-first**:
+
+- short canonical summary
+- explicit links to deeper docs
+- no attempt to absorb all project knowledge into one new truth file
+
+---
+
+## Relationship to slice finalization
+
+When a project uses local constitution context well:
+
+- restart packages stay smaller
+- governing-context refs become easier to choose
+- replanning deltas become easier to express
+- clean restart becomes safer
+
+A healthy local ordering often looks like:
+
+1. active slice doc
+2. constitution index
+3. deeper decision/state/changelog refs as needed
+
+The exact order remains project-local.
+
+---
+
+## What this does not imply
+
+This guide does not imply:
+
+- Constitution is now an AletheIA core contract
+- all projects need a constitution layer
+- the framework should absorb Brownfield/Greenfield mode now
+- restart quality depends on a special file name
+
+The framework still only requires:
+
+- compact restart packages
+- explicit governing-context continuity
+- clear project-local separation between reusable framework logic and local truth
+
+---
+
+## When to consider this pattern
+
+Consider a local constitution layer when:
+
+- restart packages repeatedly need too many project refs
+- replanning changes direction often enough that drift becomes visible
+- the same project bootstrap context is reconstructed over and over
+- a project is large enough that `PROJECT_STATE` + `DECISIONS` alone are no longer a clean bootstrap
+
+Avoid introducing it too early when:
+
+- the project is still small
+- direction changes are still local and temporary
+- one active slice doc already gives enough context
+
+---
+
+## Related surfaces
+
+- `docs/slice-finalization-and-restart.md`
+- `starter-pack/templates/slice-finalization-review-template.md`
+- `starter-pack/templates/restart-bootstrap-prompt-template.md`
+- `docs/project-extension-pattern.md`

--- a/docs/resource-aware-operations-review.md
+++ b/docs/resource-aware-operations-review.md
@@ -26,6 +26,7 @@ The 1.2 track now has:
 - an explicit next-signals stop line
 - slice finalization and restart guidance for reducing AI Fatigue without runtime-coupled reset logic
 - a docs-first adapter layer for exposing finalization and clean restart through local slash-command style delivery
+- a boundary note showing how project-local Constitution context can strengthen restart continuity without redefining the framework core
 
 ---
 

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -276,6 +276,7 @@ The next bounded 1.2 layer now also begins with:
 - `starter-pack/guides/clean-restart-command-adapters.md`
 - `starter-pack/templates/restart-bootstrap-prompt-template.md`
 - `examples/resource-aware-operations/clean-restart-command-adapter-example.md`
+- `docs/project-local-constitution-context.md`
 
 Remaining backlog includes:
 

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -156,5 +156,6 @@ Read:
 - `starter-pack/guides/clean-restart-command-adapters.md`
 - `starter-pack/templates/restart-bootstrap-prompt-template.md`
 - `examples/resource-aware-operations/clean-restart-command-adapter-example.md`
+- `docs/project-local-constitution-context.md`
 
 This future track should build on the current starter-pack surfaces rather than replace them.


### PR DESCRIPTION
## Summary
- add a guide explaining how project-local Constitution layers can strengthen governing-context continuity without becoming AletheIA core truth
- wire that clarification into the README, overview, roadmap, review, and starter-pack reading order
- keep Constitution optional and project-local while preserving the current slice-finalization/restart model

## Validation
- bash scripts/check-governance.sh
- git diff --check