### PR TITLE
Reposition AletheIA core around work slices and work items

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,9 +268,11 @@ If this is your first time here, start with:
 1. `docs/slice-finalization-and-restart.md`
 1. `starter-pack/templates/slice-finalization-review-template.md`
 1. `examples/resource-aware-operations/slice-finalization-reference.md`
+1. `starter-pack/templates/restart-bootstrap-prompt-template.md`
+1. note: finalization and restart now require a compact `Finalization Context Prompt` that identifies the project, names the official work item when available, states what must not be reopened, and explicitly says whether the next step should open a new execution surface
+1. `docs/durable-decision-finalization-context-prompt.md`
 1. `starter-pack/guides/clean-restart-command-adapters.md`
 1. `docs/github-project-operations.md`
-1. `starter-pack/templates/restart-bootstrap-prompt-template.md`
 1. `examples/resource-aware-operations/clean-restart-command-adapter-example.md`
 1. `docs/project-local-constitution-context.md`
 1. `docs/architecture.md`

--- a/README.md
+++ b/README.md
@@ -81,6 +81,38 @@ AletheIA is not:
 
 ---
 
+## Canonical operating vocabulary
+
+AletheIA now treats the following concepts as the stable public vocabulary of the framework core:
+
+- **Work Slice** — the primary operational unit of bounded AI-assisted work
+- **Work Item** — the external coordination unit that a slice may point to
+- **Restart Package** — the compact continuity artifact used to resume after a boundary
+- **Handoff** — the transition artifact that carries a slice across an agent or review boundary
+- **Governing Context** — the minimum durable context that must still govern the next boundary
+- **Durable Memory** — reviewable artifacts that survive past one execution surface
+- **Execution Surface** — the local runtime surface where work happens, such as a chat, IDE pane, agent shell, or coding assistant window
+- **External Coordination System** — a tool such as GitHub, Jira, Trello, or Linear that tracks external work state
+
+The core model is therefore:
+
+- **Work Slice** = unit of operation
+- **Work Item** = unit of external coordination
+- **Execution Surface** = runtime detail, not framework truth
+
+This means AletheIA should be explainable without depending on thread control, chat transcripts, GitHub Issues, or GitHub Projects as core concepts.
+
+GitHub Projects may still be used to coordinate the AletheIA repository itself, but that remains a **repository-local operating choice** and a first real adapter example, not a definition of the framework core.
+
+See also:
+
+- `docs/canonical-definitions.md`
+- `docs/work-item-pattern.md`
+- `docs/github-project-operations.md`
+- `docs/deprecated-thread-centric-language.md`
+
+---
+
 ## Core operating loop
 
 AletheIA works through a controlled loop:
@@ -186,7 +218,7 @@ It now also includes a bounded Crisis Monitor reference so the 1.2 track has one
 It now also defines the next signals that would justify reopening the track for stronger comparative work instead of growing by inertia.
 It now also includes a short 1.2 review so the current scope, proof level, and stop line are explicit.
 It now also adds slice finalization and restart guidance so teams can reduce AI Fatigue through compact restart packages instead of transcript replay.
-It now also adds a docs-first clean-restart command adapter layer so finalization, clean restart, and resume flows can be exposed through slash-command style adapters without turning AletheIA into a runtime platform.
+It now also adds a docs-first clean-execution-surface adapter layer so finalization, clean restart, and resume flows can be exposed through runtime-local commands without turning AletheIA into a runtime platform.
 It now also clarifies how project-local Constitution layers can strengthen governing-context continuity without becoming framework core truth.
 
 See also:
@@ -230,10 +262,14 @@ If this is your first time here, start with:
 1. `examples/resource-aware-operations/resource-aware-pilot-review-reference.md`
 1. `docs/resource-aware-next-signals.md`
 1. `docs/resource-aware-operations-review.md`
+1. `docs/canonical-definitions.md`
+1. `docs/work-item-pattern.md`
+1. `docs/deprecated-thread-centric-language.md`
 1. `docs/slice-finalization-and-restart.md`
 1. `starter-pack/templates/slice-finalization-review-template.md`
 1. `examples/resource-aware-operations/slice-finalization-reference.md`
 1. `starter-pack/guides/clean-restart-command-adapters.md`
+1. `docs/github-project-operations.md`
 1. `starter-pack/templates/restart-bootstrap-prompt-template.md`
 1. `examples/resource-aware-operations/clean-restart-command-adapter-example.md`
 1. `docs/project-local-constitution-context.md`

--- a/docs/agent-handoffs.md
+++ b/docs/agent-handoffs.md
@@ -58,6 +58,27 @@ Keep three layers distinct:
 The schema may stay smaller than the template.
 That is a feature, not a bug.
 
+### When the minimum package is enough
+
+Prefer the minimum restart package when:
+
+- the next action is obvious
+- the receiving boundary is narrow
+- the main risk is execution, not reinterpretation
+- validation continuity fits in one compact line
+
+### When to step up to the richer template
+
+Use the richer operational template when one or more of these are true:
+
+- the work crosses a meaningful ownership boundary
+- file scope must be frozen explicitly
+- semantic guardrails matter more than raw file paths
+- acceptance criteria need to be preserved to avoid reinterpretation
+- the receiving boundary should report back in a specific format
+
+Compact and restartable still beats exhaustive and noisy, but the richer template is justified when it materially reduces drift.
+
 ---
 
 ## Multi-boundary continuity

--- a/docs/agent-handoffs.md
+++ b/docs/agent-handoffs.md
@@ -2,74 +2,34 @@
 
 ## Goal
 
-This document explains how AletheIA treats handoffs between agents.
-
-In simple terms:
-
-when one agent stops and another one continues, the handoff should behave like a compact restart package instead of a loose recap.
-
----
-
-## Why this matters
-
-As soon as work crosses agent boundaries, a common failure appears:
-
-- the task is passed on
-- but the execution boundary is not
-- the context is summarized
-- but the rationale is blurred
-- the next agent continues
-- but with too much interpretation freedom
-
-This creates drift, repeated analysis, and accidental scope expansion.
-
-AletheIA should reduce that by making handoffs more explicit, more structured, and more portable.
-
----
-
-## Two kinds of handoff
-
-### 1. Narrative handoff
-
-Use when the next reader mainly needs situational understanding.
-
-Typical purpose:
-
-- explain what happened
-- summarize current status
-- list pending items and known risks
-
-This is often sufficient for humans.
-
-### 2. Operational handoff
-
-Use when the next reader is another agent expected to continue execution with low ambiguity.
-
-Typical purpose:
-
-- preserve scope boundaries
-- transfer the minimum useful context
-- reduce semantic drift
-- define what should and should not be touched next
-
-This is the more important kind of handoff for Alpha 4 and the current operational layer around it.
+Explain how AletheIA treats handoffs between agents as compact restartable transitions between work-slice boundaries.
 
 ---
 
 ## Core rule
 
-AletheIA should treat inter-agent handoffs as:
+Inter-agent handoffs should behave as:
 
 **restart packages, not transcripts**
 
-That means the handoff should optimize for:
+They should preserve:
 
-- resumability
-- scope clarity
+- work-slice boundary clarity
 - validation continuity
-- low ambiguity
+- next-action explicitness
+- low ambiguity for the next boundary
 
-Not for replaying the entire history.
+---
+
+## Handoff in the broader model
+
+A handoff sits between:
+
+- a current **Work Slice**
+- a possible related **Work Item** in an external coordination system
+- the current and next **Execution Surface**
+
+The handoff should preserve what the next boundary needs without pretending that the previous runtime surface is durable memory.
 
 ---
 
@@ -83,210 +43,45 @@ A useful operational handoff should usually make these things explicit:
 4. the next action
 5. the main risks
 6. the minimum validation expectation
-
-That is the smallest layer that helps the next boundary resume without guessing.
-
----
-
-## Three layers of handoff richness
-
-AletheIA currently benefits from keeping three layers distinct.
-
-### 1. Conceptual richness
-
-This is the full operating intent of a good handoff.
-It may include:
-
-- receiving agent role
-- dominant frontier
-- cross-boundary reason
-- allowed and forbidden files
-- semantic guardrails
-- acceptance criteria
-- expected response format
-
-### 2. Template shape
-
-The starter-pack template is richer than the minimum JSON record.
-That is intentional.
-It gives teams optional fields that reduce drift when the next boundary is non-trivial.
-
-### 3. Schema coverage
-
-The current handoff schema stays smaller.
-It captures the minimum machine-friendly continuity record without pretending to encode every nuance of a rich restart package.
-
-This smaller schema is a feature, not a bug.
+7. the related work-slice or work-item refs when they matter
 
 ---
 
-## Mapping: concept -> template -> current schema
+## Richness rule
 
-| Operational concern | Template support | Current schema coverage | Notes |
-| --- | --- | --- | --- |
-| status | `Status` | `status` | schema-backed |
-| completed work | `What was completed` | `completed` | schema-backed |
-| pending work | `What remains pending` | `pending` | schema-backed |
-| main risks | `Main risks` | `risks` | schema-backed |
-| summary for reopening | `Current status` / `Available context` | `reopen_context.summary` | schema-backed |
-| required files | `Relevant files` | `reopen_context.required_files` | schema-backed, but the template can be richer |
-| next action | `Next action` | `reopen_context.next_action` | schema-backed |
-| validation expectation | `Validation expectation` | `validation_next` | schema-backed |
-| receiving agent role | `Receiving agent role` | none | optional outside schema |
-| dominant frontier | `Dominant frontier` | none | optional outside schema |
-| cross-boundary reason | `Cross-boundary reason` | none | optional outside schema |
-| allowed / forbidden files | `Allowed files` / `Forbidden files` | none | optional outside schema |
-| semantic guardrails | `Semantic guardrails` | none | optional outside schema |
-| acceptance criteria | `Acceptance criteria` | none | optional outside schema |
-| expected response format | `Expected response format` | none | optional outside schema |
-| explicitly out of scope | `Explicitly out of scope` | none | optional outside schema |
+Keep three layers distinct:
 
-The important boundary is:
+1. **conceptual richness** — the full meaning the boundary may need
+2. **template richness** — optional fields that reduce drift
+3. **schema coverage** — the minimum structured continuity record
 
-- the **schema** captures minimum structured continuity
-- the **template** supports a richer restart package when the next boundary needs it
+The schema may stay smaller than the template.
+That is a feature, not a bug.
 
 ---
 
-## When the minimum structured record is enough
+## Multi-boundary continuity
 
