### PR TITLE
docs: add Hermes Phase -1 pre-pilot artifacts

### DIFF
--- a/docs/adr/ADR-001-hermes-role.md
+++ b/docs/adr/ADR-001-hermes-role.md
@@ -1,0 +1,182 @@
+# ADR 001 — Hermes role in the AletheIA pipeline
+
+| Field | Value |
+|---|---|
+| Status | Accepted |
+| Date | 2026-04-25 |
+| Author | Neviton Santana |
+| Deciders | Neviton Santana |
+| Related | ADR 002 — Memory and skill promotion policy |
+| Supersedes | — |
+
+## 1. Context
+
+AletheIA already operates across multiple agents and model families. As the operating surface grows, continuity friction increases: context can be lost between sessions, handoffs can degrade, durable decisions can need to be re-explained, and durable memory needs a clear owner.
+
+Hermes Agent is a candidate persistent operational runtime with multi-model routing, messaging gateways, subagents, tools, and its own memory surface.
+
+The architectural risk is Hermes drifting into process sovereignty: creating skills by itself, curating semantic memory without review, selecting models without an explicit policy, or silently expanding autonomy. That would violate the core AletheIA principle: **runtime does not govern process**.
+
+This ADR defines the role of Hermes for the pre-pilot and pilot period.
+
+## 2. Decision
+
+### 2.1 Hermes type
+
+Hermes is a **controlled runtime executor**.
+
+It is not a copilot, not a semi-autonomous operating brain, and not the source of AletheIA governance. It is an execution layer subordinated to:
+
+- AletheIA Protocol;
+- AletheIA Runtime Policy;
+- Adaptative Skills catalog;
+- human approval gates where required.
+
+This role can only be re-evaluated after the 60-day pilot, using recorded metrics. It must not expand through implicit operational habit.
+
+### 2.2 What Hermes may execute without human approval
+
+Hermes may execute without additional approval only when **all** conditions are true:
+
+- risk is classified as **low** by AletheIA Protocol;
+- scope is inside the `AletheIA Lab` profile;
+- tools are restricted to reading and sandboxed execution;
+- write access is limited to explicitly allowed paths;
+- the task does not touch production, security, credentials, paid integrations, or Crisis Monitor product core.
+
+Allowed write paths for the pre-pilot are:
+
+- `memory/proposed/`;
+- `docs/aletheia/closeouts/`;
+- isolated test branches or disposable sandbox repositories.
+
+Everything else requires human approval recorded in a versioned or GitHub-linked artifact.
+
+### 2.3 What Hermes must never execute
+
+Hermes must never execute:
+
+- changes to Crisis Monitor core product behavior;
+- production changes;
+- writes to credentials, secrets, or environment-variable files;
+- sensitive API calls, paywall access, scraping, or paid integrations without prior approval;
+- memory promotion from `memory/proposed/` to semantic memory;
+- skill promotion between lifecycle stages;
+- creation or modification of ADRs;
+- modification of its own permissions, adapters, or runtime profile;
+- unattended cron execution for real tasks.
+
+The final rule is absolute: **Hermes does not promote its own autonomy**.
+
+### 2.4 Who chooses the model
+
+Model choice follows a fixed chain:
+
+1. **AletheIA Protocol suggests** a model based on risk, cost, latency, context, reasoning depth, and sensitivity.
+2. **Hermes may propose an alternative**, but must record the reason.
+3. **Human confirmation is required** for medium-risk and high-risk tasks.
+4. **Low-risk tasks** follow the Protocol suggestion without extra approval when inside the `AletheIA Lab` profile.
+
+Model choice and rationale must be recorded in the closeout.
+
+### 2.5 How execution is recorded
+
+Every Hermes execution produces a closeout in:
+
+- `docs/aletheia/closeouts/YYYY-MM-DD-[slug].md`
+
+The closeout must use `starter-pack/templates/hermes-closeout-template.md` and include:
+
+- source issue or PR;
+- selected model and rationale;
+- applied skill;
+- tools used;
+- evidence of completion;
+- human approval record when applicable;
+- candidate learning, if any, with proposed destination.
+
+A task is not closed if required closeout fields are missing.
+
+### 2.6 Containment and shutdown criteria
+
+Hermes must be **contained** or **shut down** if any trigger occurs during the pilot.
+
+| Event | Response |
+|---|---|
+| 1+ critical scope violation | Shut down immediately and open post-mortem |
+| 3+ non-critical scope violations in 7 days | Contain by revoking permissions pending review |
+| Rework rate above pre-pilot baseline for 2 consecutive weeks | Contain |
+| Episodic memory remains unmanageable after 4 weeks | Contain and review retention policy |
+| Cost per task above the ADR 001 limit | Contain |
+| Human approvals are confirmed without effective reading | Stop pilot and redesign HITL mechanics |
+
+Cost limits for the pre-pilot/pilot are:
+
+- USD 0.50 per documentation task;
+- USD 2.00 per discovery task.
+
+Human approval timeout is **24 business hours**. After that, the task fails fast and returns to backlog as `awaiting-human`.
+
+Critical Crisis Monitor areas where Hermes must not write, even through PR, are:
+
+- `src/app/api/`;
+- `lib/cris*`;
+- credentials, secrets, and environment files;
+- production configuration;
+- auth/security surfaces;
+- paid or sensitive integrations;
+- Crisis Monitor product core behavior.
+
+Containment or shutdown decisions must be recorded as an ADR or durable decision artifact.
+
+## 3. Consequences
+
+### Positive
+
+- Hermes operates predictably.
+- Auditing remains simple through versioned closeouts and GitHub-linked approvals.
+- Runtime autonomy is bounded by explicit policy rather than intent.
+- Reversal is cheap: disabling Hermes does not collapse the AletheIA operating model.
+
+### Negative
+
+- Hermes starts with nominal features disabled, including auto-skill, auto-memory, and unattended cron.
+- Medium-risk and high-risk tasks include real human review friction.
+- Operating cost includes review time, not only model/runtime cost.
+
+### Accepted tradeoff
+
+The pre-pilot goal is to prove value before expanding autonomy. Losing nominal automation in exchange for auditable governance is intentional.
+
+## 4. Alternatives considered
+
+### A. Hermes as semi-autonomous agent from the start
+
+Keeps auto-skill and auto-memory enabled with later human review.
+
+Rejected because review queues tend to become batch approval theater, weakening governance exactly where it should be strongest.
+
+### B. Hermes only as messaging gateway
+
+Uses Hermes only for Telegram, Discord, or Slack coordination.
+
+Rejected as the primary path because it underuses the runtime. Kept as a fallback if the controlled pilot misses go thresholds.
+
+### C. Do not use Hermes; build a smaller custom agent loop
+
+Rejected for now because construction cost is high and the current friction has not yet justified bespoke runtime work.
+
+## 5. Relationship to Phase -1
+
+Phase -1 planning must treat ADR 001 and ADR 002 as the decision source of truth.
+
+Roadmaps, matrices, and templates may reference these ADRs, but should not duplicate or re-litigate the same decisions. If a Phase -1 rule changes, update the relevant ADR first and then update dependent artifacts.
+
+## 6. Review
+
+| When | What to review |
+|---|---|
+| After manual simulation | Whether the model-choice chain is usable in practice |
+| After 30 days of pilot | Containment and shutdown thresholds |
+| After 60 days of pilot | Go/no-go for any autonomy expansion |
+| After any critical violation | Full ADR review |

