### PR TITLE
Signal clean thread before new issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- clarify that `recommend-clean-restart` should explicitly signal a fresh thread / local clear-thread action before starting a new issue
 - add a project-local Constitution context guide clarifying how stronger governing-context bootstraps can support clean restart without becoming framework core
 
 - add docs-first clean-restart command adapters and a restart bootstrap prompt template on top of slice finalization guidance

--- a/docs/slice-finalization-and-restart.md
+++ b/docs/slice-finalization-and-restart.md
@@ -200,6 +200,22 @@ AletheIA should require the **meaning** of governing-context continuity, not one
 
 ---
 
+## Start-next-issue clean-thread signal
+
+When the finalization outcome is `recommend-clean-restart` and the next step is a **new issue** or new bounded slice, the framework should make one extra thing explicit:
+
+- the operator should signal that the next issue must start in a **fresh thread / clean session**
+- if the runtime offers a local clear-thread action, it should be used before the next issue begins
+- if the runtime offers no such action, the operator should still abandon the current thread and start a new one manually
+
+This signal matters because a team may agree that restart is healthier and still begin the next issue inside the same stale thread by habit.
+
+A simple operator note is enough:
+
+> Before starting the next issue, clear the current thread or open a fresh one. Resume only from the restart package.
+
+---
+
 ## Runtime boundary
 
 AletheIA does **not** depend on a runtime command such as `/clear` or `/new`.

--- a/starter-pack/guides/clean-restart-command-adapters.md
+++ b/starter-pack/guides/clean-restart-command-adapters.md
@@ -68,6 +68,7 @@ Minimum operator inputs:
 Purpose:
 
 - start a fresh session only after the slice is already closed cleanly
+- explicitly signal that the **next issue must not start in the current stale thread**
 
 Allowed only when:
 
@@ -79,6 +80,7 @@ Meaning:
   - the restart package
   - the resume entrypoint
   - the minimal governing-context refs
+- if the next task is a new issue, the operator should treat thread clearing / fresh-session start as a **precondition** before claiming that next issue inside the runtime
 
 This command must **never** imply that AletheIA controls:
 
@@ -155,7 +157,8 @@ This fallback is equivalent in meaning to the slash-command variant.
 1. `/finalize-slice`
 2. inspect the outcome
 3. if `recommend-clean-restart`, run `/clean-restart`
-4. begin the next slice with `/resume-from-package`
+4. **before starting a new issue, clear the current thread or open a fresh one**
+5. begin the next slice with `/resume-from-package`
 
 If the outcome is:
 

--- a/starter-pack/templates/restart-bootstrap-prompt-template.md
+++ b/starter-pack/templates/restart-bootstrap-prompt-template.md
@@ -2,6 +2,8 @@
 
 Use this template after a slice closes with `recommend-clean-restart`.
 
+Use only after the previous thread has already been abandoned for the new issue or slice.
+
 The prompt should rely on:
 
 - the restart package

--- a/starter-pack/templates/slice-finalization-review-template.md
+++ b/starter-pack/templates/slice-finalization-review-template.md
@@ -12,6 +12,8 @@
 
 - Finalization outcome: `continue-in-session | recommend-clean-restart | review-required | not-ready`
 - Reason:
+- Clean-thread signal before next issue: `not_needed | recommended | required`
+- Operator note if clean thread is required:
 
 ## AI Fatigue Read
 
@@ -26,6 +28,8 @@
 
 ## Validation and continuity notes
 
+- Next issue / next bounded slice starts in fresh thread: `yes | no`
+- Local clear-thread action available: `yes | no`
 - What was delivered:
 - Evidence:
 - Known constraints:


### PR DESCRIPTION
## Summary
- add an explicit signal that a new issue should start in a fresh thread after `recommend-clean-restart`
- extend the slice finalization review template with clean-thread signaling fields
- clarify that clean-thread start is a precondition before claiming a new issue in runtime-local workflows

## Testing
- bash scripts/check-governance.sh
- git diff --check