-A smaller handoff is usually enough when:
-
-- the next action is obvious
-- the receiving boundary is narrow
-- the files in scope are already stable
-- the main risk is execution, not reinterpretation
-- validation continuity can be stated in one compact line
-
-In those cases, AletheIA should prefer the minimum restart package over a heavier artifact.
-
----
-
-## When to step up to the richer operational template
-
-Use the richer optional fields when one or more of these are true:
-
-- the work crosses a meaningful ownership boundary
-- the next agent could easily reinterpret the task as a different frontier
-- file scope must be frozen explicitly
-- there are semantic guardrails that matter more than raw file paths
-- acceptance criteria need to be preserved to avoid drift
-- the receiving agent should report back in a specific shape
-
-This is the practical boundary between **schema-enough continuity** and **richer operational continuity**.
-
----
-
-## Multi-boundary continuity rule
-
-If work will cross more than one meaningful boundary, AletheIA should usually prefer:
+If work will cross more than one meaningful boundary, prefer:
 
 **a chain of compact handoffs**
 
-instead of:
+instead of one oversized artifact.
 
-**one oversized handoff trying to predict every later step**
-
-Why:
-
-- each boundary can keep a narrower scope
-- validation can remain local to the current step
-- later agents receive fresher context
-- the artifact stays reviewable instead of turning into a transcript-shaped bundle
-
-A strong multi-boundary flow normally looks like:
+A healthy flow still looks like:
 
 `boundary A -> restart package -> boundary B -> restart package -> boundary C`
-
-See:
-
-- `examples/handoffs/multi-boundary-continuity.md`
-
----
-
-## Low-bureaucracy rule
-
-A stronger handoff should reduce ambiguity, not increase ritual.
-
-That means:
-
-- use the richer template fields when they materially help the next boundary
-- skip optional detail when it only repeats obvious facts
-- do not dump raw transcripts into the artifact
-- do not turn every handoff into a long-form report
-
-Compact and restartable beats exhaustive and noisy.
 
 ---
 
 ## Model-agnostic requirement
 
-AletheIA should not define handoffs that only make sense for one tool, one shell, or one LLM family.
-
-A good agent handoff should preserve its meaning whether the next executor is:
+A good handoff should still preserve its meaning whether the next executor is:
 
 - Codex
 - Claude Code
 - another coding agent
 - a future workflow using a different provider
 
-Project-specific conventions may appear inside the artifact, but the handoff structure itself should remain provider-agnostic.
-
----
-
-## Relationship to Alpha 5
-
-Alpha 4 focuses on continuity between agents.
-
-Alpha 5 may later add a stronger semantic layer through structured risk inference.
-
-That means an operational handoff may eventually carry:
-
-- instruction and scope
-- validation expectations
-- and, when triggered, a structured inference artifact
-
-But Alpha 4 does not require Alpha 5 to be useful.
-
----
-
-## Good signs
-
-Alpha 4 is going well when:
-
-- the next agent needs less reinterpretation to continue
-- scope drift is reduced
-- validation continuity is preserved across the handoff
-- the artifact still works even if the receiving agent changes provider
-- multi-boundary work can be continued through small restart packages instead of giant recaps
-- the handoff is rich enough to restart work, but still shorter than a transcript
-
----
-
-## What not to do
-
-Do not treat an agent handoff as:
-
-- a raw transcript dump
-- a generic paragraph with no execution boundary
-- a provider-specific prompt recipe disguised as framework logic
-- a bureaucratic checklist that duplicates the entire task history
-- a single artifact trying to solve three later boundaries at once
-
-AletheIA should preserve the handoff as a reusable operating pattern.
-
----
-
-## Suggested next reading
-
-- `starter-pack/guides/handoff-guide.md`
-- `starter-pack/guides/agent-handoff-generation.md`
-- `starter-pack/templates/handoff-template.md`
-- `starter-pack/templates/agent-handoff-template.md`
-- `examples/handoffs/compact-reviewable-handoff.md`
-- `examples/handoffs/high-stakes-handoff.md`
-- `examples/handoffs/multi-boundary-continuity.md`
-- `docs/work-slice-pattern.md`
-- `docs/project-handoff-conventions.md`
-- `docs/handoff-capture-pattern.md`
-- `docs/project-extension-pattern.md`
+Runtime-local examples may differ.
+The handoff meaning should not.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,25 +1,48 @@
 # AletheIA — Core Contracts
 
-## Objetivo
+## Goal
 
-Este documento traduz a visão do `AletheIA` em contratos concretos.
-
-Em linguagem simples: se o documento principal explica **o que o framework é**, este arquivo explica **quais peças mínimas ele precisa ter para funcionar**.
-
-Os contratos existem para evitar ambiguidade.
-
-Sem eles, cada tarefa, decisão, execução ou handoff pode nascer em um formato diferente — e o framework perde:
-
-- clareza
-- rastreabilidade
-- comparabilidade
-- reuso
+Translate the AletheIA vision into the minimum contracts and conceptual surfaces the framework needs in order to stay reviewable, portable, and bounded.
 
 ---
 
-## Leitura rápida
+## Two layers to keep distinct
 
-O alpha do `AletheIA` deve começar com **6 contratos centrais**:
+AletheIA now makes an explicit distinction between:
+
+1. **core contracts**
+2. **canonical operating concepts**
+
+The core contracts are the structured artifacts already backed by schemas and engine helpers.
+The canonical operating concepts are the stable meanings that connect those artifacts across tools and runtime surfaces.
+
+See also:
+
+- `docs/canonical-definitions.md`
+- `docs/work-item-pattern.md`
+
+---
+
+## Canonical operating concepts
+
+The stable public concepts are:
+
+1. `Work Slice`
+2. `Work Item`
+3. `Restart Package`
+4. `Handoff`
+5. `Governing Context`
+6. `Durable Memory`
+7. `Execution Surface`
+8. `External Coordination System`
+
+These concepts are broader than any one schema, runtime, or board.
+
+---
+
+## Core contracts
+
+The current baseline still starts from **6 core contracts**:
 
 1. `Task Brief`
 2. `Context Pack`
@@ -28,191 +51,100 @@ O alpha do `AletheIA` deve começar com **6 contratos centrais**:
 5. `Handoff Record`
 6. `Learning Record`
 
-Eles representam a jornada completa do trabalho assistido por IA:
+They represent the reviewable chain:
 
 `tarefa -> contexto -> decisão -> execução -> handoff -> learning`
 
 ---
 
-## Por que começar pelos contratos
+## Why start from contracts and concepts together
 
-Porque o `AletheIA` não deve nascer como um monte de automação sem espinha dorsal.
+Without contracts, the framework becomes vague.
+Without concepts, the contracts can become tool-shaped and drift into one local workflow.
 
-Ele precisa primeiro deixar claro:
+AletheIA should make both explicit.
 
-- qual problema está sendo resolvido
-- qual contexto foi usado
-- qual decisão foi tomada
-- o que foi executado
-- como outra thread retoma
-- o que foi aprendido
+That is how the framework stays:
 
-Isso é o que torna o framework:
-
-- confiável
-- auditável
-- explicável
+- clear
+- auditable
+- reusable
+- less dependent on hidden runtime state
 
 ---
 
-## 1. Task Brief
+## Contract purpose summary
 
-Define a tarefa antes da execução.
+### 1. Task Brief
 
-Responde:
+Defines the task before execution.
 
-- qual é o problema?
-- qual é o objetivo?
-- qual é o nível de risco?
-- qual é o tipo da tarefa?
-- como vamos saber se deu certo?
+### 2. Context Pack
 
----
+Defines the minimum sufficient context for that task.
 
-## 2. Context Pack
+### 3. Decision Record
 
-Define o contexto mínimo suficiente para aquela tarefa.
+Explains what was interpreted, decided, and why.
 
-Responde:
+### 4. Execution Record
 
-- quais arquivos/docs entram?
-- por que eles entram?
-- o que ficou de fora?
-- qual é o budget de contexto?
+Shows what actually ran, through which adapter, and with what result.
 
----
+### 5. Handoff Record
 
-## 3. Decision Record
+Preserves explicit continuity across a boundary.
 
-É o coração do `AletheIA`.
+### 6. Learning Record
 
-Registra:
-
-- o que entrou
-- como foi interpretado
-- o que foi decidido
-- por que foi decidido
-- com qual risco
-- com qual confiança
+Turns the result into reusable learning when warranted.
 
 ---
 
-## 4. Execution Record
+## How the concepts and contracts fit together
 
-Registra a execução real ou mockada.
+- a **Work Slice** is the bounded operational unit built from one or more of the core contracts
+- a **Work Item** is the external coordination anchor a slice may point to
+- a **Restart Package** is the compact continuity block used when the slice crosses a new boundary
+- a **Handoff Record** is the structured carrier of that continuity
+- an **Execution Surface** is where the slice is currently being worked, but not where durable truth should live
 
-Responde:
-
-- o que foi executado?
-- por qual adapter?
-- em qual branch/worktree?
-- com qual resultado?
-- com quais validações?
+This avoids treating threads, chats, sessions, issues, or boards as if they were the framework itself.
 
 ---
 
-## 5. Handoff Record
+## Governance-supporting artifacts
 
-É o contrato de retomada.
-
-Responde:
-
-- o que foi feito?
-- o que falta?
-- quais são os riscos?
-- como retomar sem reler toda a conversa?
-
----
-
-## 6. Learning Record
-
-Transforma execução em aprendizado reaproveitável.
-
-Responde:
-
-- o que foi aprendido?
-- de onde veio esse aprendizado?
-- isso vira regra, teste, doc ou heurística?
-- isso foi revisado ou ainda é hipótese?
-
----
-
-## Artefatos de apoio à governança
-
-Os 6 contratos centrais continuam sendo o coração do alpha.
-
-Mas a camada de governança do `AletheIA` já indica dois artefatos de apoio que devem entrar em seguida:
+The 6 core contracts remain central.
+AletheIA also keeps two governance-supporting artifacts explicit:
 
 ### 1. Execution Scope
 
-Ajuda a explicitar:
-
-- arquivos permitidos
-- arquivos proibidos
-- tipo de operação
-- fronteira da mudança
-
-Status atual:
-
-- contrato humano formalizado
-- schema inicial criado
-- tipo TypeScript criado
-- helper mínimo de geração implementado
+Makes the execution boundary explicit.
 
 ### 2. Policy Evaluation
 
-Ajuda a registrar:
+Makes rule evaluation and action selection more auditable.
 
-- quais regras foram avaliadas
-- quais regras dispararam
-- qual ação final foi produzida
-- quais fatos sustentaram a decisão
-
-Status atual:
-
-- contrato humano formalizado
-- schema inicial criado
-- tipo TypeScript criado
-- helper mínimo de geração implementado a partir do `Policy Trace`
-
-Esses artefatos não substituem os 6 contratos centrais.
-
-Eles existem para fortalecer a camada de governança e tornar o futuro `Rule Interpreter` mais auditável.
+These artifacts strengthen the governance layer, but they do not replace the core contracts or the canonical concepts.
 
 ---
 
