### PR TITLE
docs: canonize Work Item, Work Slice, Execution Surface, and Operational Boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ AletheIA is:
 - built to be reusable across projects
 - designed for structured decision-making before execution
 
+AletheIA also keeps a stable canonical vocabulary across trackers, agent surfaces, handoff formats, and runtime-facing records.
+
+See:
+
+- `docs/canonical-vocabulary.md`
+
 ## What this is not
 
 AletheIA is not:
@@ -196,6 +202,7 @@ See also:
 If this is your first time here, start with:
 
 1. `docs/getting-started.md`
+1. `docs/canonical-vocabulary.md`
 1. `docs/00-overview.md`
 1. `docs/roadmap-alpha.md`
 1. `docs/release-1.0-readiness.md`

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -35,6 +35,24 @@ The public repository is organized around four blocks:
 
 ---
 
+## Canonical vocabulary
+
+AletheIA defines a stable public vocabulary for its core operational terms.
+
+That vocabulary exists so local trackers, agent surfaces, handoff artifacts, and runtime-facing records do not quietly redefine framework meaning.
+
+Use as the terminology anchor:
+
+- `docs/canonical-vocabulary.md`
+
+A Work Item is the official governed unit of work.
+
+A Work Slice is a bounded operational composition that helps make progress inside or around a Work Item.
+
+An Operational Boundary is the point where continuity can no longer remain implicit and explicit coordination becomes necessary.
+
+---
+
 ## Current phase
 
 AletheIA is now in its **1.0 baseline phase**.

--- a/docs/adapter-taxonomy.md
+++ b/docs/adapter-taxonomy.md
@@ -52,6 +52,15 @@ An adapter should answer questions such as:
 The adapter should change the delivery form.
 It should not change the framework truth.
 
+AletheIA distinguishes between an **Execution Surface** and an **Adapter**.
+
+- the execution surface is where the framework is delivered, read, or operated
+- the adapter is the environment-specific mapping that preserves framework meaning across that surface
+
+For canonical terminology, see:
+
+- `docs/canonical-vocabulary.md`
+
 ---
 
 ## Three adapter layers

