### PR TITLE
docs: reconcile stale roadmap wording

### DIFF
--- a/docs/enterprise-readiness-roadmap.md
+++ b/docs/enterprise-readiness-roadmap.md
@@ -122,25 +122,40 @@ That matters because many enterprise environments need stronger reviewability lo
 
 ---
 
-## What is still missing
+## What is still maturing
 
-The 1.1 track exists because the current baseline still has real gaps.
+The 1.1 track exists because the current baseline still has real gaps, even
+though the first documentation artifacts now exist.
 
-### 1. No explicit enterprise adoption guide yet
+### 1. Enterprise adoption guidance has started
 
-The framework baseline already explains many useful parts, but it still needs a direct guide that answers:
+The framework baseline now includes a direct guide for constrained adoption:
+
+- `starter-pack/guides/enterprise-adoption-considerations.md`
+
+That guide starts answering:
 
 - how to start in a constrained environment
 - how to keep the rollout bounded
 - how to treat local approvals, tool restrictions, and trust boundaries
 
-### 2. No restricted-environment extension example yet
+What remains is not the existence of the guide, but stronger evidence from
+real constrained adoption loops.
 
-AletheIA teaches the extension pattern, but constrained environments benefit from a more explicit example showing:
+### 2. Restricted-environment extension examples have started
+
+AletheIA now includes a restricted enterprise project-extension example:
+
+- `examples/project-extension/restricted-enterprise-context.md`
+
+That example starts showing:
 
 - what stays in the core
 - what becomes local rule
 - how local model/tool restrictions should be expressed
+
+What remains is not the existence of an example, but stronger repetition across
+real or realistic constrained contexts.
 
 ### 3. No stronger mapping from framework artifacts to heavier local governance
 
@@ -167,7 +182,11 @@ The lowest-regret path for 1.1 is still documentation-first.
 
 ### Step 1 — enterprise adoption guidance
 
-Create a practical guide for introducing AletheIA in environments with:
+Started through:
+
+- `starter-pack/guides/enterprise-adoption-considerations.md`
+
+This guide introduces AletheIA in environments with:
 
 - heavier approvals
 - stronger review layers
@@ -176,7 +195,12 @@ Create a practical guide for introducing AletheIA in environments with:
 
 ### Step 2 — restricted enterprise extension example
 
-Show how a project can define a local enterprise integration layer without contaminating the framework core.
+Started through:
+
+- `examples/project-extension/restricted-enterprise-context.md`
+
+This example shows how a project can define a local enterprise integration
+layer without contaminating the framework core.
 
 ### Step 3 — stronger trust-boundary posture in local mapping
 

--- a/docs/release-1.0-readiness.md
+++ b/docs/release-1.0-readiness.md
@@ -114,12 +114,15 @@ These tracks remain real and already planned, but they were **not** required for
 
 ### 1.1 — enterprise-readiness / regulated adoption
 
-Planned backlog includes:
+Current track includes:
 
 - enterprise-readiness / regulated adoption roadmap
-- enterprise adoption guidance
-- restricted enterprise extension example
-- stronger local trust-boundary posture for constrained environments
+- enterprise adoption guidance, now started through the starter-pack guide
+- restricted enterprise extension example, now started through the project-extension example
+- stronger local trust-boundary posture for constrained environments, started through docs/template/example material
+
+Remaining work is evidence-oriented: stronger constrained-adoption proof before
+claiming broader enterprise-readiness.
 
 ### 1.2 — pilot expansion / stronger real-world validation
 


### PR DESCRIPTION
## Summary
- reconcile stale 1.1 enterprise-readiness roadmap wording after backlog cleanup
- replace “guide/example missing” language with “started, still maturing” language
- clarify that remaining 1.1 work is evidence-oriented, not missing artifact creation

## Validation
- `grep -RniE "No explicit enterprise adoption guide yet|No restricted-environment extension example yet|still needs a direct guide|benefit from a more explicit example" docs/enterprise-readiness-roadmap.md docs/roadmap-alpha.md docs/release-1.0-readiness.md || true`
- Markdown local link check: `missing_links 0`
- `bash scripts/check-governance.sh`
- `git diff --check`

Closes #90