-## Fluxo mínimo
+## Quality rule
 
-```text
-Task Brief
-  ↓
-Context Pack
-  ↓
-Decision Record
-  ↓
-Execution Record
-  ↓
-Handoff Record
-  ↓
-Learning Record
-```
+Contracts and concepts should remain:
+
+- legible for humans
+- versionable
+- smaller than full transcript replay
+- provider-agnostic
+- tool-agnostic at the core
 
 ---
 
-## Regras de qualidade
+## Next reading
 
-- contratos precisam ser legíveis para humano
-- contratos precisam ser pequenos no alpha
-- contratos precisam ser agnósticos a produto e provider
-- contratos precisam ser versionáveis
-- contratos precisam conversar com testes e evals
-
----
-
-## Próximo passo recomendado
-
-Depois desta fase:
-
-1. criar exemplos mínimos dos contratos
-2. montar `hello-world`
-3. implementar o `Decision Kernel` mínimo em TypeScript
+- `docs/canonical-definitions.md`
+- `docs/work-item-pattern.md`
+- `docs/work-slice-pattern.md`
+- `docs/slice-finalization-and-restart.md`

--- a/docs/canonical-definitions.md
+++ b/docs/canonical-definitions.md
@@ -138,12 +138,18 @@ A minimal WorkSlice should make explicit:
 
 A minimal RestartPackage should make explicit:
 
+- `project_ref`
+- `official_work_item_ref`
 - `slice_id`
 - `validation_status`
 - `mission_focus`
 - `resume_entrypoint`
 - `last_boundary_summary`
 - `next_immediate_action`
+- `do_not_reopen`
+- `next_official_step`
+- `new_execution_surface`
+- `new_execution_surface_reason`
 - `known_constraints`
 - `governing_context_refs`
 - `governing_context_delta`

--- a/docs/canonical-definitions.md
+++ b/docs/canonical-definitions.md
@@ -1,0 +1,178 @@
+# Canonical Definitions
+
+## Goal
+
+Define the stable, tool-agnostic vocabulary of the AletheIA core.
+
+These definitions exist so the framework can be explained without depending on one runtime surface, one board, or one provider-specific workflow.
+
+---
+
+## Core entities
+
+### Work Slice
+
+A **Work Slice** is the primary operational unit of AletheIA.
+
+It is the smallest bounded unit of work that should remain explicit across:
+
+- framing
+- decision
+- execution
+- validation
+- handoff when needed
+- restart when boundaries change
+- learning when warranted
+
+A work slice is not the same thing as a board card, issue, ticket, or chat.
+It is the unit that AletheIA governs directly.
+
+### Work Item
+
+A **Work Item** is the canonical abstraction for any externally coordinated unit of work.
+
+Examples:
+
+- GitHub Issue
+- Jira ticket
+- Trello card
+- Linear issue
+- Notion task
+
+A work item may anchor one slice, many slices, or a larger initiative that still needs slicing.
+
+### Restart Package
+
+A **Restart Package** is the compact continuity artifact used to resume work after a boundary.
+
+Its job is to preserve reviewable continuity without requiring transcript replay.
+
+### Handoff
+
+A **Handoff** is the transition artifact that moves a slice across an agent, review, or ownership boundary.
+
+Every operational handoff should behave like a restart package, not a transcript dump.
+
+### Governing Context
+
+**Governing Context** is the minimum durable context that still constrains the next boundary.
+
+Typical refs may include:
+
+- active spec or plan
+- policy pack
+- decision log
+- quality gate or release rule
+- project-local constitution or operating rules
+
+### Durable Memory
+
+**Durable Memory** is the set of reviewable artifacts that must survive past one execution surface.
+
+Examples include docs, decisions, handoffs, restart packages, and learnings.
+
+### Execution Surface
+
+An **Execution Surface** is the local runtime surface where work happens.
+
+Examples:
+
+- a coding-agent conversation
+- an IDE agent pane
+- a chat interface
+- a shell-centered agent session
+
+Execution surfaces are real and operationally important, but they are **runtime concerns**, not core framework truth.
+
+### External Coordination System
+
+An **External Coordination System** is any tool used to track status, priority, ownership, or progress outside the core.
+
+Examples:
+
+- GitHub Projects
+- Jira boards
+- Trello boards
+- Linear views
+
+AletheIA integrates with these systems through adapter logic or operator practice, not through core dependence.
+
+---
+
+## Minimum conceptual interfaces
+
+These are conceptual interfaces only.
+They define meaning, not a final wire format.
+
+### WorkItem
+
+A minimal WorkItem should make explicit:
+
+- `system`
+- `workspace_ref`
+- `item_id`
+- `item_type`
+- `title`
+- `status`
+- `priority`
+- `owner`
+- `acceptance_refs`
+- `source_of_truth_refs`
+
+### WorkSlice
+
+A minimal WorkSlice should make explicit:
+
+- `slice_id`
+- `related_work_item_ref`
+- `goal`
+- `in_scope`
+- `out_of_scope`
+- `validation_expected`
+- `governing_context_refs`
+- `restart_package_ref`
+- `handoff_ref`
+- `finalization_outcome`
+
+### RestartPackage
+
+A minimal RestartPackage should make explicit:
+
+- `slice_id`
+- `validation_status`
+- `mission_focus`
+- `resume_entrypoint`
+- `last_boundary_summary`
+- `next_immediate_action`
+- `known_constraints`
+- `governing_context_refs`
+- `governing_context_delta`
+
+---
+
+## Responsibility boundaries
+
+| Concern type | Meaning | Examples | Must stay where |
+| --- | --- | --- | --- |
+| `core concern` | Stable framework meaning | work slice, restart package, governing context, reviewable continuity | AletheIA core docs and concepts |
+| `adapter concern` | Tool-specific translation of the core | GitHub mapping, Jira mapping, slash-command mapping, runtime-local actions | adapter docs, delivery mappings, local guides |
+| `operator concern` | Manual bridge work when automation is absent or intentionally light | opening a new runtime surface, linking a board item, pasting a restart package | local operations and project practice |
+
+Core rule:
+
+- the **core** governs boundaries, artifacts, and reviewable continuity
+- **adapters** translate those meanings into concrete tools
+- the **operator** bridges the gap when no adapter exists or when manual control is healthier
+
+---
+
+## Non-goals
+
+These definitions do **not** yet try to:
+
+- define a final adapter API
+- define a canonical state machine for all tools
+- make GitHub the default truth of the framework
+- make runtime controls part of the kernel
+
+Those belong to later adapter and delivery work.

--- a/docs/deprecated-thread-centric-language.md
+++ b/docs/deprecated-thread-centric-language.md
@@ -1,0 +1,64 @@
+# Deprecated Thread-Centric Language
+
+## Goal
+
+Mark older thread-first language as compatibility vocabulary rather than core AletheIA vocabulary.
+
+This is a **strong deprecation note** for framework-facing docs.
+
+---
+
+## Rule
+
+In core AletheIA docs, prefer the canonical terms:
+
+- `execution surface` instead of `thread`, `chat`, or `session`
+- `clean execution surface` instead of `clean thread` or `fresh session`
+- `work item` instead of treating `issue`, `ticket`, or `card` as universal truth
+
+Older terms may still appear only when they are:
+
+- runtime-local examples
+- adapter vocabulary
+- project-local operating conventions
+- compatibility notes for readers coming from existing workflows
+
+---
+
+## Replacement table
+
+| Deprecated core phrasing | Preferred phrasing | Why |
+| --- | --- | --- |
+| thread / chat / session | execution surface | keeps runtime semantics local instead of core |
+| clear thread | clean execution surface | removes tool-specific coupling from the core |
+| new thread / new session | fresh execution surface | preserves meaning without assuming one runtime |
+| issue as universal unit | work item | keeps external coordination tool-agnostic |
+| GitHub Project as implied default board | external coordination system | keeps the framework adaptable across tools |
+
+---
+
+## Compatibility rule
+
+Adapter docs may still say things such as:
+
+- open a new thread
+- start a fresh chat
+- clear the current session
+
+But they should do so only while making it explicit that:
+
+- the phrase is runtime-local
+- the core meaning is still `clean execution surface`
+- the continuity artifact is still a `restart package`
+
+---
+
+## What this deprecation does not mean
+
+It does **not** mean that execution surfaces are unimportant.
+
+It means they are:
+
+- operationally real
+- architecturally secondary
+- not the source of durable framework meaning

--- a/docs/durable-decision-finalization-context-prompt.md
+++ b/docs/durable-decision-finalization-context-prompt.md
@@ -1,0 +1,92 @@
+# Durable Decision — Finalization Context Prompt
+
+## Title
+
+Require a compact Finalization Context Prompt at slice finalization.
+
+## Status
+
+- accepted
+
+## Context
+
+AletheIA already treated restart packages as the compact continuity artifact for resuming after a boundary.
+
+That baseline was directionally right, but still left an operational gap:
+
+- project identity could stay implicit
+- the official work item could remain unstated even when an adapter existed
+- operators could reopen already-closed scope by accident
+- the decision to open a new execution surface could remain implicit
+- too much continuity pressure could still leak into transcript replay, memory dependence, and token waste
+
+This became more visible in real cross-project usage where one operator alternates between multiple repos and bounded slices.
+
+## Decision
+
+AletheIA now requires every finalization-ready slice to leave a compact **Finalization Context Prompt** as part of its restart/finalization package.
+
+That prompt must explicitly include:
+
+- `project_ref`
+- `official_work_item_ref` when an adapter exists
+- what was proved enough to close the slice
+- `do_not_reopen`
+- `next_official_step`
+- whether the next step should open a new execution surface
+- a one-line reason for that choice
+
+## Why
+
+This choice was preferred because it improves continuity without reintroducing transcript-first behavior.
+
+It gives the next execution surface the minimum bounded context needed to resume safely while preserving AletheIA’s portable framing:
+
+- project-aware
+- adapter-aware when useful
+- execution-surface aware instead of thread-centric
+- compact enough to reduce token waste and memory dependence
+
+## Alternatives considered
+
+- **Keep the restart package generic and let projects decide the rest**
+  - rejected because too much important continuity stayed implicit
+
+- **Make the next-thread decision an operator-only convention**
+  - rejected because it weakens portability and makes cross-project continuity drift too easily
+
+- **Build a heavier ADR or lifecycle system first**
+  - rejected because the framework only needed a compact durable rule, not more process machinery
+
+## Consequences
+
+Benefits:
+
+- lower restart ambiguity across projects
+- less accidental reopening of closed scope
+- better token discipline at slice boundaries
+- cleaner distinction between continue-on-current-surface and open-new-surface decisions
+
+Tradeoffs:
+
+- finalization artifacts become slightly richer
+- operators must fill a few more fields at closure time
+- adapters may later want tighter tool-specific mappings for `official_work_item_ref`
+
+## Boundaries
+
+This decision does **not** decide:
+
+- a global issue schema for all adapters
+- any specific GitHub, Jira, or Linear implementation rule
+- runtime-local commands for opening a new execution surface
+- whether every project must use issues as its only external coordination model
+
+## Related artifacts
+
+- `docs/durable-decisions.md`
+- `docs/canonical-definitions.md`
+- `docs/slice-finalization-and-restart.md`
+- `starter-pack/templates/slice-finalization-review-template.md`
+- `starter-pack/templates/restart-bootstrap-prompt-template.md`
+- `examples/resource-aware-operations/slice-finalization-reference.md`