--- a/docs/canonical-vocabulary.md
+++ b/docs/canonical-vocabulary.md
@@ -1,0 +1,362 @@
+# Canonical Vocabulary
+
+## Goal
+
+Define the stable public vocabulary of AletheIA so later documentation, adapters, examples, and local project extensions do not reintroduce tool-shaped ambiguity.
+
+This document exists to keep the framework readable across environments without letting local workflow conventions redefine framework truth.
+
+---
+
+## Why this document exists
+
+As AletheIA grows, the same ideas can appear through:
+
+- repo-native docs
+- agent instruction files
+- handoff artifacts
+- runtime-facing records
+- local project protocols
+
+Without a canonical vocabulary, those surfaces can drift and quietly change meaning.
+
+This document defines the stable terms that should remain recognizable across all of them.
+
+---
+
+## 1. Work Item
+
+### Definition
+
+A **Work Item** is the official governed unit of work in AletheIA.
+
+### What it is
+
+A Work Item is the unit used to answer questions such as:
+
+- what is the work?
+- what outcome is expected?
+- what governs this work?
+- what local system currently tracks its state?
+
+A Work Item is intentionally tracker-agnostic.
+
+It may be represented locally as:
+
+- a GitHub issue
+- a Jira ticket
+- a Notion task
+- an internal request
+- a manual review artifact
+
+Those are local implementations of the same concept.
+
+### What it is not
+
+A Work Item is not:
+
+- a specific tracker object by definition
+- a transcript
+- a single prompt
+- a single execution attempt
+- a mandatory schema tied to one tool
+
+### Minimum conceptual interface
+
+A Work Item should make these elements explicit:
+
+- identity
+- objective
+- expected outcome
+- governing context or source-of-truth reference
+- local status in the host system
+
+---
+
+## 2. Work Slice
+
+### Definition
+
+A **Work Slice** is a bounded operational composition that makes one portion of a Work Item explicit enough to frame, execute, validate, hand off, or learn from.
+
+### Relationship to Work Item
+
+A Work Item is the official governed unit.
+
+A Work Slice is the bounded operational unit used to make progress inside or around that Work Item.
+
+In practice:
+
+- one Work Item may contain one slice
+- one Work Item may evolve through multiple slices
+- one slice should remain bounded enough to review, resume, or validate without replaying the whole history
+
+### Relationship to existing contracts
+
+A Work Slice does not replace AletheIA's existing contracts.
+
+It is built from them.
+
+A slice may compose:
+
+- task brief
+- decision record
+- execution record
+- handoff record when needed
+- learning record when warranted
+
+### What it is not
+
+A Work Slice is not:
+
+- a new core schema by default
+- a replacement for the Work Item
+- a universal state machine
+- a claim that every task needs the same amount of ceremony
+
+### Minimum conceptual interface
+
+A Work Slice should make these elements explicit:
+
+- slice identity
+- bounded goal and scope
+- current operational state
+- validation expectation
+- handoff expectation
+- artifact map when applicable
+
+---
+
+## 3. Restart Package
+
+### Definition
+
+A **Restart Package** is the continuity artifact that allows work to resume across a real boundary without relying on hidden thread memory or transcript replay.
+
+### Why it exists
+
+AletheIA should not depend on long conversational history to preserve continuity.
+
+When work crosses a real operational boundary, the receiving side should be able to restart from a compact, explicit package.
+
+### What it should preserve
+
+A Restart Package should preserve:
+
+- slice or work reference
+- current status
+- active entrypoint
+- last validated state
+- next immediate action
+- relevant constraints
+- governing context references
+
+### What it is not
+
+A Restart Package is not:
+
+- a full transcript export
+- a mandatory runtime feature
+- a replacement for source-of-truth documents
+
+It is a continuity bridge.
+
+### Relationship to handoff
+
+A handoff may include a Restart Package.
+
+A Restart Package becomes especially important when the next step cannot safely depend on implied context.
+
+---
+
+## 4. Execution Surface
+
+### Definition
+
+An **Execution Surface** is the surface where AletheIA is delivered, read, or operated without changing its meaning.
+
+### Examples
+
+Execution surfaces may include:
+
+- repo-native documentation
+- an agent instruction surface
+- a handoff artifact
+- a review surface
+- a runtime-facing record
+- a restart-oriented operational surface
+
+### Why this matters
+
+AletheIA may appear differently across environments.
+
+The surface may change.
+
+The meaning should not.
+
+### What it is not
+
+An Execution Surface is not the same as an adapter.
+
+The surface is where the framework appears or is used.
+
+The adapter is the mapping that preserves AletheIA meaning across surfaces.
+
+### Minimum conceptual interface
+
+An Execution Surface should make these dimensions legible:
+
+- surface type
+- intended audience
+- compression level
+- preserved meaning
+
+---
+
+## 5. Operational Boundary
+
+### Definition
+
+An **Operational Boundary** is the point where continuity can no longer remain implicit and explicit coordination becomes necessary.
+
+This is the condition that justifies handoff, restart packaging, escalation, or explicit ownership signaling.
+
+### Key rule
+
+A work item may cross themes, concerns, or lenses without requiring formal handoff.
+
+**Thematic crossing alone is not an operational boundary.**
+
+### Typical operational-boundary triggers
+
+An explicit boundary is usually present when one or more of these happen:
+
+- executor changes
+- dominant execution surface changes
+- dominant mode of work changes in a way that affects continuity
+- risk or contract posture changes
+- work is truly split into parallel sub-work-items
+- one actor formally stops so another can continue
+
+### What should not trigger a boundary by itself
+
+The following do not automatically create an operational boundary:
+
+- crossing more than one topic
+- touching product, observability, and UX in the same governed unit
+- moving through more than one lens of analysis
+- local complexity that still preserves the same executor, surface, and governing posture
+
+### Why this matters
+
+This keeps AletheIA from turning every cross-cutting task into unnecessary ceremony.
+
+The framework should preserve explicit coordination only where the work itself actually changes operational shape.
+
+---
+
+## 6. Core vs Adapter vs Operator
+
+### Core
+
+The **core** is the stable framework meaning.
+
+It includes:
+
+- operating concepts
+- contracts
+- governance principles
+- vocabulary
+- reviewable logic about continuity, validation, and learning
+
+The core should remain stable across environments.
+
+### Adapter
+
+An **adapter** is the environment-specific mapping that preserves core meaning across a different surface.
+
+Adapters may change:
+
+- format
+- compression
+- delivery style
+- local packaging
+
+Adapters should not change framework truth.
+
+### Operator
+
+The **operator** is the local human or agent actor who applies, chooses, initiates, reviews, resumes, or closes work inside a real environment.
+
+Operators may decide:
+
+- which local tool to use
+- which tracker represents the work item
+- when to initiate a restart
+- how much local structure is justified
+- what local extension rules apply
+
+These are local actions, not framework truth.
+
+---
+
+## 7. One compact example
+
+A team has one Work Item to improve a high-risk reporting workflow.
+
+Inside that Work Item, one Work Slice may touch:
+
+- product semantics
+- observability updates
+- user-facing wording
+
+If the same executor continues the work, the same execution surface remains active, and the same risk posture still governs the slice, no formal handoff is required.
+
+The Work Item is crossing themes, but it has not crossed an Operational Boundary.
+
+Later, the same Work Item may require:
+
+- a different executor
+- a move into a design-oriented instruction surface
+- a risk or contract review
+- or true parallel split into separate tracks
+
+At that point, the work has crossed an Operational Boundary.
+
+Now explicit coordination is required, such as:
+
+- handoff
+- restart package
+- review gate
+- or sub-work-item creation
+
+---
+
+## 8. Relationship to existing documents
+
+Read this document together with:
+
+- `docs/governance.md`
+- `docs/work-slice-pattern.md`
+- `docs/slice-finalization-and-restart.md`
+- `docs/adapter-taxonomy.md`
+- `docs/runtime-adapter-contract.md`
+
+These documents elaborate different parts of the model.
+
+This file exists to keep the vocabulary itself stable across them.
+
+---
+
+## Final rule
+
+AletheIA should stay:
+
+- project-agnostic
+- tracker-agnostic
+- provider-agnostic
+- surface-flexible
+
+The purpose of canonical vocabulary is not to remove local variation.
+
+It is to prevent local variation from becoming mistaken for framework truth.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,11 +34,12 @@ Most readers should start in one of these modes:
 
 Read in this order:
 
