### PR TITLE
docs: record Hermes Agentic Stack readiness

### DIFF
--- a/docs/aletheia/closeouts/2026-04-25-hermes-agentic-stack-sandbox-readiness.md
+++ b/docs/aletheia/closeouts/2026-04-25-hermes-agentic-stack-sandbox-readiness.md
@@ -1,0 +1,184 @@
+# Hermes Closeout — Agentic Stack Sandbox Readiness
+
+## 1. Identification
+
+| Field | Value |
+|---|---|
+| Title | Hermes Agent + Agentic Stack controlled sandbox readiness |
+| Issue | AletheIA #100 |
+| Branch | `codex/hermes-agentic-stack-readiness` |
+| Repository | AletheIA |
+| Start date | 2026-04-25 |
+| Closeout date | 2026-04-25 |
+| Executor | Codex, preparing controlled Hermes/Agentic Stack readiness evidence |
+| Human operator | Neviton Santana |
+
+## 2. Pre-execution — AletheIA Protocol inputs
+
+Filled before execution. Without this, the task does not start.
+
+**Intent**
+Determine whether the current environment is ready for a controlled Hermes Agent + Agentic Stack sandbox pilot without treating Codex simulation as Hermes runtime telemetry.
+
+**Scope**
+Record local availability checks for Hermes Agent and Agentic Stack, inspect the integration risk introduced by Agent Skills / `.agent/`, and document the minimum no-go/readiness boundary before any real Hermes-controlled task.
+
+**Out of scope**
+Do not install Hermes Agent or Agentic Stack into the AletheIA repository, do not run a productive Hermes task, do not enable cron/gateway automation, do not promote memory or skills, do not change ADR policy, and do not create new runtime autonomy.
+
+**Risk classification**
+Low: documentation/readiness evidence only; no runtime install, no credentials, no production task, and no policy mutation.
+
+**Applied skill**
+`none — ad-hoc execution`; this is a one-off sandbox-readiness check, not enough to promote a skill.
+
+**Selected model**
+GPT via Codex. Rationale: repository/GitHub/documentation workflow with explicit guardrails and no sensitive runtime operation.
+
+**Allowed tools**
+GitHub issue/PR commands, isolated branch/worktree, local shell inspection commands (`command -v`, `find`, `grep`, `git ls-tree`, `git grep`), read-only web inspection of public upstream repositories, local Markdown editing for this closeout, `bash scripts/check-governance.sh`, `corepack pnpm test:contracts` when dependencies allow, `git diff --check`, git commit, git push, and PR creation.
+
+**Expected evidence**
+Closeout report showing local command availability checks, upstream capability/risk observations, no-go/readiness verdict, governance/contract/diff validation, Issue update, and PR.
+
+**Human approval required?**
+No for this low-risk documentation/readiness slice. Human approval is required before any future sandbox install, Hermes runtime execution, memory promotion, skill promotion, cron activation, or autonomy expansion.
+
+## 3. Active sandbox and gates
+
+- [x] `AletheIA Lab` represented as a readiness/sandbox plan only
+- [x] Unattended cron disabled / not configured in this slice
+- [x] Writes restricted to AletheIA documentation on an isolated branch
+- [x] Skill auto-promotion disabled / not configured in this slice
+- [x] Semantic memory write disabled / not configured in this slice
+- [x] Isolated branch or sandbox repository active
+
+## 4. Execution — Layer 1, operational core
+
+**Delivered**
+Recorded a controlled readiness/no-go report for integrating AletheIA with Hermes Agent, Agent Skills, and Agentic Stack.
+
+**Validated**
+Local checks confirmed that neither `hermes`, `hermes-agent`, nor `agentic-stack` is currently available on PATH in this execution environment. The clean AletheIA worktree contains no `.agent/`, `.agents/`, `AGENTS.md`, `CLAUDE.md`, or `ANTIGRAVITY.md` harness files before this slice. Existing AletheIA Hermes artifacts remain documentation/guardrails only.
+
+**Current state**
+No-go for real Hermes runtime execution from this environment. Ready for PR review as a sandbox-readiness documentation slice.
+
+**Artifacts**
+- Issue: https://github.com/nevitonsantana/AletheIA/issues/100
+- Closeout: this file
+- Public upstream references inspected:
+  - Hermes Agent: https://github.com/NousResearch/hermes-agent
+  - Agentic Stack: https://github.com/codejunkie99/agentic-stack
+
+**Completeness**
+Final for this readiness slice. Partial for the broader Hermes pilot: the next step requires explicit human approval to install and constrain the tools in a disposable sandbox.
+
+**Next issue?**
+Recommended only if the human approves installation work: create a separate sandbox-install issue for Hermes Agent + Agentic Stack diagnostics. Do not combine that with this readiness report.
+
+### Readiness findings
+
+| Check | Result |
+|---|---|
+| `command -v hermes` | not found |
+| `command -v hermes-agent` | not found |
+| `command -v agentic-stack` | not found |
+| AletheIA `.agent/` present before integration | no |
+| AletheIA harness files present before integration | no |
+| Existing Hermes baseline docs present | yes |
+| Real Hermes runtime telemetry available | no |
+
+### Upstream risk observations
+
+Hermes Agent is a candidate runtime, but its public feature surface includes persistent memory, skills, scheduled automation, messaging gateways, subagents, and tool configuration. Those capabilities are useful for the intended pilot but overlap directly with AletheIA's ADR guardrails.
+
+Agentic Stack is a portable `.agent/` brain layer with memory, skills, protocols, adapters, and review tools. Its Hermes adapter routes Hermes through `AGENTS.md` into `.agent/`, and its README describes memory layers, skills, permissions, and optional recall/search behavior.
+
+These are integration risks, not blockers by themselves. The blocker is that neither tool is locally installed and constrained yet.
+
+### Validation performed
+
+| Validation | Result | Evidence |
+|---|---|---|
+| Local command availability | pass/no-go evidence | `hermes`, `hermes-agent`, and `agentic-stack` not found on PATH |
+| Repo harness contamination check | pass | no `.agent/`, `.agents/`, `AGENTS.md`, `CLAUDE.md`, or `ANTIGRAVITY.md` present in clean worktree |
+| Governance baseline | pass | `bash scripts/check-governance.sh` completed successfully |
+| Contract tests | blocked by local dependency state | `corepack pnpm test:contracts` could not find `tsx`; `node_modules` absent |
+| Whitespace/diff check | pass | `git diff --check` completed successfully |
+
+### Minimum next gates before any real Hermes task
+
+- install Hermes Agent only in a disposable sandbox or explicitly approved local profile;
+- install/apply Agentic Stack only in the sandbox, not in the AletheIA repo root;
+- run diagnostics only (`hermes doctor` or equivalent; `agentic-stack ... doctor/status` or equivalent);
+- inspect generated `.agent/` and `AGENTS.md` before any task execution;
+- keep cron/gateways disabled;
+- keep memory/skill promotion human-reviewed only;
+- record any generated memory/skill candidates as sandbox artifacts, not accepted AletheIA memory;
+- do not call any Codex-simulated result Hermes telemetry.
+
+## 5. Human approval
+
+Human approval is not required for this documentation/readiness report. It is required before tool installation, runtime execution, memory promotion, skill promotion, cron activation, gateway activation, or autonomy expansion.
+
+## 6. Learning and memory — Layer 2
+
+### Candidate learning
+
+**Description**
+The first real Hermes pilot cannot start from this environment until Hermes Agent and Agentic Stack are installed and constrained in a disposable sandbox; current evidence supports readiness/no-go, not runtime telemetry.
+
+**Type**
+Operational.
+
+**Proposed destination**
+Keep in this closeout only; do not promote to semantic memory.
+
+### Discarded memory
+
+No memory or skill candidate was generated by Hermes or Agentic Stack. No semantic memory was promoted.
+
+## 7. Durable decision — Layer 2
+
+Omitted. This slice records readiness evidence and preserves existing ADR decisions; it does not change the policy that Hermes is a controlled runtime executor and does not govern process, memory, or skills.
+
+## 8. End of cycle — Layer 3
+
+**Roadmap status**
+Moves the Hermes pre-pilot from document-only baselines toward a concrete toolchain-readiness boundary, while preserving the distinction between readiness evidence and real Hermes telemetry.
+
+**Metrics recorded**
+
+| Metric | Value |
+|---|---|
+| Time to closeout | Same execution window |
+| Execution cost | USD 0.00 Hermes runtime cost |
+| Context re-explanations | 0 after user supplied plan |
+| Human corrections | 0 during execution |
+| Scope violations | 0 |
+
+**Handoff**
+Human decision required before the next boundary: whether to approve a disposable sandbox install/diagnostic issue for Hermes Agent + Agentic Stack.
+
+**Key learnings**
+AletheIA's Hermes guardrails are compatible with a sandbox-first integration path, but Agentic Stack's `.agent/` memory/skills layer must be treated as a candidate runtime brain layer until human review accepts any durable memory or skills.
+
+**Recalibration**
+- Model choice was adequate for readiness documentation.
+- No skill was applied or promoted.
+- The next slice should be installation diagnostics only, not a productive Hermes task.
+
+## 9. Audit
+
+| Field | Value |
+|---|---|
+| Did the task violate scope? | no |
+| Did the task require human approval? | no for documentation/readiness; yes before future install/runtime work |
+| Was human approval effective? | pending for next boundary |
+| Did any gate fail or get bypassed? | no |
+| Was cost inside ADR 001 limit? | yes; no paid Hermes runtime executed |
+
+## Baseline verdict
+
+The AletheIA repository is not yet ready for a real Hermes Agent execution. The correct next step is a separate, human-approved sandbox-install diagnostics slice. Until then, the status is controlled no-go for real Hermes runtime telemetry.


### PR DESCRIPTION
## Summary
- Adds a Hermes/Agentic Stack controlled sandbox-readiness closeout for Issue #100.
- Records that Hermes Agent and Agentic Stack are not currently installed in this environment.
- Preserves the no-go boundary: no real Hermes telemetry, no install in the repo root, no memory/skill promotion, no cron/gateway activation.

## Validation
- `command -v hermes` -> not found
- `command -v hermes-agent` -> not found
- `command -v agentic-stack` -> not found
- clean worktree harness check -> no `.agent/`, `.agents/`, `AGENTS.md`, `CLAUDE.md`, or `ANTIGRAVITY.md`
- `bash scripts/check-governance.sh` -> pass
- `corepack pnpm test:contracts` -> blocked locally because `tsx` / `node_modules` are absent
- `git diff --check` -> pass

## Next boundary
A future issue should be opened only after human approval to install and constrain Hermes Agent + Agentic Stack in a disposable sandbox.

Closes #100