--- a/docs/durable-decisions.md
+++ b/docs/durable-decisions.md
@@ -101,6 +101,10 @@ Recommended forms:
 - ADR-style markdown
 - decision appendix inside a roadmap or governance doc
 
+Current example:
+
+- `docs/durable-decision-finalization-context-prompt.md`
+
 The important part is not the label.
 The important part is that future contributors can find and understand the reasoning.
 

--- a/docs/github-project-operations.md
+++ b/docs/github-project-operations.md
@@ -1,0 +1,95 @@
+# GitHub Project Operations for the AletheIA Repository
+
+## Goal
+
+Describe how the **AletheIA repository** may use a GitHub Project for coordination without turning GitHub into framework core truth.
+
+---
+
+## Positioning
+
+The GitHub Project for this repository is:
+
+- the coordination surface for the repo backlog
+- the first real field of proof for a GitHub adapter posture
+- a repository-local operating choice
+
+It is **not**:
+
+- the definition of a work slice
+- the definition of a work item across all tools
+- a required core dependency of AletheIA
+
+---
+
+## Recommended project scope
+
+Use one repository project with mixed scope for:
+
+- framework architecture
+- documentation and taxonomic shifts
+- starter-pack evolution
+- implementation tasks
+- adapter and delivery mapping work
+
+This keeps conceptual and execution work connected without fragmenting the repo into artificial boards.
+
+---
+
+## Recommended statuses
+
+- `Backlog`
+- `Ready`
+- `In Progress`
+- `Pending Handoff`
+- `In Review`
+- `Blocked`
+- `Done`
+
+---
+
+## Recommended fields
+
+- `Status`
+- `Executor`
+- `Priority`
+- `Target Release`
+- `Link / Context`
+
+Optional local fields may exist, but these should be enough to keep the repo readable.
+
+---
+
+## Initial backlog lanes
+
+Create and maintain at least these groupings in the repo backlog:
+
+1. `Core repositioning`
+2. `Canonical model`
+3. `Starter-pack agnostic`
+4. `Adapters & delivery mappings`
+
+---
+
+## Suggested first issues
+
+- revise the central framework vocabulary
+- publish canonical definitions
+- formalize `core vs adapter vs operator` boundaries
+- revise finalization / restart / handoff docs
+- add a work-item-ready template
+- revise the work-slice template
+- publish the thread-centric deprecation note
+
+---
+
+## Operating rule
+
+When this repo uses GitHub Project as its coordination system, the meaning should be read as:
+
+- GitHub Project = local **External Coordination System**
+- GitHub Issue = local **Work Item** representation
+- AletheIA docs and templates = durable memory and operational artifacts
+- active agent surface = local **Execution Surface**
+
+That mapping is healthy precisely because the concepts stay distinct.

--- a/docs/github-project-operations.md
+++ b/docs/github-project-operations.md
@@ -38,6 +38,8 @@ This keeps conceptual and execution work connected without fragmenting the repo 
 
 ## Recommended statuses
 
+Use `Workflow Status` as the operational source of truth for the repo workflow:
+
 - `Backlog`
 - `Ready`
 - `In Progress`
@@ -46,15 +48,24 @@ This keeps conceptual and execution work connected without fragmenting the repo 
 - `Blocked`
 - `Done`
 
+The native GitHub `Status` field may still exist for lightweight board visibility, but it is not rich enough to express the full repo workflow by itself.
+
 ---
 
 ## Recommended fields
 
-- `Status`
+- `Workflow Status`
+- `Status` (optional compatibility / visual summary)
 - `Executor`
 - `Priority`
 - `Target Release`
 - `Link / Context`
+- `Lane`
+
+This matches the current repository project setup more closely:
+
+- `Workflow Status` = operational truth
+- native `Status` = lightweight GitHub-native visual state when useful
 
 Optional local fields may exist, but these should be enough to keep the repo readable.
 

--- a/docs/project-handoff-conventions.md
+++ b/docs/project-handoff-conventions.md
@@ -2,33 +2,7 @@
 
 ## Goal
 
-This document explains how a project can define local handoff conventions on top of AletheIA without breaking the framework's model-agnostic handoff structure.
-
-In simple terms:
-
-AletheIA defines the handoff shape.
-A project may define local conventions for how that shape is filled.
-
----
-
-## Why this matters
-
-Alpha 4 should not stop at a generic handoff template.
-
-Real projects often need local conventions such as:
-
-- ownership boundaries between agents
-- preferred handoff folder locations
-- local frontier labels
-- repo-specific file scope rules
-- project-specific validation expectations
-- local wording for response formats
-
-Those conventions are useful.
-
-But if they replace the framework structure itself, handoffs become tied to one product or one toolchain.
-
-The point of project-level conventions is to keep the local layer explicit.
+Explain how a project may define local handoff conventions on top of AletheIA without replacing the framework's model-agnostic meaning.
 
 ---
 
@@ -37,148 +11,46 @@ The point of project-level conventions is to keep the local layer explicit.
 A project may customize:
 
 - vocabulary
-- local ownership rules
-- storage location
-- naming patterns
-- validation expectations
-- handoff cadence
-- multi-boundary chain rules
+- storage locations
+- ownership boundaries
+- validation defaults
+- response-format preferences
+- coordination-system mappings
 
 A project should not silently replace:
 
-- the restart-package concept
-- the distinction between narrative and operational handoffs
-- the need for explicit execution boundaries
-- the model-agnostic meaning of the artifact
+- handoff as restart package
+- work slice as the operational unit
+- work item as the external coordination abstraction
+- execution surface as a runtime detail
 
 ---
 
-## What a project may define locally
+## What may stay project-local
 
-### 1. Frontier taxonomy
+A project may define:
 
-A project may define its own dominant frontier labels.
+- dominant frontier labels
+- ownership maps
+- local storage conventions
+- naming conventions
+- default proof expectations
+- how a GitHub/Jira/Trello item is mapped locally
 
-Examples:
-
-- integration
-- UX writing
-- visual polish
-- security
-- observability
-- internal platform
-
-The exact labels may vary by project.
-
-### 2. Ownership map
-
-A project may define which agent or team usually owns which layer.
-
-Examples:
-
-- backend owned by one agent
-- visual refinement owned by another
-- copy allowed to cross the visual surface under specific rules
-
-### 3. Handoff storage convention
-
-A project may define where handoffs live.
-
-Examples:
-
-- `docs/handoffs/`
-- `ops/handoffs/`
-- issue-linked artifacts
-- task-linked artifacts in a work log
-
-### 4. Naming convention
-
-A project may define how handoff artifacts are named.
-
-Examples:
-
-- date + target + scope
-- task id + target agent + frontier
-- feature slice + handoff type
-
-### 5. Validation expectation defaults
-
-A project may define recurring proof expectations.
-
-Examples:
-
-- lint for UI changes
-- smoke for route behavior
-- domain-specific audit checks
-- human review for sensitive flows
-
-### 6. Response format preference
-
-A project may define the preferred return format from the receiving agent.
-
-Examples:
-
-- changed files + validation + next step
-- execution summary + blockers + suggested follow-up
-- implementation status + out-of-scope notes
-
-### 7. Multi-boundary chain convention
-
-A project may define when one task should generate:
-
-- one operational handoff
-- or a sequence of smaller handoffs
-
-Examples:
-
-- implementation -> observability -> review
-- backend boundary -> UX writing boundary -> visual polish boundary
-- feature hardening -> security review -> release check
-
-The project may define naming or storage patterns for these chains, but the framework meaning should remain the same: each step is still a restart package with explicit scope and validation continuity.
+These rules are healthy when they reduce ambiguity without turning local habits into framework truth.
 
 ---
 
-## What should remain framework-stable
+## Stable framework meaning
 
-The following should remain stable even when the project layer changes:
+The following should remain stable even when the local layer changes:
 
 - handoff as restart package
-- allowed files vs forbidden files distinction
-- semantic guardrails
-- acceptance criteria
-- validation expectation
 - explicit next action
+- validation expectation
+- semantic guardrails when needed
 - provider-agnostic meaning of the artifact
-
-These are part of the framework logic, not only local preference.
-
----
-
-## Recommended project convention checklist
-
-If a project wants handoffs to be consistent, it should make explicit:
-
-1. where handoffs are stored
-2. how they are named
-3. which frontier labels are valid locally
-4. which ownership boundaries matter most
-5. what proof is expected by default for each major frontier
-6. what response format the receiving agent should use
-7. when a handoff should be narrative vs operational
-8. when a multi-boundary chain is preferred over one larger artifact
-
----
-
-## Relationship to project extension pattern
-
-This document is a direct extension of:
-
-- `docs/project-extension-pattern.md`
-
-The project extension pattern explains the boundary between framework core and local project rules.
-
-This document applies that same discipline specifically to inter-agent handoffs.
+- separation between work slice, work item, and execution surface
 
 ---
 
@@ -186,30 +58,7 @@ This document applies that same discipline specifically to inter-agent handoffs.
 
 Project-level handoff conventions are healthy when:
 
-- local conventions reduce ambiguity without changing the framework meaning
-- handoffs are easier to generate and easier to review
-- multiple agents can work in the same project without relying on hidden memory
+- local conventions reduce ambiguity without changing framework meaning
+- multiple agents can continue work without hidden memory
 - the project can evolve local rules without forking the framework logic
-- multi-boundary chains remain smaller and more explicit than one oversized recap
-
----
-
-## What not to do
-
-Do not let project conventions turn into:
-
-- provider-specific framework rules
-- hidden assumptions not written anywhere
-- one team's habits masquerading as universal structure
-- prompts that only make sense in one agent shell
-- giant handoff bundles that hide the actual boundary transitions
-
----
-
-## Suggested next reading
-
-- `docs/agent-handoffs.md`
-- `starter-pack/guides/agent-handoff-generation.md`
-- `starter-pack/templates/agent-handoff-template.md`
-- `examples/handoffs/multi-boundary-continuity.md`
-- `docs/project-extension-pattern.md`
+- coordination-system choices remain clearly local