--- a/docs/adr/ADR-002-memory-and-skill-promotion-policy.md
+++ b/docs/adr/ADR-002-memory-and-skill-promotion-policy.md
@@ -1,0 +1,156 @@
+# ADR 002 — Memory and skill promotion policy for Hermes pre-pilot
+
+| Field | Value |
+|---|---|
+| Status | Accepted |
+| Date | 2026-04-25 |
+| Author | Neviton Santana |
+| Deciders | Neviton Santana |
+| Related | ADR 001 — Hermes role in the AletheIA pipeline |
+| Supersedes | — |
+
+## 1. Context
+
+AletheIA depends on durable memory and reusable skills, but those surfaces can easily become self-referential governance if a runtime is allowed to create, promote, and consume them without review.
+
+Hermes may help produce candidate memories and candidate skill updates during the pre-pilot. It must not own promotion.
+
+The design goal is to preserve learning while preventing memory bloat, skill drift, and runtime self-governance.
+
+## 2. Decision
+
+### 2.1 Memory lifecycle
+
+Hermes may write only to candidate memory:
+
+- `memory/proposed/`
+
+Promotion from proposed memory to semantic or durable memory requires human review. Hermes cannot promote memory directly.
+
+The default memory flow is:
+
+1. Hermes records a candidate learning in the task closeout.
+2. If the learning is worth retaining, Hermes may create or reference a file in `memory/proposed/`.
+3. Human review accepts, edits, merges, or discards the candidate.
+4. Only accepted items move to semantic/durable memory.
+
+### 2.2 Memory promotion threshold
+
+The pilot should show evidence of curation, not accumulation.
+
+The go threshold is:
+
+- promoted memories remain below **30%** of proposed memories during the pilot review window.
+
+This captures selectivity without rewarding the creation of bad memories merely to increase discard volume.
+
+A high discard count is not itself success. Success is a low promotion rate plus clear reasons for what was promoted.
+
+### 2.3 Memory types and belonging test
+
+Use the following direct belonging test:
+
+| Type | Belongs here when |
+|---|---|
+| Personal | It reflects a human preference or durable collaboration constraint |
+| Operational | It is a convention, rule, boundary, or project operating fact |
+| Procedural | It is executable by an agent with triggers or steps |
+| Episodic | It records a specific run, task, incident, or short-lived occurrence |
+
+If a candidate is executable by an agent with triggers, it is **Procedural**.
+If it is a convention or rule, it is **Operational**.
+
+### 2.4 Skill lifecycle
+
+Skills use this lifecycle:
+
+| Stage | Meaning |
+|---|---|
+| `draft` | Idea captured but not yet shaped for use |
+| `proposed` | Candidate skill with owner and intended trigger |
+| `experimental` | Used in bounded tests with explicit review |
+| `validated` | Proven useful across repeated tasks or pilot evidence |
+| `default` | Preferentially loaded or routed when trigger, risk, and context match |
+
+`default` is operational, not decorative: it gives the skill preferential loading/routing when its trigger and risk profile match the task.
+
+`default` does **not** mean automatic execution, bypassed review, or permission expansion.
+
+### 2.5 Skill promotion
+
+Hermes may propose a new skill or a lifecycle change, but cannot approve it.
+
+Promotion requires:
+
+- human review;
+- evidence from at least one closeout;
+- a clear trigger;
+- a clear risk boundary;
+- a rollback path when the skill causes confusion or drift.
+
+Hermes cannot promote a skill that changes its own permissions, routing priority, memory access, or runtime autonomy.
+
+### 2.6 Baseline and measurement windows
+
+Use separate baseline windows for different signal types.
+
+Operational metrics use a **2-week pre-pilot baseline**:
+
+- time to closeout;
+- rework rate;
+- number of context re-explanations;
+- cost per task;
+- violations of scope or gates.
+
+Qualitative metrics use a **continuous baseline through Phase 5**, then compare against the same amount of post-Hermes work:
+
+- perceived handoff quality;
+- gaps found after handoff;
+- clarity of candidate memories;
+- usefulness of proposed skill changes.
+
+This avoids pretending that one or two weeks create enough qualitative signal.
+
+## 3. Consequences
+
+### Positive
+
+- Memory stays curated rather than accumulated.
+- Skill lifecycle has practical meaning.
+- Hermes can contribute learning without governing learning.
+- Go/no-go review has numeric thresholds and qualitative evidence.
+
+### Negative
+
+- Some useful memories and skills may wait for human review.
+- The pilot measures discipline before automation speed.
+- Qualitative baselines require patience through Phase 5.
+
+## 4. Alternatives considered
+
+### A. Let Hermes promote memory automatically
+
+Rejected because it gives the runtime governance over what future executions inherit.
+
+### B. Let Hermes promote skills after successful use
+
+Rejected because successful use is not enough to prove safe default routing.
+
+### C. Use discard volume as the curation metric
+
+Rejected because it can reward producing low-quality candidates. Promotion rate below 30% is safer.
+
+## 5. Boundaries
+
+This ADR does not define a full memory database, active skill registry, or runtime adapter implementation.
+
+It defines the pre-pilot promotion policy that any later implementation must respect.
+
+## 6. Review
+
+| When | What to review |
+|---|---|
+| After manual simulation | Whether the closeout captures candidate learning without overwork |
+| After 2 weeks of baseline | Operational metric availability |
+| At Phase 5 | Qualitative baseline maturity |
+| After 60-day pilot | Whether any promotion rule can be relaxed |

