### PR TITLE
docs: fix README agent role link

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ For the roadmap and release framing, see:
 
 ### Work with agent roles and runtime fit
 
-- `docs/agent-roles-skills-runtime-adapters.md`
+- `docs/agent-role-adoption-guide.md`
 - `docs/agent-role-catalog.md`
 - `docs/runtime-adapter-contract.md`
 - `docs/agent-runtime-decision-guide.md`

--- a/docs/hermes/baseline-phase-minus-1-docs-index-closeout.md
+++ b/docs/hermes/baseline-phase-minus-1-docs-index-closeout.md
@@ -93,7 +93,7 @@ Keep in this closeout only; do not promote to semantic memory.
 
 ### Discarded memory
 
-No semantic-memory candidate was promoted. This remains task-level evidence. A whole-document README link scan also surfaced one pre-existing unrelated missing reference (`docs/agent-roles-skills-runtime-adapters.md`); it was not changed in this Hermes baseline scope.
+No semantic-memory candidate was promoted. This remains task-level evidence. A whole-document README link scan also surfaced one pre-existing unrelated missing README reference; it was left out of the Hermes baseline scope and later tracked separately in AletheIA #98.
 
 ## 7. Durable decision — Layer 2
 


### PR DESCRIPTION
## Summary
- Replaces the broken README reference `docs/agent-roles-skills-runtime-adapters.md` with the existing `docs/agent-role-adoption-guide.md`.
- Updates the Hermes baseline closeout note so it no longer preserves the stale missing path and points to Issue #98 as the separate cleanup.

## Validation
- grep for old missing reference: no hits
- README Markdown/file reference check: passed
- `bash scripts/check-governance.sh`: passed
- `git diff --check`: passed

Refs #98