--- a/docs/slice-finalization-and-restart.md
+++ b/docs/slice-finalization-and-restart.md
@@ -166,18 +166,70 @@ For this version, the operator-facing artifact should include a copyable markdow
 ```md
 <!-- RESTART_PACKAGE_BEGIN -->
 ## Context for Clean Restart
+- **Project:** ...
+- **Official Work Item:** ...
 - **Slice ID:** ...
 - **Related Work Item:** ...
 - **Validation Status:** ...
 - **Mission Focus:** ...
 - **Resume Entrypoint:** ...
 - **Last Boundary Summary:** ...
+- **Do Not Reopen:** ...
+- **Next Official Step:** ...
+- **Open New Execution Surface:** `yes | no`
+- **Why:** ...
 - **Next Immediate Action:** ...
 - **Known Constraints:** ...
 - **Governing Context Refs:** ...
 - **Governing Context Delta:** ...
 <!-- RESTART_PACKAGE_END -->
 ```
+
+### Required continuity rule
+
+Every finalization-ready slice should leave a **Finalization Context Prompt** that is:
+
+- short
+- copyable
+- project-identified
+- explicit about whether the next action should open a new execution surface
+
+This exists to reduce:
+
+- token waste
+- memory dependence
+- transcript replay
+- accidental reopening of the closed slice
+
+The package must therefore answer:
+
+1. what project or system this belongs to
+2. what official work item anchors the slice when an adapter exists
+3. what was proved enough to close the slice
+4. what must not be reopened
+5. what the next official step is
+6. whether the next action should open a new clean execution surface, and why
+
+### New execution-surface rule
+
+The restart package must explicitly say:
+
+- `Open New Execution Surface: yes`
+- or `Open New Execution Surface: no`
+
+and give a one-line reason.
+
+Use `yes` when:
+
+- the next step belongs to a new slice
+- the next step crosses a new executor, tool, contract, risk, or ownership boundary
+- carrying the current transcript would cost more than it helps
+
+Use `no` when:
+
+- the next step is still inside the same bounded slice
+- no meaningful boundary changed
+- continuing locally is cheaper and clearer than restarting
 
 ---
 

--- a/docs/slice-finalization-and-restart.md
+++ b/docs/slice-finalization-and-restart.md
@@ -2,9 +2,9 @@
 
 ## Goal
 
-Define a manual-first way to close a work slice cleanly, preserve continuity through a compact restart package, and recommend a clean new session only when transcript replay is no longer needed.
+Define a manual-first way to close a work slice cleanly, preserve continuity through a compact restart package, and recommend a **clean execution surface** only when transcript replay is no longer needed.
 
-This is not a "clear chat" feature.
+This is not a thread-control feature.
 It is a slice-finalization capability.
 
 In canonical AletheIA vocabulary:
@@ -18,50 +18,41 @@ For canonical terminology, see:
 
 ---
 
-## Why this exists
+## Core rule
 
-Long AI-assisted threads tend to accumulate stale context.
-That creates two related forms of avoidable fatigue.
+AletheIA should optimize for:
 
-### 1. Human fatigue
-
-Examples:
-
-- heavy recap before the next step begins
-- repeated questions about decisions that were already settled
-- ambiguous reopen state after the useful part of the slice is already done
-
-### 2. Operational fatigue
-
-Examples:
-
-- context inflation from legacy material
-- retries that keep happening inside a slice that should already have closed
-- drift caused by continuing in the same session after the real boundary was already crossed
-
-AletheIA already has the right principle:
-
-**restart package, not transcript**
-
-This guide turns that principle into an explicit closure practice.
+- `restart package, not transcript`
+- `work slice, not conversation history`
+- `execution surface as runtime detail, not framework truth`
 
 ---
 
-## Relationship to existing AletheIA surfaces
+## Why this exists
 
-This guide reuses existing surfaces.
-It does **not** replace them.
+Long AI-assisted execution surfaces accumulate stale context.
+That creates avoidable fatigue for both humans and agents.
 
-It builds on:
+Examples:
 
+- recap drag before the next bounded step begins
+- repeated questions about already-settled decisions
+- drift caused by staying on the same stale surface after the real slice boundary was crossed
+
+---
+
+## Relationship to other AletheIA surfaces
+
+This guide builds on:
+
+- `docs/canonical-definitions.md`
 - `docs/agent-handoffs.md`
 - `docs/work-slice-pattern.md`
-- `docs/slice-telemetry-model.md`
-- `docs/progressive-policy-signals.md`
 - `docs/readiness-gates-spec.md`
+- `docs/slice-telemetry-model.md`
 
-Use the existing handoff record as the structured continuity artifact.
-Use this guide as the operational review layer for deciding whether the slice is ready for healthy restart.
+Use the existing handoff surfaces as the structured continuity artifact.
+Use this guide as the operational review layer for deciding whether the slice is healthy to continue on the current execution surface or should resume on a clean one.
 
 ---
 
@@ -70,21 +61,19 @@ Use this guide as the operational review layer for deciding whether the slice is
 A healthy slice finalization should follow this order:
 
 1. validation check
-2. handoff / restart check
+2. continuity check
 3. AI fatigue read
 4. finalization outcome
 5. optional clean-restart recommendation
 
 The goal is not to restart by habit.
-The goal is to restart when continuing in the same session would now carry more drag than value.
+The goal is to restart when continuing on the same execution surface now carries more drag than value.
 
 A Restart Package is justified when continuity can no longer remain implicit, not merely because the work touched more than one concern.
 
 ---
 
 ## Minimum finalization questions
-
-Before a slice closes, ask:
 
 ### 1. Was the slice validated?
 
@@ -97,14 +86,14 @@ The slice needs review first.
 
 ### 3. Is a structured continuity artifact available?
 
-A compact handoff or restart package should exist whenever the next boundary matters.
+A compact restart package should exist whenever the next boundary matters.
 
 ### 4. Does the next step still belong to the same slice?
 
-If yes, continuing in the same session may still be healthier.
+If yes, continuing on the current execution surface may still be healthier.
 If not, a bounded restart may be healthier.
 
-### 5. Would the next session still depend on replaying transcript history?
+### 5. Would the next execution surface still depend on transcript replay?
 
 If yes, the slice has not closed cleanly enough.
 
@@ -120,20 +109,18 @@ A finalization review should explicitly read these fields:
 - `handoff_size_class`: `compact | inflated | heavy`
 - `redundant_question_risk`: `low | medium | high`
 - `governing_context_changed`: `yes | no`
-- `governing_context_ref`: list of refs
+- `governing_context_refs`: list of refs
 - `governing_context_summary`: short summary when changed
 
 ### Hard rule
 
 If `transcript_replay_needed = yes`, the slice is **not** ready for healthy clean restart.
 
-That means the next boundary would still depend on hidden history instead of compact durable context.
-
 ---
 
 ## Finalization outcomes
 
-### `continue-in-session`
+### `continue-on-current-surface`
 
 Use when:
 
@@ -158,7 +145,7 @@ Use when:
 - the next action is ambiguous
 - regression or fork is still open
 - the handoff is inflated
-- restarting now would carry confusion into the next session
+- restarting now would carry confusion into the next boundary
 
 ### `not-ready`
 
@@ -174,56 +161,39 @@ Use when:
 
 Do not treat the restart package as only a loose summary inside the handoff.
 
-For this v1, the operator-facing artifact should include a **copyable markdown block**:
+For this version, the operator-facing artifact should include a copyable markdown block:
 
 ```md
 <!-- RESTART_PACKAGE_BEGIN -->
 ## Context for Clean Restart
 - **Slice ID:** ...
+- **Related Work Item:** ...
 - **Validation Status:** ...
 - **Mission Focus:** ...
-- **Active Spec / Entrypoint:** ...
-- **Last Handoff Summary:** ...
+- **Resume Entrypoint:** ...
+- **Last Boundary Summary:** ...
 - **Next Immediate Action:** ...
 - **Known Constraints:** ...
-- **Governing Context Version:** ...
+- **Governing Context Refs:** ...
 - **Governing Context Delta:** ...
 <!-- RESTART_PACKAGE_END -->
 ```
 
-This block is meant to let the operator begin a new session with minimal noise.
-
 ---
 
-## Project-local governing context
+## Compatibility note
 
-Projects may define their own governing-context sources.
+Older materials may still say things like:
 
-Examples might include:
+- fresh thread
+- clean session
+- clear the chat
 
-- active feature or plan docs
-- project decision logs
-- project state summaries
-- local changelog entries
+Those phrases should now be read as runtime-local examples of the same core meaning:
 
-This remains project-local.
-AletheIA should require the **meaning** of governing-context continuity, not one universal project file.
+**resume on a clean execution surface from the restart package only**
 
----
-
-## Start-next-issue clean-thread signal
-
-When the finalization outcome is `recommend-clean-restart` and the next step is a **new issue** or new bounded slice, the framework should make one extra thing explicit:
-
-- the operator should signal that the next issue must start in a **fresh thread / clean session**
-- if the runtime offers a local clear-thread action, it should be used before the next issue begins
-- if the runtime offers no such action, the operator should still abandon the current thread and start a new one manually
-
-This signal matters because a team may agree that restart is healthier and still begin the next issue inside the same stale thread by habit.
-
-A simple operator note is enough:
-
-> Before starting the next issue, clear the current thread or open a fresh one. Resume only from the restart package.
+See `docs/deprecated-thread-centric-language.md`.
 
 ---
 
@@ -231,18 +201,13 @@ A simple operator note is enough:
 
 AletheIA does **not** depend on a runtime command such as `/clear` or `/new`.
 
-In this version:
-
-- runtime actions remain illustrative only
-- restart is still a local operator action
-- no runtime hooks or auto-reset behavior are part of the core
-
-The core capability is:
+Runtime-local actions remain examples only.
+The core capability is still:
 
 - finish the slice
 - preserve continuity
 - detect fatigue risk
-- recommend restart when healthy
+- recommend clean restart when healthy
 
 ---
 
@@ -254,33 +219,6 @@ A healthy restart recommendation should usually imply:
 - `redundant_question_risk = low`
 - `restart_burden = low`
 
-A practical success proxy is:
+A practical success proxy remains:
 
 - **TRC (Time to Recover Context)** `< 2 interactions`