-1. `docs/00-overview.md`
-2. `docs/governance.md`
-3. `docs/token-policy.md`
-4. `docs/durable-decisions.md`
-5. `docs/enforcement-boundaries.md`
+1. `docs/canonical-vocabulary.md`
+2. `docs/00-overview.md`
+3. `docs/governance.md`
+4. `docs/token-policy.md`
+5. `docs/durable-decisions.md`
+6. `docs/enforcement-boundaries.md`
 
 ### 2. I want to try the framework quickly
 
@@ -71,6 +72,10 @@ into this:
 `intent -> context -> decision -> execution -> validation -> learning`
 
 If you understand that shift, you already understand the core idea of the framework.
+
+If you are unsure what counts as a Work Item, Work Slice, Restart Package, or Execution Surface, read:
+
+- `docs/canonical-vocabulary.md`
 
 ---
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -110,13 +110,17 @@ Pode ser:
 
 #### Work Item
 
-É a unidade mínima de trabalho governável.
+A Work Item is the official governed unit of work in AletheIA.
 
-Idealmente, ele deve ter:
+It is tracker-agnostic by design.
 
-- um objetivo
-- um output claro
-- limites explícitos
+A GitHub issue may represent a Work Item in one project, but the framework does not depend on GitHub or any other specific tracker to define the concept.
+
+A Work Item should keep an objective, an expected outcome, a governing context, and a local lifecycle state explicit enough to be reviewed and resumed.
+
+For canonical vocabulary, see:
+
+- `docs/canonical-vocabulary.md`
 
 #### Authoritative Layer
 

--- a/docs/runtime-adapter-contract.md
+++ b/docs/runtime-adapter-contract.md
@@ -25,6 +25,16 @@ The goal is to define the smallest shared shape that later local adapters can ma
 
 ## Relationship to existing surfaces
 