--- a/docs/hermes/manual-simulation-closeout.md
+++ b/docs/hermes/manual-simulation-closeout.md
@@ -1,0 +1,159 @@
+# Hermes Manual Simulation Closeout — Crisis Monitor Issue 113
+
+## 1. Identification
+
+| Field | Value |
+|---|---|
+| Title | Manual simulation of Hermes closeout on a closed Crisis Monitor issue |
+| Issue | Crisis Monitor #113 |
+| Repository | Crisis Monitor |
+| Start date | 2026-04-25 |
+| Closeout date | 2026-04-25 |
+| Executor | Hermes simulated manually by Codex |
+| Human operator | Neviton Santana |
+
+Source issue: https://github.com/nevitonsantana/Crisis-Monitor/issues/113
+
+## 2. Pre-execution — AletheIA Protocol inputs
+
+**Intent**
+Validate whether the Hermes closeout template can represent a real completed task without relying on chat memory.
+
+**Scope**
+Map a closed Crisis Monitor protocol-alignment issue into the Hermes closeout structure.
+
+**Out of scope**
+Do not re-execute the Crisis Monitor task, change Crisis Monitor files, or claim Hermes actually ran.
+
+**Risk classification**
+Low: documentation-only simulation using a closed issue.
+
+**Applied skill**
+`none — ad-hoc execution`; candidate pattern is closeout conversion for prior completed tasks.
+
+**Selected model**
+GPT via Codex. Rationale: low-risk documentation synthesis with repository/GitHub context.
+
+**Allowed tools**
+GitHub issue read, local documentation read, Markdown authoring in AletheIA branch.
+
+**Expected evidence**
+A versioned closeout that identifies field friction, consistently empty fields, and whether the Hermes matrix is actionable.
+
+**Human approval required?**
+No for simulation. Human review occurs through the PR.
+
+## 3. Active sandbox and gates
+
+- [x] `AletheIA Lab` profile represented as simulation only
+- [x] Unattended cron disabled
+- [x] Writes restricted to AletheIA documentation paths
+- [x] Skill auto-promotion disabled
+- [x] Semantic memory write disabled
+- [x] Isolated branch active
+
+## 4. Execution — Layer 1, operational core
+
+**Delivered**
+Converted Crisis Monitor Issue #113 into a Hermes-style closeout simulation.
+
+**Validated**
+Issue #113 was closed on 2026-04-22 and records the protocol rollout: Issue/kanban as official work unit, crossing themes without automatic handoff, and handoff only on real operational boundary.
+
+**Current state**
+Simulation artifact added to AletheIA documentation branch.
+
+**Artifacts**
+- Source issue: https://github.com/nevitonsantana/Crisis-Monitor/issues/113
+- Closeout: `docs/hermes/manual-simulation-closeout.md`
+- Template tested: `starter-pack/templates/hermes-closeout-template.md`
+
+**Completeness**
+Final for Phase -1 simulation.
+
+**Next issue?**
+No. Future real Hermes pilot work should open a new issue.
+
+## 5. Human approval
+
+Omitted because this is a low-risk simulation. Human approval happens through PR review.
+
+## 6. Learning and memory — Layer 2
+
+### Candidate learning
+
+**Description**
+A Hermes closeout is feasible for completed work, but fields that depend on runtime telemetry are not available when backfilling a historical issue.
+
+**Type**
+Operational.
+
+**Proposed destination**
+Keep in this simulation artifact; do not promote to semantic memory yet.
+
+### Field friction observed
+
+Harder fields to fill from an already closed issue:
+
+- exact model choice at execution time;
+- cost of execution;
+- effective human approval quality;
+- tool allowlist at the moment of execution;
+- time spent from start to closeout when comments are sparse.
+
+Consistently empty or omitted fields in this simulation:
+
+- PR link when issue comments did not include one directly;
+- approval table for low-risk simulation;
+- durable decision section beyond the already documented protocol decision;
+- handoff section because the issue was closed without next issue.
+
+## 7. Durable decision — Layer 2
+
+**Decision**
+Backfilled closeouts are useful for testing structure, but real Hermes tasks must create the closeout before execution begins.
+
+**Record location**
+This simulation artifact. No separate ADR required.
+
+**Rejected alternatives**
+Do not treat missing historical telemetry as failure of the template; treat it as evidence that closeouts must be started before execution.
+
+## 8. End of cycle — Layer 3
+
+**Roadmap status**
+Supports Phase -1 readiness by testing the closeout template before a real Hermes pilot.
+
+**Metrics recorded**
+
+| Metric | Value |
+|---|---|
+| Time to closeout | Not reliably recoverable from historical issue |
+| Execution cost | Not available |
+| Context re-explanations | Not available |
+| Human corrections | Not available |
+| Scope violations | 0 observed in issue record |
+
+**Key learnings**
+The template is usable, but the operational matrix is only unambiguous if pre-execution sections are filled before work starts.
+
+**Recalibration**
+- Model choice was adequate for simulation.
+- No skill was applied.
+- Effort cannot be compared to original because this was a backfill simulation.
+
+## 9. Audit
+
+| Field | Value |
+|---|---|
+| Did the task violate scope? | no |
+| Did the task require human approval? | no |
+| Was human approval effective? | PR review pending |
+| Did any gate fail or get bypassed? | no |
+| Was cost inside ADR 001 limit? | yes; no paid Hermes execution occurred |
+
+## Simulation verdict
+
+The Hermes closeout format is usable for the pre-pilot, but it should not be backfilled as the normal operating mode.
+
+For real Hermes tasks, sections 1–3 must exist before execution. Otherwise, cost, approval quality, and tool boundaries become guesswork.