-
-If a restarted session needs more than two back-and-forth turns before it becomes productive, the restart package was not self-contained enough.
-
----
-
-## What this is not
-
-This guide is not:
-
-- a new canonical reset schema
-- a runtime-hook system
-- a benchmark layer
-- a learning-layer capability
-- a promise of zero cognitive effort
-
-It is a bounded operational practice for reducing avoidable AI fatigue.
-
----
-
-## Suggested next reading
-
-- `docs/agent-handoffs.md`
-- `docs/work-slice-pattern.md`
-- `docs/readiness-gates-spec.md`
-- `docs/slice-telemetry-model.md`
-- `starter-pack/templates/slice-finalization-review-template.md`
-- `examples/resource-aware-operations/slice-finalization-reference.md`

--- a/docs/work-item-pattern.md
+++ b/docs/work-item-pattern.md
@@ -1,0 +1,120 @@
+# Work Item Pattern
+
+## Goal
+
+Define how AletheIA treats an externally coordinated unit of work without making any single board or ticketing tool part of the core.
+
+---
+
+## What a Work Item is
+
+A **Work Item** is the canonical abstraction for a unit of externally coordinated work.
+
+It is how the framework refers to items such as:
+
+- GitHub Issues
+- Jira tickets
+- Trello cards
+- Linear issues
+- Notion tasks
+
+A work item is **not** the same thing as a work slice.
+
+- the **work item** tracks external coordination
+- the **work slice** tracks bounded operational execution
+
+---
+
+## Why this distinction matters
+
+Without a work-item abstraction, teams drift into tool-first thinking:
+
+- an issue starts to look like the only valid unit of work
+- a board column starts to look like framework truth
+- the runtime conversation starts to carry continuity that should live in artifacts
+
+AletheIA should prevent that drift.
+
+---
+
+## One Work Item, many slices
+
+A single work item may relate to:
+
+- one slice
+- multiple sequential slices
+- one initiative that still needs slicing before execution
+
+This is normal.
+The point is not to force one exact mapping.
+The point is to keep the operational unit and the coordination unit distinct.
+
+---
+
+## Minimum conceptual contract
+
+A minimal work item should make these things explicit:
+
+- `system` — external coordination system
+- `workspace_ref` — project, board, repo, or workspace reference
+- `item_id` — stable external identifier
+- `item_type` — issue, task, ticket, card, or equivalent
+- `title`
+- `status`
+- `priority`
+- `owner`
+- `acceptance_refs`
+- `source_of_truth_refs`
+
+This is enough to anchor a slice without claiming a final adapter schema.
+
+---
+
+## Relationship to execution surfaces
+
+Work items do not belong to one execution surface.
+
+A slice may move across:
+
+- one agent conversation
+- another agent conversation
+- human review
+- a fresh execution surface after restart
+
+The related work item may remain the same while the execution surface changes.
+That is exactly why the distinction matters.
+
+---
+
+## Examples
+
+### GitHub
+
+- Work item = issue
+- Coordination system = GitHub Issues / GitHub Project
+- Work slice = bounded implementation, review, or hardening step attached to that issue
+
+### Jira
+
+- Work item = ticket
+- Coordination system = Jira board / project
+- Work slice = bounded delivery or review step that may span more than one agent surface
+
+### Trello
+
+- Work item = card
+- Coordination system = Trello board
+- Work slice = bounded work package, even if Trello itself carries only lightweight metadata
+
+---
+
+## What this pattern is not
+
+A work item is not:
+
+- the new kernel contract
+- the same thing as a work slice
+- proof that GitHub-like semantics should become core truth
+- a demand for rich automation before the framework is usable
+
+It is a stable concept that allows adapters and manual operations to stay coherent later.

--- a/docs/work-slice-pattern.md
+++ b/docs/work-slice-pattern.md
@@ -2,60 +2,77 @@
 
 ## Goal
 
-This document explains how AletheIA can treat a bounded unit of work as a **work slice** without introducing a new core contract.
+Explain how AletheIA treats a **Work Slice** as its primary operational unit while still building on the existing core contracts.
 
 This document should be read as the operational pattern for `Work Slice`, not as the source of the term itself.
 
 For the canonical definition of `Work Slice` and its relationship to `Work Item`, `Restart Package`, and `Operational Boundary`, see:
 
-- `docs/canonical-vocabulary.md`
+- `docs/canonical-definitions.md`
 
-A work slice is an operational composition.
-It gathers the artifacts that make one unit of work more resumable, reviewable, and teachable.
+A work slice is the bounded operational composition that keeps one unit of work resumable, reviewable, and restartable across boundaries.
 
-It is not a new schema.
-It is not a new kernel capability.
-It is a low-regret pattern built on contracts that already exist.
+---
+
+## Core rule
+
+AletheIA should read work through this lens:
+
+- **Work Slice** = unit of operation
+- **Work Item** = unit of external coordination
+- **Execution Surface** = runtime detail
+
+A work slice may point to a work item, but it does not collapse into that work item.
 
 ---
 
 ## What a work slice is
 
-A work slice is the smallest useful package of work that should remain explicit across:
+A work slice is the smallest useful bounded package of work that should remain explicit across:
 
 - framing
 - decision
 - execution
 - validation
 - handoff when needed
+- restart when the boundary changes
 - learning when warranted
 
-In practice, a work slice usually composes these existing artifacts:
+In practice, a work slice usually composes these artifacts:
 
 1. **task brief**
 2. **decision record**
 3. **execution record**
-4. **handoff record** when work crosses an agent or review boundary
-5. **learning record** when the slice produces a reusable lesson
-
-Not every slice needs every artifact in the same depth.
-But the pattern becomes valuable as soon as the work should be resumed, reviewed, validated, or learned from.
+4. **handoff record** when work crosses a boundary
+5. **restart package** when a clean execution surface is healthier
+6. **learning record** when the slice produces reusable learning
 
 ---
 
-## Why this exists
+## Why this matters
 
-AletheIA already has strong individual contracts.
-What is often missing in real work is a visible unit that ties them together.
+Without a visible work-slice unit, teams drift toward the wrong anchors:
 
-Without that composition, teams can end up with:
+- the runtime conversation starts to feel like the source of truth
+- an issue or board card starts to feel like the operational unit
+- validation, restart, and learning lose their connection to one bounded step
 
-- a task brief that never becomes a clear execution unit
-- a decision that is not easy to reconnect to validation
-- a handoff that floats separately from the work it belongs to
-- a learning that loses its link to the slice that generated it
+The work-slice pattern keeps those layers distinct.
 
-The work-slice pattern makes that chain easier to read without inflating the framework core.
+---
+
+## Relationship to Work Items
+
+A slice may map to:
+
+- one work item
+- part of one work item
+- several slices inside one larger work item
+
+This is normal.
+The framework only needs the distinction to remain legible.
+
+See also: `docs/work-item-pattern.md`.
 
 A Work Slice may cross more than one theme or concern without requiring formal handoff.
 
@@ -68,159 +85,42 @@ Explicit coordination becomes necessary only when the slice crosses an Operation
 Use a work slice when at least one of these is true:
 
 - the work is no longer trivial or one-shot
-- the work should survive more than one turn or one session
+- the work should survive more than one turn or one execution surface
 - the work will cross an agent, review, or validation boundary
-- the work needs a clearer risk read before execution
-- the work may produce a reusable learning
-- the work is part of an iterative maintenance loop where one round should remain legible from the next
-
-You do **not** need a fully explicit work slice for every tiny action.
-
-If the task is extremely local, reversible, and obvious, a lighter flow may still be enough.
-
----
-
-## Relationship to existing AletheIA layers
-
-### Task framing
-
-The task brief gives the slice its initial boundary:
-
-- what problem exists
-- what the objective is
-- what is in and out of scope
-- what risk and validation posture are expected
-
-### Decision
-
-The decision record makes the slice reviewable before execution.
-It explains why the work may continue, be reviewed, be blocked, or be escalated.
-
-### Execution
-
-The execution record shows what actually happened, where it ran, and what proof exists.
-
-### Handoff
-
-The handoff record matters when the slice crosses an agent or review boundary.
-In that case, the work slice should preserve continuity through a restart package instead of relying on hidden thread memory.
-
-### Learning
-
-The learning record closes the slice when the work produced a reusable heuristic, guardrail, or test gap.
+- the work needs clearer risk and validation posture
+- the work may produce reusable learning
 
 ---
 
 ## Derived operational states
 
-AletheIA's core loop remains:
+A useful operational read may include:
 
-`intent -> context -> decision -> execution -> validation -> learning`
+- `framed`
+- `context-scoped`
+- `decision-recorded`
+- `execution-in-progress`
+- `validation-pending`
+- `review`
+- `validated`
+- `blocked`
+- `escalated`
+- `learning-stored`
 
-A work slice can make that loop more tangible through a **derived operational vocabulary**.
-These are not engine enums.
-They are a practical reading layer.
-
-| Derived state | Typical signal inside the slice |
-| --- | --- |
-| `framed` | a task brief exists with scope and success criteria |
-| `context-scoped` | the minimum relevant context has been selected and bounded |
-| `decision-recorded` | a decision record makes the next step explicit |
-| `execution-in-progress` | an execution record is planned or running |
-| `validation-pending` | execution advanced, but proof or review is still incomplete |
-| `review` | the slice now needs explicit inspection before it may close cleanly |
-| `validated` | the required proof exists and closure is justified |
-| `blocked` | the slice cannot advance safely under current conditions |
-| `escalated` | the next step requires a higher-trust review or human gate |
-| `learning-stored` | a reusable learning record was captured from the slice |
-
-This vocabulary should stay optional and operational.
-It should not become a new mandatory core state machine at this stage.
-
-### Regression-sensitive progression
-
-In iterative maintenance work, a detected regression may change the slice progression rather than leaving the round on the same path.
-
-A healthy operational read might become:
-
-- `validation-pending -> review` when a previously stable behavior breaks
-- `review -> blocked` when the regression is real and unresolved
-- `blocked -> escalated` when the unresolved regression now requires a higher-trust review or wider validation boundary
-
-This does not create a new engine state machine.
-It makes a governance-relevant event easier to read inside the slice.
-
----
-
-## Recommended composition levels
-
-### 1. Lightweight slice
-
-Good for small, low-risk work.
-Usually includes:
-
-- task brief
-- decision record
-- execution record
-
-### 2. Reviewable slice
-
-Good for work that needs clearer proof or a second boundary.
-Usually includes:
-
-- task brief
-- decision record
-- execution record
-- handoff record or explicit validation step
-
-### 3. Learning-producing slice
-
-Good for work that revealed a pattern worth reusing.
-Usually includes:
-
-- task brief
-- decision record
-- execution record
-- optional handoff record
-- learning record
-
----
-
-## What this pattern is not
-
-A work slice is **not**:
-
-- a replacement for the existing JSON contracts
-- a new universal schema
-- a new Alpha
-- a claim that every task needs the same ceremony
-- a hidden attempt to add a runtime orchestrator through documentation
-
-It is deliberately smaller than that.
+This remains a reading layer, not a mandatory engine state machine.
 
 ---
 
 ## Suggested file shape
 