+This document defines a runtime-facing adapter shape, not the full canonical meaning of Execution Surface.
+
+Execution Surface is the broader canonical term.
+A runtime adapter is one specific way of preserving AletheIA meaning on such a surface.
+
+See:
+
+- `docs/canonical-vocabulary.md`
+- `docs/adapter-taxonomy.md`
+
 This contract builds directly on:
 
 - `docs/context-resource-telemetry-spec.md`

--- a/docs/slice-finalization-and-restart.md
+++ b/docs/slice-finalization-and-restart.md
@@ -7,6 +7,15 @@ Define a manual-first way to close a work slice cleanly, preserve continuity thr
 This is not a "clear chat" feature.
 It is a slice-finalization capability.
 
+In canonical AletheIA vocabulary:
+
+- a Restart Package is the continuity artifact used when work must resume across a real boundary
+- that boundary should be understood as an Operational Boundary, not as thematic crossing by itself
+
+For canonical terminology, see:
+
+- `docs/canonical-vocabulary.md`
+
 ---
 
 ## Why this exists
@@ -68,6 +77,8 @@ A healthy slice finalization should follow this order:
 
 The goal is not to restart by habit.
 The goal is to restart when continuing in the same session would now carry more drag than value.
+
+A Restart Package is justified when continuity can no longer remain implicit, not merely because the work touched more than one concern.
 
 ---
 

--- a/docs/work-slice-pattern.md
+++ b/docs/work-slice-pattern.md
@@ -4,6 +4,12 @@
 
 This document explains how AletheIA can treat a bounded unit of work as a **work slice** without introducing a new core contract.
 
+This document should be read as the operational pattern for `Work Slice`, not as the source of the term itself.
+
+For the canonical definition of `Work Slice` and its relationship to `Work Item`, `Restart Package`, and `Operational Boundary`, see:
+
+- `docs/canonical-vocabulary.md`
+
 A work slice is an operational composition.
 It gathers the artifacts that make one unit of work more resumable, reviewable, and teachable.
 
@@ -50,6 +56,10 @@ Without that composition, teams can end up with:
 - a learning that loses its link to the slice that generated it
 
 The work-slice pattern makes that chain easier to read without inflating the framework core.
+
+A Work Slice may cross more than one theme or concern without requiring formal handoff.
+
+Explicit coordination becomes necessary only when the slice crosses an Operational Boundary.
 
 ---
 


### PR DESCRIPTION
## Summary

Publishes a canonical vocabulary anchor for AletheIA and aligns the main docs around it.

This PR introduces `docs/canonical-vocabulary.md` as the source of truth for:

- Work Item
- Work Slice
- Restart Package
- Execution Surface
- Operational Boundary
- Core vs Adapter vs Operator

It also aligns the surrounding docs so AletheIA communicates a stable framework meaning across trackers, agent surfaces, handoff artifacts, and runtime-facing records.

## Why

The repo already explains work slices, restart packages, adapters, and runtime-facing contracts, but the terminology is still distributed across multiple docs.

This PR reduces drift by making explicit that:

- Work Item is the official governed unit of work
- Work Slice is a bounded operational composition
- Restart Package is the continuity artifact used across a real boundary
- Execution Surface is not the same thing as Adapter
- crossing themes alone does not require handoff
- explicit coordination only becomes necessary at an Operational Boundary

## Changes

### New doc
- add `docs/canonical-vocabulary.md`

### Doc alignment
- update `README.md`
- update `docs/00-overview.md`
- update `docs/getting-started.md`
- update `docs/governance.md`
- update `docs/work-slice-pattern.md`
- update `docs/slice-finalization-and-restart.md`
- update `docs/adapter-taxonomy.md`
- update `docs/runtime-adapter-contract.md`

## Canonical decisions reflected here

- AletheIA remains tracker-agnostic
- GitHub issue is a valid local implementation of a Work Item, not its universal definition
- Work may cross themes without mandatory handoff
- Operational Boundary is the real trigger for explicit continuity artifacts
- Adapter preserves meaning across a surface; it does not define the surface itself

Closes #79