--- a/docs/hermes/phase-minus-1-operational-matrix.md
+++ b/docs/hermes/phase-minus-1-operational-matrix.md
@@ -1,0 +1,126 @@
+# Hermes Phase -1 Operational Matrix
+
+## Purpose
+
+This matrix turns ADR 001 and ADR 002 into an executable pre-pilot checklist.
+
+ADR 001 and ADR 002 are the source of decision truth. This matrix references them; it must not re-litigate the role of Hermes, memory policy, or skill promotion policy.
+
+## Timebox and ownership
+
+Phase -1 is a **1-week** setup slice.
+
+It is a single-owner sprint owned by Neviton Santana. Work should be serial inside the week. It is only “parallel” in the sense that it should not block Phase 2 preparation.
+
+If Phase -1 exceeds one week, stop and review whether a decision is still immature instead of producing low-quality ADRs.
+
+## Execution profile
+
+| Surface | Decision |
+|---|---|
+| Runtime | Hermes as controlled runtime executor |
+| Profile | `AletheIA Lab` |
+| Autonomy | Low-risk, sandboxed tasks only |
+| Human gate | Required for medium/high risk and policy changes |
+| Cron | Disabled for real tasks |
+| Memory | `memory/proposed/` only |
+| Skill promotion | Human review only |
+| ADR edits | Human/Codex only, not Hermes |
+
+## Allowed without additional approval
+
+Hermes may run without extra approval only when all conditions hold:
+
+- low risk;
+- `AletheIA Lab` profile;
+- read or sandbox tools only;
+- writes limited to allowed paths;
+- no production, security, credential, paid integration, or Crisis Monitor core impact.
+
+## Explicitly allowed write paths
+
+- `memory/proposed/`
+- `docs/aletheia/closeouts/`
+- isolated test branches
+- disposable sandbox repositories
+
+## Critical no-write areas
+
+Hermes must not write to these Crisis Monitor areas, even through PR:
+
+- `src/app/api/`
+- `lib/cris*`
+- credentials, secrets, and environment files
+- production configuration
+- auth/security surfaces
+- paid or sensitive integrations
+- Crisis Monitor product core behavior
+
+## Human-in-the-loop rule
+
+| Case | Required action |
+|---|---|
+| Low risk inside `AletheIA Lab` | May proceed with recorded closeout |
+| Medium/high risk | Human approval before mutation |
+| Approval waits over 24 business hours | Fail fast; return to backlog as `awaiting-human` |
+| Approval appears unread or rubber-stamped | Stop pilot and revise HITL mechanics |
+
+## Memory and skill gates
+
+| Gate | Rule |
+|---|---|
+| Candidate memory | Hermes may propose in `memory/proposed/` |
+| Semantic memory | Human promotion only |
+| Promotion threshold | Promoted memories stay below 30% of proposed memories |
+| Candidate skill | Hermes may propose with trigger and risk boundary |
+| Skill promotion | Human approval only |
+| `default` skill | Preferential routing/loading when trigger and risk match; no automatic execution |
+
+## Baseline windows
+
+| Metric family | Baseline |
+|---|---|
+| Operational metrics | 2 weeks before pilot |
+| Qualitative metrics | Continuous baseline through Phase 5, compared to equivalent post-Hermes work |
+
+Operational metrics:
+
+- time to closeout;
+- rework rate;
+- context re-explanations;
+- cost per task;
+- scope/gate violations.
+
+Qualitative metrics:
+
+- perceived handoff quality;
+- gaps found after handoff;
+- clarity of candidate memories;
+- usefulness of proposed skill changes.
+
+## Go / no-go thresholds
+
+| Signal | Go threshold | Contain / no-go trigger |
+|---|---|---|
+| Scope safety | 0 critical violations | 1+ critical violation |
+| Non-critical violations | Fewer than 3 in 7 days | 3+ in 7 days |
+| Rework | At or below baseline | Above baseline for 2 consecutive weeks |
+| Memory curation | Promotion rate below 30% | Promotion rate at or above 30% without strong justification |
+| Cost | Within ADR 001 limits | Above USD 0.50 documentation or USD 2.00 discovery limit |
+| HITL quality | Approval is recorded and substantively reviewed | Approval confirmed without effective reading |
+
+## Required Phase -1 artifacts
+
+- `docs/adr/ADR-001-hermes-role.md`
+- `docs/adr/ADR-002-memory-and-skill-promotion-policy.md`
+- `starter-pack/templates/hermes-closeout-template.md`
+- `docs/hermes/manual-simulation-closeout.md`
+- this matrix
+
+## Validation for this slice
+
+- stale wording grep has no contradictory hits;
+- Markdown link check returns `missing_links 0`;
+- `bash scripts/check-governance.sh` passes;
+- `git diff --check` passes;
+- manual simulation states what was hard to fill, what stayed empty, and whether the matrix was unambiguous.