-One healthy way to make a work slice concrete is to keep its related artifacts together, for example:
+One healthy way to keep a slice legible is to group together:
 
 - `task-brief.json`
 - `decision-record.json`
 - `execution-record.json`
 - `handoff-record.json` when needed
+- `restart-package.md` when the next boundary will resume on a clean surface
 - `learning-record.json` when generated
 - `README.md` to explain the slice in plain language
 
-This is a convenience pattern, not a required filesystem contract.
-
----
-
-## Suggested next reading
-
-- `starter-pack/templates/work-slice-template.md`
-- `starter-pack/guides/risk-to-gate-mapping.md`
-- `docs/agent-handoffs.md`
-- `examples/work-slices/standard-slice/README.md`
-- `examples/handoffs/compact-reviewable-handoff.md`
-- `examples/handoffs/high-stakes-handoff.md`
-- `examples/iterative-maintenance/three-round-loop/README.md`
+This is still a convenience pattern, not a required filesystem contract.

--- a/examples/resource-aware-operations/slice-finalization-reference.md
+++ b/examples/resource-aware-operations/slice-finalization-reference.md
@@ -8,6 +8,8 @@ The next step is a separate reviewable task rather than a continuation of the sa
 
 ## Finalization read
 
+- Project: `Crisis Monitor`
+- Official Work Item: `GitHub Issue #123 — PR/Comms phase 2 — operational production validation`
 - Slice ID: `example-slice-finalization-001`
 - Validation status: `validated`
 - Handoff ref: `handoff-record.json`
@@ -36,16 +38,25 @@ The next step is a separate reviewable task rather than a continuation of the sa
 
 <!-- RESTART_PACKAGE_BEGIN -->
 ## Context for Clean Restart
+- **Project:** `Crisis Monitor`
+- **Official Work Item:** `GitHub Issue #123 — PR/Comms phase 2 — operational production validation`
 - **Slice ID:** `example-slice-finalization-001`
+- **Related Work Item:** `GitHub Issue #123`
 - **Validation Status:** `validated`
 - **Mission Focus:** Close the current slice and begin the review-only continuation with minimal inherited context.
-- **Active Spec / Entrypoint:** `docs/feature-review-notes.md`
-- **Last Handoff Summary:**
+- **Resume Entrypoint:** `docs/feature-review-notes.md`
+- **Last Boundary Summary:**
   - implementation work was completed
   - declared validation passed
   - the next boundary is a review slice, not more execution in the same thread
+- **Do Not Reopen:** the validated implementation slice, the already-closed backend scope, or transcript replay as the default continuity method
+- **Next Official Step:** `GitHub Issue #125 — WhatsApp Meta Graph production validation`
+- **Open New Execution Surface:** `yes`
+- **Why:** the next step crosses into a new slice with a different integration and risk profile, so stale execution history would add drag without improving clarity
 - **Next Immediate Action:** Open the review notes and continue from the explicit next action instead of replaying transcript history.
 - **Known Constraints:** Do not resume by scanning old transcript unless the restart package proves insufficient.
-- **Governing Context Version:** `review-direction-1`
+- **Governing Context Refs:**
+  - `docs/feature-review-notes.md`
+  - `docs/DECISIONS.md`
 - **Governing Context Delta:** Shift from implementation mode to review-only closure after validation passed.
 <!-- RESTART_PACKAGE_END -->

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -43,7 +43,7 @@ The current practical Alpha 4 handoff baseline now includes:
 - `docs/project-handoff-conventions.md`
 - `docs/handoff-capture-pattern.md`
 
-Use this set when you need model-agnostic continuity between agents without relying on hidden thread memory.
+Use this set when you need model-agnostic continuity between agents without relying on hidden runtime memory.
 
 
 ## Alpha 5 baseline
@@ -72,6 +72,9 @@ AletheIA may suggest a fit, but the user may still choose a different model.
 
 If you want to make bounded work more tangible without changing the core contracts, read:
 
+- `docs/canonical-definitions.md`
+- `docs/work-item-pattern.md`
+- `starter-pack/templates/work-item-template.md`
 - `docs/work-slice-pattern.md`
 - `starter-pack/templates/work-slice-template.md`
 - `starter-pack/guides/risk-to-gate-mapping.md`
@@ -154,6 +157,7 @@ Read:
 - `starter-pack/templates/slice-finalization-review-template.md`
 - `examples/resource-aware-operations/slice-finalization-reference.md`
 - `starter-pack/guides/clean-restart-command-adapters.md`
+- `docs/github-project-operations.md`
 - `starter-pack/templates/restart-bootstrap-prompt-template.md`
 - `examples/resource-aware-operations/clean-restart-command-adapter-example.md`
 - `docs/project-local-constitution-context.md`

--- a/starter-pack/guides/clean-restart-command-adapters.md
+++ b/starter-pack/guides/clean-restart-command-adapters.md
@@ -3,36 +3,25 @@
 This guide adds a small operator-facing command vocabulary on top of the existing slice-finalization flow.
 
 It does **not** change the core framework contract.
-It only shows how a team may expose clean-restart behavior through lightweight slash-command style adapters.
+It only shows how a team may expose clean-restart behavior through lightweight, runtime-local adapters.
 
 Use this guide together with:
 
 - `docs/slice-finalization-and-restart.md`
+- `docs/deprecated-thread-centric-language.md`
 - `starter-pack/templates/slice-finalization-review-template.md`
 - `starter-pack/templates/restart-bootstrap-prompt-template.md`
 
 ---
 
-## Why this exists
+## Core rule
 
-Many teams want a short operator command for:
+The adapter may name local runtime actions however it wants.
+The core meaning must stay:
 
-- closing a slice
-- deciding whether to restart cleanly
-- resuming from a compact restart package
-
-That is useful, but AletheIA should stay smaller than a CLI or runtime platform.
-
-So this guide defines a **logical command vocabulary**:
-
-- `/finalize-slice`
-- `/clean-restart`
-- `/resume-from-package`
-
-These commands are **adapter vocabulary only**.
-
-- if a runtime supports slash commands, an adapter may expose them that way
-- if it does not, the operator can run the same flow as a checklist with no semantic loss
+- finalize a work slice
+- decide whether a clean execution surface is healthier
+- resume from the restart package only
 
 ---
 
@@ -49,46 +38,17 @@ Purpose:
 
 Required result:
 
-- one of:
-  - `continue-in-session`
-  - `recommend-clean-restart`
-  - `review-required`
-  - `not-ready`
-
-Minimum operator inputs:
-
-- slice id
-- validation status
-- next action
-- resume entrypoint
-- AI Fatigue read
+- `continue-on-current-surface`
+- `recommend-clean-restart`
+- `review-required`
+- `not-ready`
 
 ### `/clean-restart`
 
 Purpose:
 
-- start a fresh session only after the slice is already closed cleanly
-- explicitly signal that the **next issue must not start in the current stale thread**
-
-Allowed only when:
-
-- finalization outcome is `recommend-clean-restart`
-
-Meaning:
-
-- the operator should begin a fresh session using:
-  - the restart package
-  - the resume entrypoint
-  - the minimal governing-context refs
-- if the next task is a new issue, the operator should treat thread clearing / fresh-session start as a **precondition** before claiming that next issue inside the runtime
-
-This command must **never** imply that AletheIA controls:
-
-- chat cache internals
-- runtime memory internals
-- hidden session state
-
-It only signals that a clean restart is now the healthier operating choice.
+- start a clean execution surface only after the slice is already closed cleanly
+- make it explicit that the next work item or slice should not begin on the stale runtime surface
 
 ### `/resume-from-package`
 
@@ -96,59 +56,29 @@ Purpose:
 
 - resume work from the restart package only
 
-Meaning:
-
-- bootstrap the next slice from:
-  - the restart package
-  - the restart bootstrap prompt
-  - the explicit governing refs when present
-
-Default rule:
-
-- do **not** replay transcript history unless the restart package proves insufficient
-
 ---
 
 ## Runtime mappings
 
-These are illustrative mappings, not core framework requirements.
+These are illustrative mappings, not core requirements.
 
-### Codex-style clean start
+### Codex-style mapping
 
-Possible mapping:
+An adapter may say things like:
 
-- `/finalize-slice` -> fill `starter-pack/templates/slice-finalization-review-template.md`
-- `/clean-restart` -> operator opens a fresh session or uses the runtime's clean-start action if available
-- `/resume-from-package` -> operator pastes the restart package and a bootstrap prompt based on `starter-pack/templates/restart-bootstrap-prompt-template.md`
+- open a new thread
+- use `/clear`
 
-Notes:
+That is acceptable only when the adapter also makes explicit that these are **runtime-local phrases** for the core action: **resume on a clean execution surface**.
 
-- a Codex adapter may mention actions like “open a new thread” or `/clear`
-- the adapter must still describe these as **runtime-local**, not as AletheIA truth
+### Claude Code-style mapping
 
-### Claude Code-style clean start
-
-Possible mapping:
-
-- `/finalize-slice` -> fill the finalization review artifact in repo-native form
-- `/clean-restart` -> operator starts a fresh session or uses the runtime's preferred clean-start action
-- `/resume-from-package` -> operator starts the next session from the restart package and explicit entrypoint
-
-Notes:
-
-- a Claude Code adapter may describe a fresh chat/session boundary
-- the adapter must not depend on runtime hooks or automation to preserve the meaning of the command
+An adapter may describe a fresh chat or session boundary.
+Again, the core meaning must remain the same.
 
 ### No slash-command support
 
-If the runtime has no slash-command surface, use the same sequence as an operator checklist:
-
-1. finalize the slice with the review template
-2. inspect the outcome
-3. if the outcome is `recommend-clean-restart`, start a fresh session manually
-4. resume from the restart package and bootstrap prompt only
-
-This fallback is equivalent in meaning to the slash-command variant.
+If the runtime has no slash-command surface, use the same flow as an operator checklist with no semantic loss.
 
 ---
 
@@ -156,15 +86,9 @@ This fallback is equivalent in meaning to the slash-command variant.
 
 1. `/finalize-slice`
 2. inspect the outcome
-3. if `recommend-clean-restart`, run `/clean-restart`
-4. **before starting a new issue, clear the current thread or open a fresh one**
-5. begin the next slice with `/resume-from-package`
-
-If the outcome is:
-
-- `continue-in-session` -> stay in the current session
-- `review-required` -> resolve ambiguity before restart
-- `not-ready` -> finish validation or closure first
+3. if `recommend-clean-restart`, start a clean execution surface
+4. before starting the next work item or slice, confirm the stale surface has been abandoned
+5. resume from the restart package and bootstrap prompt only
 
 ---
 
