### PR TITLE
Add clean restart guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- add bounded slice-finalization and clean-restart guidance so teams can test fresh-thread continuation through restart packages without claiming runtime cache control
 - add a 1.2 resource-aware operations review to make the current proof level and stop line explicit
 
 - add a resource-aware next-signals guide so the 1.2 track only reopens on stronger evidence

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ It now also adds a bounded pilot guide/checklist/template so real-world 1.2 vali
 It now also includes a bounded Crisis Monitor reference so the 1.2 track has one real-world pilot-shaped reading before any benchmark or learning move.
 It now also defines the next signals that would justify reopening the track for stronger comparative work instead of growing by inertia.
 It now also includes a short 1.2 review so the current scope, proof level, and stop line are explicit.
+It now also adds a bounded slice-finalization and clean-restart layer for teams that want to end one slice and start the next in a fresh thread without turning runtime cache control into framework truth.
 
 See also:
 
@@ -220,6 +221,10 @@ If this is your first time here, start with:
 1. `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
 1. `docs/resource-aware-next-signals.md`
 1. `docs/resource-aware-operations-review.md`
+1. `docs/slice-finalization-and-clean-restart.md`
+1. `starter-pack/guides/clean-restart-command-adapters.md`
+1. `starter-pack/templates/restart-bootstrap-prompt-template.md`
+1. `examples/resource-aware-operations/clean-restart-command-adapter-example.md`
 1. `docs/architecture.md`
 1. `docs/governance.md`
 1. `docs/token-policy.md`

--- a/docs/resource-aware-operations-review.md
+++ b/docs/resource-aware-operations-review.md
@@ -24,6 +24,7 @@ The 1.2 track now has:
 - bounded pilot guidance
 - a real-world Crisis Monitor reference
 - an explicit next-signals stop line
+- a bounded clean-restart guidance bridge for teams that want to start the next slice in a fresh thread without transcript replay
 
 ---
 

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -274,6 +274,7 @@ The next bounded 1.2 layer now also begins with:
 Remaining backlog includes:
 
 - stronger repeated real-world pilot evidence before any benchmark or learning ambition
+- a bounded docs-first clean-restart layer that lets teams test fresh-thread continuation without redefining runtime cache control as framework truth
 
 ### 1.3+ — Benchmark and comparative evaluation
 

--- a/docs/slice-finalization-and-clean-restart.md
+++ b/docs/slice-finalization-and-clean-restart.md
@@ -1,0 +1,198 @@
+# Slice Finalization and Clean Restart
+
+## Goal
+
+Define how AletheIA can help teams end one bounded slice, preserve usable continuity, and start the next slice in a fresh thread or session **without depending on transcript replay**.
+
+This document exists because many teams describe the problem as:
+
+- "clear the thread"
+- "clear the chat cache"
+- "start clean for the next task"
+
+AletheIA should interpret that operationally, not literally.
+
+The framework does **not** manage runtime cache internals.
+It helps teams reach a state where a clean restart is healthy because the previous slice has already been finalized well.
+
+---
+
+## Correct framing
+
+The problem is not:
+
+> how do we clear a chat?
+
+The problem is:
+
+> how do we close one slice cleanly enough that the next slice can begin without hauling old thread residue forward?
+
+That is why the framework should keep saying:
+
+- restart packages, not transcripts
+- slice closure before clean restart
+- continuity by explicit artifact, not hidden memory
+
+---
+
+## What this capability should do
+
+A healthy slice-finalization and clean-restart layer should help teams:
+
+- confirm whether the current slice is actually complete enough to stop
+- capture a compact restart package
+- decide whether continuing in the same thread is still healthy
+- recommend a clean restart only when the next slice no longer benefits from old thread carryover
+- bootstrap the next slice with the smallest useful context package
+
+---
+
+## What this capability should not claim
+
+This layer should **not** claim that AletheIA:
+
+- clears model memory or runtime cache internals
+- controls `/clear`, `/new`, or provider-native reset commands
+- requires runtime hooks or automation to be useful
+- replaces project-local governance or trust rules
+
+Those remain local runtime or project concerns.
+
+---
+
+## Finalization outcomes
+
+For this bounded layer, AletheIA can express four practical outcomes:
+
+### `continue-in-session`
+
+Use when:
+
+- the next step is still part of the same bounded slice
+- the current thread still contains useful local context
+- restart would add ceremony without reducing confusion
+
+### `recommend-clean-restart`
+
+Use when:
+
+- the slice is finished and validated enough to stop
+- the next step is a new bounded slice
+- transcript replay is no longer the healthiest continuity path
+- a compact restart package exists
+
+### `review-required`
+
+Use when:
+
+- the current slice is partially closed but the next move is still ambiguous
+- the restart package is too weak or too inflated
+- multiple continuations are plausible and the thread should not be cleared yet
+
+### `not-ready`
+
+Use when:
+
+- validation is incomplete
+- conflict or unresolved risk is still open
+- no usable restart package exists
+- a clean restart would only hide unresolved work
+
+---
+
+## Minimum finalization checks
+
+Before a clean restart is recommended, the framework should at least be able to answer:
+
+1. Was the slice validated enough for closure?
+2. Is the next action explicit?
+3. Is the restart package compact enough to replace transcript replay?
+4. Would continuing in the same thread preserve more noise than value?
+
+If the answer to any of those is unclear, `recommend-clean-restart` is premature.
+
+---
+
+## Anti-fatigue rule
+
+AletheIA should treat a clean restart as successful only when it reduces both:
+
+- **human fatigue**
+  - recap burden
+  - redundant questions
+  - confusion about what changed
+- **operational fatigue**
+  - stale context carryover
+  - retry drag
+  - thread expansion beyond the healthy slice boundary
+
+A clean restart that still requires replaying the old transcript is not a real win.
+
+---
+
+## Relationship to Alpha 4 and 1.2
+
+This layer does not replace existing handoff or resource-aware work.
+It composes them.
+
+It builds on:
+
+- `docs/agent-handoffs.md`
+- `docs/handoff-capture-pattern.md`
+- `docs/work-slice-pattern.md`
+- `docs/token-policy.md`
+- `docs/resource-aware-operations-roadmap.md`
+- `docs/waste-heuristics.md`
+- `docs/progressive-policy-signals.md`
+- `docs/readiness-gates-spec.md`
+
+In practice, this layer is a bounded bridge between:
+
+- Alpha 4 restart-package continuity
+- the 1.2 resource-aware stop/continue posture
+
+---
+
+## Clean restart as a local runtime action
+
+The framework meaning should stay stable even if runtimes differ.
+
+That means:
+
+- one runtime may expose `/clear`
+- another may expose `/new`
+- another may require starting a new session manually
+- another may offer custom slash commands
+
+AletheIA should care about the **semantic outcome**, not the runtime-specific mechanic.
+
+The semantic outcome is:
+
+> the next slice starts with a compact restart package instead of inherited thread residue.
+
+---
+
+## Recommended local composition
+
+Projects that want to test this pattern should usually compose four artifacts:
+
+1. a slice-finalization review
+2. a restart package
+3. a restart bootstrap prompt
+4. an optional runtime-local adapter mapping
+
+The framework core stays smaller if these remain docs-first and manual-first before any automation attempt.
+
+---
+
+## Healthy first use
+
+The healthiest first use is usually:
+
+- one recently completed bounded slice
+- one explicit next slice
+- one compact restart package
+- one local clean-start action
+- one review of whether the next slice could start without transcript replay
+
+This is enough to test the pattern without overbuilding it.

--- a/examples/resource-aware-operations/README.md
+++ b/examples/resource-aware-operations/README.md
@@ -13,6 +13,7 @@ The first examples stay docs-first and intentionally small.
 - `comparative-review-example.md`
 - `constrained-local-review-example.md`
 - `bounded-pilot-conversion-loop.md`
+- `clean-restart-command-adapter-example.md`
 
 ## Related pilot support
 
@@ -21,3 +22,6 @@ The first examples stay docs-first and intentionally small.
 - `../../starter-pack/templates/resource-aware-pilot-review-template.md`
 - `resource-aware-pilot-review-reference.md`
 - `../../docs/resource-aware-crisis-monitor-reference.md`
+- `../../docs/slice-finalization-and-clean-restart.md`
+- `../../starter-pack/guides/clean-restart-command-adapters.md`
+- `../../starter-pack/templates/restart-bootstrap-prompt-template.md`

--- a/examples/resource-aware-operations/clean-restart-command-adapter-example.md
+++ b/examples/resource-aware-operations/clean-restart-command-adapter-example.md
@@ -1,0 +1,104 @@
+# Clean Restart Command Adapter Example
+
+## Scenario
+
+A bounded slice just finished.
+
+The team now needs to decide whether to:
+
+- continue in the same thread
+- stop for review
+- or start the next slice in a clean thread with a compact restart package
+
+---
+
+## Step 1 — finalize the slice
+
+Logical command:
+
+- `/finalize-slice`
+
+Review result:
+
+- validation status: complete
+- next action: explicit
+- restart package: compact
+- transcript replay needed: no
+
+Outcome:
+
+- `recommend-clean-restart`
+
+---
+
+## Step 2 — map into a runtime-local clean start
+
+Possible Codex-style local action:
+
+- operator starts a fresh thread or uses a local clean-start action
+
+Possible Claude Code-style local action:
+
+- operator starts a fresh session or clean thread in the local workflow
+
+The framework meaning remains the same:
+
+- the next slice should begin from the restart package, not from inherited thread residue
+
+---
+
+## Step 3 — resume from package
+
+Logical command:
+
+- `/resume-from-package`
+
+Bootstrap prompt shape:
+
+```text
+Continue the project with a fresh thread for the next bounded slice.
+
+Read only:
+- the restart package
+- the active slice / next-slice entrypoint
+- any minimal governing refs listed there
+
+Current objective:
+prepare the next bounded pilot review
+
+Primary entrypoint:
+docs/resource-aware-bounded-pilot.md
+
+Known constraints:
+do not replay the old transcript; keep the next slice bounded
+```
+
+---
+
+## Why this is healthier than transcript carryover
+
+This pattern is healthier when:
+
+- the finished slice already has reviewable closure
+- the next slice is meaningfully new
+- old thread context contains more stale residue than useful carryover
+- the restart package is strong enough to start the next slice quickly
+
+It is **not** healthier when the next move still belongs to the same slice or the restart package is too weak.
+
+---
+
+## Failure case
+
+Bad pattern:
+
+- `/clean-restart` is used before validation is done
+- the restart package is vague
+- the next session still needs the whole transcript to proceed
+
+In that case, the real outcome was either:
+
+- `review-required`
+- or `not-ready`
+
+not `recommend-clean-restart`.

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -125,6 +125,18 @@ If you want to run a bounded pilot in a constrained environment before broader r
 - `starter-pack/templates/constrained-pilot-review-template.md`
 - `examples/pilot-conversion/constrained-adoption-bounded-validation.md`
 
+## Bounded clean-restart guidance
+
+If you want to test ending one slice, starting the next slice in a fresh thread, and avoiding transcript replay, read:
+
+- `docs/slice-finalization-and-clean-restart.md`
+- `starter-pack/guides/clean-restart-command-adapters.md`
+- `starter-pack/templates/restart-bootstrap-prompt-template.md`
+- `examples/resource-aware-operations/clean-restart-command-adapter-example.md`
+
+This layer is docs-first and manual-first.
+It does not claim runtime cache control.
+
 ## Queued 1.2 operationalization track
 
 The next queued post-1.0 track is resource-aware operations.

--- a/starter-pack/guides/clean-restart-command-adapters.md
+++ b/starter-pack/guides/clean-restart-command-adapters.md
@@ -1,0 +1,141 @@
+# Clean Restart Command Adapters
+
+## Goal
+
+Define a small logical command vocabulary for teams that want to test clean thread restart after slice finalization.
+
+These commands are **adapter vocabulary**, not framework truth.
+They may become slash commands in a runtime that supports them, or remain a simple operator checklist in a runtime that does not.
+
+---
+
+## Why this layer exists
+
+Teams often want something like:
+
+- `/finalize-slice`
+- `/clear`
+- `/new`
+- `/resume`
+
+The risk is that the runtime command becomes the whole story.
+
+AletheIA should invert that.
+The command is only useful if the slice has already been closed well enough for a clean restart to be healthy.
+
+---
+
+## Logical adapter vocabulary
+
+### `/finalize-slice`
+
+Meaning:
+
+- run the slice-finalization review
+- decide whether the slice is ready to stop
+- emit or update the restart package
+- produce one of these outcomes:
+  - `continue-in-session`
+  - `recommend-clean-restart`
+  - `review-required`
+  - `not-ready`
+
+Minimum expectations:
+
+- validation status is explicit
+- next action is explicit
+- restart package is compact enough to replace transcript replay
+
+### `/clean-restart`
+
+Meaning:
+
+- start the next slice in a fresh thread or session
+- use only the restart package and minimal bootstrap context
+- do this **only** after `recommend-clean-restart`
+
+Boundary:
+
+- this command does **not** mean AletheIA controls hidden runtime memory
+- it only means the operator should now prefer a clean start over continued carryover
+
+### `/resume-from-package`
+
+Meaning:
+
+- bootstrap the next slice from the restart package
+- use the restart bootstrap prompt and minimal refs
+- avoid transcript replay as the default path
+
+This command is especially useful when the runtime has no native slash-command support and the workflow is still manual.
+
+---
+
+## Runtime mapping examples
+
+### Codex-style mapping
+
+Possible local mapping:
+
+- `/finalize-slice` -> fill the review artifact and emit restart package
+- `/clean-restart` -> operator starts a new clean session, possibly using a local action such as `/clear` or opening a fresh thread
+- `/resume-from-package` -> operator pastes the restart package plus the bootstrap prompt
+
+Important:
+
+- `/clear` is a local runtime convenience, not an AletheIA contract
+
+### Claude Code-style mapping
+
+Possible local mapping:
+
+- `/finalize-slice` -> fill the review artifact and emit restart package
+- `/clean-restart` -> operator starts a fresh session or thread in the local workflow
+- `/resume-from-package` -> operator provides the restart package and minimal refs to begin the next bounded slice
+
+Important:
+
+- the meaning should remain identical even if the runtime does not expose a specific reset command
+
+---
+
+## Checklist fallback when no slash commands exist
+
+If the runtime supports no custom commands, teams can still use this sequence:
+
+1. **Finalize the slice**
+   - confirm validation status
+   - confirm next action
+   - produce restart package
+2. **Decide the outcome**
+   - continue
+   - clean restart
+   - review required
+   - not ready
+3. **Start clean if recommended**
+   - open a fresh thread or session
+4. **Resume only from the package**
+   - use the restart bootstrap prompt
+   - load only minimal refs
+   - avoid transcript replay
+
+Semantically, this is equivalent to the slash-command version.
+
+---
+
+## Stop lines
+
+Do **not** use this layer to imply that AletheIA now provides:
+
+- runtime automation hooks
+- session lifecycle APIs
+- memory/cache deletion
+- provider-native command ownership
+- benchmark-backed claims about token savings without evidence
+
+Keep it:
+
+- manual-first
+- docs-first
+- provider-agnostic
+- restart-package-centered

--- a/starter-pack/templates/restart-bootstrap-prompt-template.md
+++ b/starter-pack/templates/restart-bootstrap-prompt-template.md
@@ -1,0 +1,24 @@
+# Restart Bootstrap Prompt Template
+
+Use this template after a slice has already been finalized and a clean restart has been recommended.
+
+```text
+Continue the project with a fresh thread for the next bounded slice.
+
+Read only:
+- the restart package
+- the active slice / next-slice entrypoint
+- any minimal governing refs listed there
+
+Current objective:
+{{next_action}}
+
+Primary entrypoint:
+{{resume_entrypoint}}
+
+Known constraints:
+{{known_constraints}}
+
+Do not replay the old transcript by default.
+If context still seems missing, ask only for the smallest missing detail that is not already explicit in the restart package.
+```


### PR DESCRIPTION
## Summary
- add docs-first slice finalization and clean restart guidance
- define slash-command adapter vocabulary for finalize / clean restart / resume-from-package
- add a bootstrap prompt template and lightweight example for fresh-thread continuation

## Testing
- bash scripts/check-governance.sh
- git diff --check