--- a/starter-pack/templates/hermes-closeout-template.md
+++ b/starter-pack/templates/hermes-closeout-template.md
@@ -1,0 +1,195 @@
+# Hermes Closeout Template
+
+> Copy this file to `docs/aletheia/closeouts/YYYY-MM-DD-[slug].md` when starting a Hermes-controlled execution.
+>
+> Fill sections 1–3 before execution, section 4 during execution, and sections 5–9 at closeout.
+>
+> Empty fields are omitted, not filled with `N/A`.
+>
+> Durable decisions must live in versioned artifacts, not only in chat.
+
+## 1. Identification
+
+| Field | Value |
+|---|---|
+| Title | … |
+| Issue | #… |
+| PR | #… |
+| Branch | … |
+| Repository | AletheIA / Adaptative Skills / Crisis Monitor / other |
+| Start date | YYYY-MM-DD |
+| Closeout date | YYYY-MM-DD |
+| Executor | Hermes / Codex / Claude Code / Human |
+| Human operator | … |
+
+## 2. Pre-execution — AletheIA Protocol inputs
+
+Filled before execution. Without this, the task does not start.
+
+**Intent**
+One sentence describing what must be true at close.
+
+**Scope**
+What is inside this execution.
+
+**Out of scope**
+What not to do, even if useful.
+
+**Risk classification**
+Low / Medium / High, with one-line rationale.
+
+**Applied skill**
+Skill ID and stage: `draft` / `proposed` / `experimental` / `validated` / `default`.
+
+If no skill applies, write: `none — ad-hoc execution` and note whether a recurring pattern may justify a candidate skill.
+
+`default` means preferential loading/routing when trigger, context, and risk match. It does not mean automatic execution or expanded permissions.
+
+**Selected model**
+Model and provider, with one-line rationale using risk / cost / context / reasoning / sensitivity.
+
+**Allowed tools**
+Explicit list. Anything not listed is forbidden.
+
+**Expected evidence**
+How completion will be proven.
+
+**Human approval required?**
+Yes / No. If yes, where approval will be recorded.
+
+## 3. Active sandbox and gates
+
+For Hermes in `AletheIA Lab`. Omit if executor is human.
+
+- [ ] `AletheIA Lab` profile active
+- [ ] Unattended cron disabled
+- [ ] Writes restricted to allowed paths
+- [ ] Skill auto-promotion disabled
+- [ ] Semantic memory write disabled
+- [ ] Isolated branch or sandbox repository active
+
+## 4. Execution — Layer 1, operational core
+
+**Delivered**
+One objective sentence.
+
+**Validated**
+Tests, diff review, smoke, link check, or other proof.
+
+**Current state**
+Commit / PR / merge / deploy / blocked.
+
+**Artifacts**
+- PR: …
+- Docs updated: …
+- Closeout: this file
+
+**Completeness**
+Final / partial. If partial, name the next step and dependency.
+
+**Next issue?**
+Yes -> create Context Seed.
+No -> close here.
+
+## 5. Human approval
+
+Required for medium-risk and high-risk tasks.
+
+| Field | Value |
+|---|---|
+| Approved by | … |
+| Date | YYYY-MM-DD HH:MM |
+| Approval location | PR comment / issue comment / decision artifact |
+| Note | optional |
+
+## 6. Learning and memory — Layer 2
+
+Only fill when something changes the operational repertoire.
+
+### Candidate learning
+
+**Description**
+What was learned that may matter later.
+
+**Type**
+Personal / Operational / Procedural / Episodic.
+
+Belonging test: if executable by an agent with triggers, it is Procedural. If it is a convention or rule, it is Operational.
+
+**Proposed destination**
+- `memory/proposed/` -> awaiting review for semantic memory
+- durable decision artifact -> decision worth retaining
+- discard -> not worth maintenance
+
+### Proposed skill
+
+| ID | Name | Domain | Estimated risk | Initial stage |
+|---|---|---|---|---|
+| … | … | … | low / medium / high | `draft` or `proposed` |
+
+Justification: why this skill represents a recurring pattern.
+
+### Discarded memory
+
+If generated candidate memory is discarded, record why. Discarded candidates are useful evidence, but pilot success is measured by promotion rate below 30%, not by maximizing discard volume.
+
+## 7. Durable decision — Layer 2
+
+Only fill when the task produced a decision that matters beyond this task.
+
+**Decision**
+One line.
+
+**Record location**
+ADR or durable decision path.
+
+**Human approval**
+Link or reference to section 5.
+
+**Rejected alternatives**
+What was considered and rejected.
+
+## 8. End of cycle — Layer 3
+
+Only fill when closing a larger cycle, release, or handoff.
+
+**Roadmap status**
+What changed for the milestone.
+
+**Metrics recorded**
+
+| Metric | Value |
+|---|---|
+| Time to closeout | … h |
+| Execution cost | USD … |
+| Context re-explanations | … |
+| Human corrections | … |
+| Scope violations | 0 / … |
+
+**Handoff**
+Who receives what, when. Link Context Seed when applicable.
+
+**Key learnings**
+What to carry into the next cycle.
+
+**Recalibration**
+- Was the model choice adequate?
+- Did the skill help?
+- Did estimated effort match actual effort?
+- Should model matrix or gates change?
+
+## 9. Audit
+
+| Field | Value |
+|---|---|
+| Did the task violate scope? | yes / no — detail |
+| Did the task require human approval? | yes / no |
+| Was human approval effective? | yes / no |
+| Did any gate fail or get bypassed? | yes / no — detail |
+| Was cost inside ADR 001 limit? | yes / no |
+
+If any violation field is `yes`, open a post-mortem durable decision before closing the task.
+
+## Notes
+
+Free space for durable context that does not fit above.


### PR DESCRIPTION
## Summary
- add ADR 001 locking Hermes as a controlled runtime executor
- add ADR 002 for memory and skill promotion policy
- add Hermes closeout template, Phase -1 operational matrix, and manual simulation closeout using Crisis Monitor #113

## Validation
- stale wording grep for discard/pending guide contradictions returned no results
- `default` skill semantics are explicitly defined as preferential routing/loading, not automatic execution
- Markdown link check: `missing_links 0`
- `bash scripts/check-governance.sh`
- `git diff --check --cached`

Closes #92