@@ -177,5 +101,3 @@ This guide does not:
 - define auto-reset behavior
 - guarantee native slash-command support
 - redefine slice finalization as a tooling problem
-
-It only provides a stable vocabulary for local delivery adapters.

--- a/starter-pack/templates/restart-bootstrap-prompt-template.md
+++ b/starter-pack/templates/restart-bootstrap-prompt-template.md
@@ -18,22 +18,40 @@ It should **not** rely on transcript replay by default.
 ## Template
 
 ```text
-Continue the work from a clean execution surface.
+Continue the work using only the minimum finalization context below.
 
 Read only:
-- the restart package below
+- the finalization context package below
 - the resume entrypoint
 - the governing-context refs listed in the package, if present
 
 Do not replay old transcript history unless the restart package proves insufficient.
 
+Project:
+{{project_ref}}
+
+Official work item:
+{{official_work_item_ref}}
+
 Objective:
 {{next_action}}
+
+Open a new execution surface:
+{{new_execution_surface}}
+
+Why:
+{{new_execution_surface_reason}}
 
 Resume entrypoint:
 {{resume_entrypoint}}
 
-Restart package:
+Do not reopen:
+{{do_not_reopen}}
+
+Next official step:
+{{next_official_step}}
+
+Finalization context package:
 {{restart_package_block}}
 ```
 
@@ -42,5 +60,6 @@ Restart package:
 ## Notes
 
 - if the restart package is not self-contained enough, fix the package rather than normalizing transcript replay
+- if `Open a new execution surface = no`, keep working only if the next action still belongs to the same bounded slice
 - if the package references governing-context docs, load only the minimum needed refs
 - if the previous slice ended with `review-required` or `not-ready`, do not use this template yet

--- a/starter-pack/templates/restart-bootstrap-prompt-template.md
+++ b/starter-pack/templates/restart-bootstrap-prompt-template.md
@@ -2,7 +2,7 @@
 
 Use this template after a slice closes with `recommend-clean-restart`.
 
-Use only after the previous thread has already been abandoned for the new issue or slice.
+Use it only after the previous execution surface has already been abandoned for the next slice or work item.
 
 The prompt should rely on:
 
@@ -18,7 +18,7 @@ It should **not** rely on transcript replay by default.
 ## Template
 
 ```text
-Continue the project from a clean session.
+Continue the work from a clean execution surface.
 
 Read only:
 - the restart package below

--- a/starter-pack/templates/slice-finalization-review-template.md
+++ b/starter-pack/templates/slice-finalization-review-template.md
@@ -2,6 +2,8 @@
 
 ## Slice
 
+- Project:
+- Official work item:
 - Slice ID:
 - Related Work Item:
 - Validation status:
@@ -33,6 +35,11 @@
 - Runtime-local clean-start action available: `yes | no`
 - What was delivered:
 - Evidence:
+- What was effectively proved:
+- Do not reopen:
+- Next official step:
+- Open new execution surface: `yes | no`
+- Why:
 - Known constraints:
 - Why the next step should stay on the current surface or restart cleanly:
 
@@ -40,12 +47,18 @@
 
 <!-- RESTART_PACKAGE_BEGIN -->
 ## Context for Clean Restart
+- **Project:**
+- **Official Work Item:**
 - **Slice ID:**
 - **Related Work Item:**
 - **Validation Status:**
 - **Mission Focus:**
 - **Resume Entrypoint:**
 - **Last Boundary Summary:**
+- **Do Not Reopen:**
+- **Next Official Step:**
+- **Open New Execution Surface:** `yes | no`
+- **Why:**
 - **Next Immediate Action:**
 - **Known Constraints:**
 - **Governing Context Refs:**

--- a/starter-pack/templates/slice-finalization-review-template.md
+++ b/starter-pack/templates/slice-finalization-review-template.md
@@ -3,6 +3,7 @@
 ## Slice
 
 - Slice ID:
+- Related Work Item:
 - Validation status:
 - Handoff ref: (`not_needed` if not applicable)
 - Next action:
@@ -10,10 +11,10 @@
 
 ## Finalization outcome
 
-- Finalization outcome: `continue-in-session | recommend-clean-restart | review-required | not-ready`
+- Finalization outcome: `continue-on-current-surface | recommend-clean-restart | review-required | not-ready`
 - Reason:
-- Clean-thread signal before next issue: `not_needed | recommended | required`
-- Operator note if clean thread is required:
+- Clean execution-surface signal before next boundary: `not_needed | recommended | required`
+- Operator note if a clean execution surface is required:
 
 ## AI Fatigue Read
 
@@ -28,24 +29,25 @@
 
 ## Validation and continuity notes
 
-- Next issue / next bounded slice starts in fresh thread: `yes | no`
-- Local clear-thread action available: `yes | no`
+- Next bounded slice starts on a clean execution surface: `yes | no`
+- Runtime-local clean-start action available: `yes | no`
 - What was delivered:
 - Evidence:
 - Known constraints:
-- Why the next step is still in-session or should restart cleanly:
+- Why the next step should stay on the current surface or restart cleanly:
 
 ## Restart Package
 
 <!-- RESTART_PACKAGE_BEGIN -->
 ## Context for Clean Restart
 - **Slice ID:**
+- **Related Work Item:**
 - **Validation Status:**
 - **Mission Focus:**
-- **Active Spec / Entrypoint:**
-- **Last Handoff Summary:**
+- **Resume Entrypoint:**
+- **Last Boundary Summary:**
 - **Next Immediate Action:**
 - **Known Constraints:**
-- **Governing Context Version:**
+- **Governing Context Refs:**
 - **Governing Context Delta:**
 <!-- RESTART_PACKAGE_END -->

--- a/starter-pack/templates/work-item-template.md
+++ b/starter-pack/templates/work-item-template.md
@@ -1,0 +1,51 @@
+# Work Item Ready-for-Agent Template
+
+Use this template when an externally coordinated task should be made explicit enough for one or more AletheIA work slices.
+
+A work item is an external coordination anchor.
+It is **not** the same thing as the work slice that will execute inside it.
+
+---
+
+## Work item identity
+
+- Coordination system:
+- Workspace / board / repo ref:
+- Work item ID:
+- Work item type:
+- Title:
+- Status:
+- Priority:
+- Owner:
+
+---
+
+## Execution intent
+
+### Summary
+
+### Acceptance refs
+
+### Source-of-truth refs
+
+### Dependencies / blockers
+
+---
+
+## Slice readiness
+
+### Why this work item is ready for an agent
+
+### Likely first slice goal
+
+### Out of scope for the first slice
+
+### Expected validation for the first slice
+
+### Governing-context refs for the first slice
+
+---
+
+## Notes
+
+Use this template to make an externally coordinated item agent-readable without pretending that the board item itself is the full operational artifact.

--- a/starter-pack/templates/work-slice-template.md
+++ b/starter-pack/templates/work-slice-template.md
@@ -1,30 +1,27 @@
 # Work Slice Template
 
-Use this template when a bounded unit of work should be made easier to frame, resume, validate, or learn from.
+Use this template when a bounded unit of work should be easier to frame, resume, validate, hand off, or restart cleanly.
 
 This template does **not** replace the existing AletheIA contracts.
-It is a composition layer that points to them.
+It is the coordination layer for one explicit slice.
 
 ---
 
 ## Slice identity
 
-### Slice ID
-
-### Slice title
-
-### Current derived state
-
-Examples:
-- framed
-- context-scoped
-- decision-recorded
-- execution-in-progress
-- validation-pending
-- validated
-- blocked
-- escalated
-- learning-stored
+- Slice ID:
+- Slice title:
+- Related Work Item ref: (`not_needed` if no external coordination anchor exists)
+- Current derived state:
+  - framed
+  - context-scoped
+  - decision-recorded
+  - execution-in-progress
+  - validation-pending
+  - validated
+  - blocked
+  - escalated
+  - learning-stored
 
 ---
 
@@ -38,27 +35,15 @@ Examples:
 
 ---
 
-## Minimum context
+## Governing context
 
-### Relevant context
+### Governing context refs
 
-List only the context that should travel with this slice.
+List only the durable refs that should still govern the slice.
 
 ### Constraints
 
 ### Dependencies
-
----
-
-## Risk read
-
-### Task type / severity / risk
-
-### Why this risk posture applies
-
-### Human gate required?
-
-State `yes` or `no`, and explain briefly if useful.
 
 ---
 
@@ -80,15 +65,19 @@ State what must be true before the slice can be closed.
 
 ---
 
-## Handoff expectation
+## Boundary expectations
 
 ### Handoff needed?
 
 State `yes`, `no`, or `maybe later`.
 
+### Restart package expected?
+
+State `yes`, `no`, or `only if boundary changes`.
+
 ### Why
 
-If a handoff is expected, explain why the next boundary exists.
+Explain why the next boundary exists or why clean restart may be needed.
 
 ---
 
@@ -96,24 +85,16 @@ If a handoff is expected, explain why the next boundary exists.
 
 Fill these with file paths, IDs, or references.
 
-### Task brief
-
-### Decision record
-
-### Execution record
-
-### Handoff record
-
-Use only if a handoff exists.
-
-### Learning record
-
-Use only if the slice produced a reusable learning.
+- Task brief:
+- Decision record:
+- Execution record:
+- Handoff record:
+- Restart package:
+- Learning record:
 
 ---
 
 ## Notes
 
-Use this template to make one slice legible.
-Do not turn it into a second transcript.
 Keep the slice tight, bounded, and reviewable.
+Do not turn this artifact into a second transcript.


### PR DESCRIPTION
## Summary
- introduce canonical definitions for Work Slice, Work Item, Restart Package, Execution Surface, and External Coordination System
- strongly deprecate thread-centric core language and revise restart/handoff/work-slice docs to use execution-surface framing
- add repo-local GitHub Project operations guidance and a work-item ready-for-agent starter-pack template
- formalize a compact Finalization Context Prompt in the finalization/restart path
- extend templates and examples with project, official work item, do-not-reopen, next official step, and open-new-execution-surface fields
- record this rule as a durable decision in the framework docs

## Validation
- docs-only change for the new finalization-context layer
- no runtime tests run in this incremental update

## Notes
- this PR also creates the initial AletheIA GitHub Project backlog framing through issues #78-#83
- GitHub Project is documented as repository-local coordination, not framework core truth
- finalization/restart continuity is now explicitly optimized for lower token waste, lower memory dependence, and less transcript replay across projects

Closes #78
Closes #81
Closes #82
