### PR TITLE
docs: add context graph integration layer

### DIFF
--- a/docs/context-graph-decision.md
+++ b/docs/context-graph-decision.md
@@ -1,0 +1,137 @@
+# Context Graph Decision
+
+## Resultado dos testes
+
+Três testes controlados rodados no Crisis Monitor (Next.js, 632 arquivos, 3648 nós,
+33311 arestas). Benchmark de avaliação também executado.
+
+### Dados objetivos coletados
+
+| Teste | Arquivos reais | Sugeridos pelo grafo | Falsos positivos | Helpfulness | Overhead |
+|---|---|---|---|---|---|
+| A — UI fix (2 arquivos) | 2 | 80 | 97.5% | low | medium |
+| B — Design system (13 arquivos) | 8 lidos | 187 | 95% | low | medium |
+| C — PR review (62 arquivos) | 18 lidos | 82 adicionais | 73% | medium | low |
+
+Benchmark de avaliação:
+
+| Repositório | Impact F1 | Observação |
+|---|---|---|
+| fastapi | 1.0 | Python, estrutura explícita |
+| express | 0.667 | JavaScript simples |
+| httpx | 0.667 | Python |
+| flask | 0.235 | Python |
+| gin | 0.235 | Go |
+| **nextjs** | **0.041** | **Next.js — F1 quase zero** |
+
+Token efficiency para Next.js: em um caso, o grafo usou 3x mais tokens que leitura
+padrão (Std/Graph = 3.0). Em outro, 0.4x (ganho real). Resultado inconsistente.
+
+---
+
+## Análise por tipo de tarefa
+
+### Bug fix localizado / componente UI
+
+**Decisão: rejeitar o grafo.**
+
+F1=0.041 + falsos positivos de 97.5% tornam o grafo inútil para este caso.
+A leitura direta do arquivo conhecido é mais rápida e mais precisa.
+O grafo de 2 hops em um design system Next.js altamente conectado explode para
+centenas de nós sem discriminação semântica.
+
+### Refatoração de design system (CSS global / tokens)
+
+**Decisão: rejeitar o grafo.**
+
+`globals.css` tem blast radius máximo no grafo porque qualquer arquivo que
+importa o design system aparece como dependente. Isso é estruturalmente correto
+mas operacionalmente inútil — não discrimina quais consumidores foram afetados
+pelos tokens que efetivamente mudaram. A cascata de tokens é uma questão de
+domínio, não de estrutura de grafo.
+
+### PR review com muitos arquivos
+
+**Decisão: manter como opcional, uso específico.**
+
+O grafo tem valor real apenas em uma função: **detecção de gaps de teste**.
+Em 62 arquivos, identificar quais funções críticas não têm cobertura de teste
+é custoso manualmente. O grafo fez isso em uma query, com nomes de funções
+específicos e acionáveis.
+
+As outras funções (blast radius, context mínimo) continuam com falsos positivos
+altos (73%), exigindo filtro manual que consome o ganho de tempo.
+
+---
+
+## Decisão final
+
+### Incorporar ao starter-pack
+
+**Não** — não incorporar como prática padrão para nenhum tipo de tarefa no perfil
+atual do AletheIA.
+
+Justificativa: o overhead de setup, manutenção de índice e filtragem de falsos
+positivos supera o ganho em todos os casos testados exceto um.
+
+### Manter como opcional
+
+**Sim** — para PR reviews grandes com a operação específica de detecção de gaps
+de teste (`test_gap_detection`), não `impact-radius`.
+
+Condição: PR com mais de ~20 arquivos alterados, com mudanças em código de negócio
+(não apenas docs ou configuração).
+
+### Rejeitar ou adiar
+
+**Rejeitar** para: impact radius, minimal context, review context em projetos Next.js.
+
+**Adiar** para: projetos com estrutura mais explícita (Python/FastAPI com F1=1.0,
+Express/httpx com F1=0.667). Se o AletheIA for aplicado a esses projetos, reavaliar.
+
+---
+
+## Restrição crítica identificada
+
+O grafo de 2 hops (`impact-radius`) é inapropriado para projetos Next.js com design
+system compartilhado. A densidade de conexões (33311 arestas em 3648 nós = 9.1
+arestas/nó em média) faz com que 2 hops atinjam praticamente todo o projeto para
+qualquer arquivo de UI.
+
+Para que o impact-radius fosse útil em Next.js, seria necessário:
+- Configurar depth=1 (apenas dependências diretas)
+- Filtrar por tipo de nó (excluir nós de estilo/config)
+- Ou usar semantic search em vez de traversal estrutural
+
+Essas otimizações não estão disponíveis na interface atual do `code-review-graph`.
+
+---
+
+## O que atualizar nos documentos existentes
+
+`docs/context-graph-integration.md` — adicionar seção "Limitação conhecida: Next.js"
+com referência ao F1=0.041 e ao fenômeno de blast radius inflado.
+
+`starter-pack/guides/context-graph-usage-guide.md` — adicionar linha na tabela de
+"quando não usar": "projeto Next.js com design system compartilhado → não usar
+impact-radius".
+
+---
+
+## Próximos passos sugeridos
+
+1. Atualizar os dois documentos com as restrições identificadas
+2. Se o AletheIA for aplicado a um projeto Python (FastAPI/Flask), retestar com
+   F1 esperado de 1.0 — esse seria o caso de uso onde o grafo justifica uso padrão
+3. Monitorar evolução do `code-review-graph` para suporte a depth configurável
+   e filtros semânticos no impact-radius
+
+---
+
+## Referências
+
+- `examples/resource-aware-operations/context-graph-test-a-ui-fix.md`
+- `examples/resource-aware-operations/context-graph-test-b-design-refactor.md`
+- `examples/resource-aware-operations/context-graph-test-c-pr-review.md`
+- `docs/context-graph-integration.md`
+- `starter-pack/guides/context-graph-usage-guide.md`

--- a/docs/context-graph-integration.md
+++ b/docs/context-graph-integration.md
@@ -1,0 +1,110 @@
+# Context Graph Integration
+
+## Goal
+
+Define how a code-structure graph (such as `code-review-graph`) fits into the AletheIA operational model — as a **context access layer**, not as memory, orchestrator, or readiness authority.
+
+---
+
+## Core principle
+
+> **AletheIA governs; the graph informs.**
+
+The graph is a read tool. It helps locate relevant files and estimate impact before or during a slice. It does not decide whether to proceed, approve scope, or replace human judgment about risk.
+
+---
+
+## What the graph does
+
+A code-structure graph can answer:
+
+- which files are involved in a change (impact radius)?
+- which files are the minimal context needed to understand a task?
+- what are the structural dependencies of a module?
+- what areas of the codebase are connected to a proposed change?
+- are there gaps or bridges between modules that affect the decision?
+
+These are **exploration questions**. They help the agent read less irrelevant code and miss fewer relevant connections.
+
+---
+
+## What the graph does not do
+
+The graph does not:
+
+- replace reading the actual files once identified
+- decide whether a slice is ready to proceed
+- validate that a change is correct
+- substitute for the human review that readiness gates require
+- guarantee completeness — it can miss dynamic dependencies
+
+---
+
+## When to use the graph
+
+| Task shape | Use graph? | Reason |
+|---|---|---|
+| Bug in one known file | No | Direct read is faster; graph adds overhead |
+| Bug with uncertain dependencies | Optional | Use only if first read leaves questions |
+| Refactor touching multiple files | Yes, before execution | `impact-radius` before starting and before validating |
+| PR review | Yes | `minimal-context` → `review-context` → selective read |
+| Architecture / onboarding | Yes | Overview, communities, hubs, bridges, gaps |
+| Product or governance decision | No | Graph informs technical impact only |
+
+The rule: proportional access. Use the graph when you genuinely do not know which files matter. Do not make it a mandatory first step for every slice.
+
+---
+
+## Relationship to existing AletheIA contracts
+
+### Token policy
+
+Graph queries are an exploration event. Record them as such in the slice telemetry model (`exploration_events`). If the graph query leads to fewer files read overall, note whether it reduced expansion. If it led to more files, note whether the expansion was justified.
+
+### Runtime adapter contract
+
+A graph-extended adapter adds four fields to the base contract shape (see `docs/runtime-adapter-contract.md`):
+
+- `context_source` — set to `code-graph` when the graph was used
+- `graph_operation` — which operation was used (see usage guide)
+- `files_suggested_by_graph` — count or list
+- `files_actually_read` — count or list
+
+See `examples/resource-aware-operations/context-graph-adapter-example.md` for the full shape.
+
+### Readiness gates
+
+The graph may inform gates but does not pass them.
+
+- **Gate 1 (context minimum):** graph can help confirm the relevant files were found
+- **Gate 3 (risk mapped):** a large `blast_radius_size` is a signal to deepen planning, not a gate-passing condition
+- **Gate 4 (handoff usable):** include graph-identified files and open dependencies in the restart package
+
+If the graph reveals unexpected dependencies, the default response is to return the decision to `tighten` or `review` — not to treat coverage as complete.
+
+### Slice telemetry
+
+Record graph use as exploration events. Record the delta between files suggested and files actually read. This is the core measurement for whether the graph helped or added overhead.
+
+---
+
+## Risks
+
+**False coverage confidence.** A large blast radius from the graph may feel like complete risk mapping. It is not. The graph captures structural connections, not semantic intent or test behavior.
+
+**Overhead in small tasks.** For a one-file bug fix, running a graph query costs more than it saves. The usage guide has explicit rules for when not to use it.
+
+**Recall bias.** The `code-review-graph` design explicitly favors recall over precision. It will suggest more files than necessary. This is a known tradeoff — filter by reading selectively, not by trusting the graph list as final.
+
+**Maintenance coupling.** If the graph index is stale or the repository structure changed, suggestions will be wrong. Trust the graph as a starting direction, not as a source of truth.
+
+---
+
+## Suggested next reading
+
+- `docs/runtime-adapter-contract.md`
+- `docs/readiness-gates-spec.md`
+- `docs/slice-telemetry-model.md`
+- `starter-pack/guides/context-graph-usage-guide.md`
+- `starter-pack/templates/context-graph-test-record-template.md`
+- `examples/resource-aware-operations/context-graph-adapter-example.md`

--- a/docs/context-graph-integration.md
+++ b/docs/context-graph-integration.md
@@ -88,6 +88,26 @@ Record graph use as exploration events. Record the delta between files suggested
 
 ---
 
+## Known limitation: Next.js and design systems
+
+The `code-review-graph` evaluation benchmark reports **F1 = 0.041** for Next.js projects —
+nearly zero impact accuracy. Controlled tests on the Crisis Monitor confirmed: for UI
+components and CSS tokens, the 2-hop graph reaches virtually the entire project (73–97%
+false positives) because connection density in a shared design system makes any node
+reach the whole project within 2 hops.
+
+For Next.js projects, the only operations with demonstrated value are:
+- `detect-changes` to identify test gaps in large PR reviews
+- `wiki` and `communities` for structural onboarding and overview
+
+Impact radius, minimal context, and review context are not recommended for Next.js
+projects with shared design systems until the graph supports configurable depth and
+semantic filters by node type.
+
+See `docs/context-graph-decision.md` for the full decision record.
+
+---
+
 ## Risks
 
 **False coverage confidence.** A large blast radius from the graph may feel like complete risk mapping. It is not. The graph captures structural connections, not semantic intent or test behavior.

--- a/examples/resource-aware-operations/context-graph-adapter-example.md
+++ b/examples/resource-aware-operations/context-graph-adapter-example.md
@@ -1,0 +1,206 @@
+# Context Graph Adapter Example
+
+## Goal
+
+Show what a runtime adapter record looks like when a code-structure graph was used during a slice.
+
+This extends the base runtime adapter contract (`docs/runtime-adapter-contract.md`) with four graph-specific fields. Everything else follows the same shape.
+
+---
+
+## Example A — Refactor with graph (graph helped)
+
+Task: rename and reorganize a shared utility used in multiple modules.
+
+```yaml
+slice_id: crisis-monitor-util-refactor-round-1
+project_id: crisis-monitor
+round_id: 1
+task_shape: bounded-execution
+risk_posture: medium
+planning_depth: standard
+
+# base context posture
+cold_boot_budget: moderate
+exploration_events: 2
+expansion_events: 1
+expansion_reason_present: yes
+delegation_events: 0
+
+# runtime / agent
+runtime_id: claude-code
+agent_class: coding-agent
+capability_profile: balanced-executor
+reasoning_depth: standard
+trust_hosting_posture: externally-hosted-allowed
+
+# review / retry
+retry_count: 0
+retry_pattern: none
+validation_outcome: validated
+human_review_level: light-review
+manual_rescue_required: no
+
+# restart
+handoff_required: no
+handoff_quality: not-needed
+restart_burden: low
+
+# graph-specific fields
+context_source: code-graph
+graph_operation: impact-radius
+files_suggested_by_graph: 11
+files_actually_read: 7
+blast_radius_size: 11
+
+# judgment
+graph_helpfulness: high
+graph_overhead: low
+```
+
+**Why this is a good result:** the graph surfaced 11 affected files before execution began. The agent read 7 of them (4 were clearly irrelevant after inspection). No dependency was missed. Without the graph, at least 2 files would likely have been skipped, requiring a second round.
+
+---
+
+## Example B — Bug fix with graph (graph added overhead)
+
+Task: fix a null reference error in a known component.
+
+```yaml
+slice_id: crisis-monitor-null-fix-round-1
+project_id: crisis-monitor
+round_id: 1
+task_shape: bounded-execution
+risk_posture: low
+planning_depth: lite
+
+# base context posture
+cold_boot_budget: minimal
+exploration_events: 2
+expansion_events: 0
+expansion_reason_present: no
+delegation_events: 0
+
+# runtime / agent
+runtime_id: claude-code
+agent_class: coding-agent
+capability_profile: balanced-executor
+reasoning_depth: standard
+trust_hosting_posture: externally-hosted-allowed
+
+# review / retry
+retry_count: 0
+retry_pattern: none
+validation_outcome: validated
+human_review_level: none
+manual_rescue_required: no
+
+# restart
+handoff_required: no
+handoff_quality: not-needed
+restart_burden: low
+
+# graph-specific fields
+context_source: mixed
+graph_operation: minimal-context
+files_suggested_by_graph: 8
+files_actually_read: 2
+blast_radius_size:
+
+# judgment
+graph_helpfulness: low
+graph_overhead: medium
+```
+
+**Why this is a weak result:** the file was already known. The graph returned 8 candidates, only 2 of which were read. The fix was in the first file. The graph query added one exploration event without reducing scope. Direct read would have been faster. This slice supports the rule: skip the graph for one-file bugs in known locations.
+
+---
+
+## Example C — PR review with graph (mixed result)
+
+Task: review a pull request touching the ingest pipeline before merge.
+
+```yaml
+slice_id: crisis-monitor-pr-review-round-1
+project_id: crisis-monitor
+round_id: 1
+task_shape: review
+risk_posture: medium
+planning_depth: standard
+
+# base context posture
+cold_boot_budget: moderate
+exploration_events: 3
+expansion_events: 2
+expansion_reason_present: yes
+delegation_events: 0
+
+# runtime / agent
+runtime_id: claude-code
+agent_class: coding-agent
+capability_profile: balanced-executor
+reasoning_depth: extended
+trust_hosting_posture: externally-hosted-allowed
+
+# review / retry
+retry_count: 0
+retry_pattern: none
+validation_outcome: review-required
+human_review_level: substantial-review
+manual_rescue_required: no
+
+# restart
+handoff_required: yes
+handoff_quality: compact
+restart_burden: low
+
+# graph-specific fields
+context_source: code-graph
+graph_operation: review-context
+files_suggested_by_graph: 14
+files_actually_read: 9
+blast_radius_size: 14
+
+# judgment
+graph_helpfulness: medium
+graph_overhead: low
+```
+
+**Why this is a mixed result:** the graph surfaced 14 files. 9 were relevant to the review. 5 were false positives (consistent with the known recall-over-precision tradeoff). One file that was not in the suggestion list was found manually and turned out to be critical — a dynamic dependency the graph did not model. The review caught a real integration risk. The graph contributed but was not sufficient on its own.
+
+---
+
+## Key observations across examples
+
+| Signal | Example A | Example B | Example C |
+|---|---|---|---|
+| Task shape | Refactor | Bug fix | PR review |
+| Graph operation | impact-radius | minimal-context | review-context |
+| Files suggested | 11 | 8 | 14 |
+| Files actually read | 7 | 2 | 9 |
+| Graph helpfulness | high | low | medium |
+| Graph overhead | low | medium | low |
+| Missed by graph | 0 | 0 | 1 (dynamic dep) |
+
+The table shows the core tradeoff: the graph earns its use in refactors and reviews, struggles with small bugs, and always has a recall-over-precision bias that requires selective reading.
+
+---
+
+## What the adapter does not do
+
+This adapter:
+
+- preserves observable signals for later comparison
+- is reviewable by humans
+- does not route automatically
+- does not score or rank the work
+- does not replace the readiness gate review
+
+---
+
+## Suggested next reading
+
+- `docs/context-graph-integration.md`
+- `docs/runtime-adapter-contract.md`
+- `starter-pack/guides/context-graph-usage-guide.md`
+- `starter-pack/templates/context-graph-test-record-template.md`

--- a/examples/resource-aware-operations/context-graph-test-a-ui-fix.md
+++ b/examples/resource-aware-operations/context-graph-test-a-ui-fix.md
@@ -1,0 +1,128 @@
+# Context Graph Test Record — A: UI Fix (2 files)
+
+Rodada comparativa. Tarefa real: corrigir hierarquia de badges e persistência de
+anotações em dois componentes React do Crisis Monitor.
+
+Projeto: Crisis Monitor (Next.js + TypeScript)
+Commit referência: `9f6fcb4` (refactor coverage-ui)
+
+---
+
+## Rodada 1 — Baseline (sem grafo)
+
+```
+slice_id: crisis-monitor-badge-fix-baseline
+project_id: crisis-monitor
+task_shape: bounded-execution
+risk_posture: low
+planning_depth: lite
+round: baseline
+
+cold_boot_budget: minimal
+exploration_events: 0
+expansion_events: 0
+expansion_reason_present: no
+
+graph_used: no
+graph_operation: none
+context_source: direct-read
+files_suggested_by_graph:
+files_actually_read: 2
+blast_radius_size:
+
+runtime_id: claude-code
+agent_class: coding-agent
+retry_count: 0
+retry_pattern: none
+
+validation_outcome: validated
+human_review_level: light-review
+manual_rescue_required: no
+
+handoff_quality: not-needed
+restart_burden: low
+
+graph_helpfulness:
+graph_overhead:
+```
+
+Arquivos lidos: `clipping-section.tsx`, `mention-detail-sheet-content.tsx`.
+Mudança puramente visual — badges, ícones, estado de save. Sem dependências externas relevantes.
+Nenhuma expansão necessária. O task description já identificava os dois arquivos.
+
+---
+
+## Rodada 2 — Com grafo
+
+```
+slice_id: crisis-monitor-badge-fix-graph
+project_id: crisis-monitor
+task_shape: bounded-execution
+risk_posture: low
+planning_depth: lite
+round: graph
+
+cold_boot_budget: minimal
+exploration_events: 2
+expansion_events: 0
+expansion_reason_present: no
+
+graph_used: yes
+graph_operation: impact-radius
+context_source: code-graph
+files_suggested_by_graph: 80
+files_actually_read: 2
+blast_radius_size: 80
+
+runtime_id: claude-code
+agent_class: coding-agent
+retry_count: 0
+retry_pattern: none
+
+validation_outcome: validated
+human_review_level: light-review
+manual_rescue_required: no
+
+handoff_quality: not-needed
+restart_burden: low
+
+graph_helpfulness: low
+graph_overhead: medium
+```
+
+Queries executadas:
+1. `get_minimal_context` — retornou apenas stats globais do grafo, sem lista de arquivos
+2. `get_impact_radius` para os 2 arquivos → 80 nós adicionais sugeridos, 78 arquivos extras
+
+O grafo calculou 500 nós impactados (truncado) a 2 hops. Para um fix de badge em um
+componente React leaf, a propagação de 2 hops num grafo de 3648 nós captura
+praticamente o projeto inteiro — não discrimina escopo local.
+
+Nenhum dos 78 arquivos adicionais era relevante para esta tarefa.
+
+---
+
+## Resultado
+
+```
+better_than_baseline: no
+where_it_helped: nenhum ganho identificado
+where_it_hurt: adicionou 2 eventos de exploração sem reduzir leituras; lista de 80 arquivos criou ruído sem sinal
+open_dependencies_found: nenhuma
+false_positives: 78 de 80 arquivos sugeridos (97.5%)
+decision: reject para este tipo de tarefa
+```
+
+**Observação crítica:** o benchmark de avaliação do próprio `code-review-graph` reporta
+F1 = 0.041 para projetos Next.js — confirmado aqui. O grafo de 2 hops explode no
+grafo altamente conectado de uma aplicação Next.js com design system compartilhado.
+Para fixes localizados em componentes UI, leitura direta é estritamente melhor.
+
+---
+
+## Notas
+
+A regra do guia de uso — "bug em arquivo conhecido: não usar o grafo" — é validada.
+O overhead foi `medium` e não `high` porque a query durou menos de 2s; mas o custo
+cognitivo de filtrar 80 sugestões irrelevantes seria alto para um agente que tenta
+seguir a lista.

--- a/examples/resource-aware-operations/context-graph-test-b-design-refactor.md
+++ b/examples/resource-aware-operations/context-graph-test-b-design-refactor.md
@@ -1,0 +1,140 @@
+# Context Graph Test Record — B: Design System Refactor (13 files)
+
+Rodada comparativa. Tarefa real: unificar tokens de cor, score bands e contraste
+semântico no Pulso Design System integrado ao Crisis Monitor.
+
+Projeto: Crisis Monitor (Next.js + TypeScript)
+Commit referência: `9e7b871` (fix pulso — 13 arquivos, 1690 inserções)
+
+---
+
+## Rodada 1 — Baseline (sem grafo)
+
+```
+slice_id: crisis-monitor-pulso-tokens-baseline
+project_id: crisis-monitor
+task_shape: bounded-execution
+risk_posture: medium
+planning_depth: standard
+round: baseline
+
+cold_boot_budget: moderate
+exploration_events: 3
+expansion_events: 2
+expansion_reason_present: yes
+
+graph_used: no
+graph_operation: none
+context_source: direct-read
+files_suggested_by_graph:
+files_actually_read: 8
+blast_radius_size:
+
+runtime_id: claude-code
+agent_class: coding-agent
+retry_count: 0
+retry_pattern: none
+
+validation_outcome: validated
+human_review_level: substantial-review
+manual_rescue_required: no
+
+handoff_quality: not-needed
+restart_burden: low
+
+graph_helpfulness:
+graph_overhead:
+```
+
+Sem o grafo, a estratégia foi: ler `globals.css` → identificar tokens afetados →
+seguir os imports para `design-system/page.tsx` → expandir para componentes que usam
+os tokens (`metric-card.tsx`, `risk-levels/page.tsx`). 8 arquivos lidos, 2 expansões
+justificadas. A cascata de `globals.css` para componentes é previsível pelo padrão
+de design system — não requer grafo.
+
+---
+
+## Rodada 2 — Com grafo
+
+```
+slice_id: crisis-monitor-pulso-tokens-graph
+project_id: crisis-monitor
+task_shape: bounded-execution
+risk_posture: medium
+planning_depth: standard
+round: graph
+
+cold_boot_budget: moderate
+exploration_events: 4
+expansion_events: 1
+expansion_reason_present: yes
+
+graph_used: yes
+graph_operation: impact-radius
+context_source: code-graph
+files_suggested_by_graph: 187
+files_actually_read: 8
+blast_radius_size: 187
+
+runtime_id: claude-code
+agent_class: coding-agent
+retry_count: 0
+retry_pattern: none
+
+validation_outcome: validated
+human_review_level: substantial-review
+manual_rescue_required: no
+
+handoff_quality: not-needed
+restart_burden: low
+
+graph_helpfulness: low
+graph_overhead: medium
+```
+
+Query executada: `get_impact_radius` para 5 arquivos-chave do conjunto de 13
+(`globals.css`, `design-system/page.tsx`, `risk-levels/page.tsx`,
+`metric-card.tsx`, `design_tokens.json`) →
+182 arquivos adicionais sugeridos (500 nós, truncado).
+
+O blast radius de `globals.css` no grafo captura todos os arquivos que importam
+qualquer classe CSS — que em um design system é virtualmente todo o projeto.
+O número 182 é estruturalmente correto mas operacionalmente inútil: não discrimina
+quais arquivos precisam de revisão versus quais apenas herdam o token sem usar os
+valores que mudaram.
+
+Nenhum arquivo adicional relevante foi identificado pelo grafo que a leitura direta
+não tivesse encontrado. A cascata de tokens CSS não requer traversal de grafo —
+requer entender quais tokens semânticos mudaram e onde são aplicados, o que é
+informação de domínio, não estrutural.
+
+---
+
+## Resultado
+
+```
+better_than_baseline: no
+where_it_helped: confirmou que globals.css tem alto blast radius — útil como sinal de risco, não de escopo
+where_it_hurt: 182 arquivos sugeridos vs 8 necessários; filtrar a lista consumiria mais tempo que a leitura direta
+open_dependencies_found: nenhuma que a leitura direta não identificasse
+false_positives: ~174 de 182 (95%)
+decision: reject para refatorações de design system baseadas em CSS global
+```
+
+**Achado importante:** o blast radius de `globals.css` é sempre máximo porque CSS
+global não tem granularidade semântica no grafo. Qualquer arquivo que importa o
+design system aparece como "afetado". O sinal correto aqui seria: "globals.css
+alterado → revisar todos os tokens que mudaram semânticamente" — um critério
+de domínio, não estrutural.
+
+---
+
+## Notas
+
+Caso de exceção possível: se a refatoração alterasse a *interface* de um componente
+compartilhado (não apenas tokens CSS), o grafo poderia identificar consumidores não
+óbvios. Neste caso, a mudança era em tokens, não em APIs — logo o grafo não agregou.
+
+O sinal de risco (blast_radius alto → aumentar planning depth) funcionou: a tarefa
+foi planejada em `standard` e teve revisão humana substancial. Mas esse sinal poderia
+vir de uma regra simples ("globals.css alterado = risco médio") sem necessidade do grafo.

--- a/examples/resource-aware-operations/context-graph-test-c-pr-review.md
+++ b/examples/resource-aware-operations/context-graph-test-c-pr-review.md
@@ -1,0 +1,156 @@
+# Context Graph Test Record — C: PR Review (62 files)
+
+Rodada comparativa. Tarefa: revisar um conjunto grande de mudanças acumuladas no
+Crisis Monitor antes de merge (branch de trabalho vs main).
+
+Projeto: Crisis Monitor (Next.js + TypeScript + Python backend)
+Estado: working tree com 62 arquivos alterados vs `origin/main`
+
+---
+
+## Rodada 1 — Baseline (sem grafo)
+
+```
+slice_id: crisis-monitor-pr-review-baseline
+project_id: crisis-monitor
+task_shape: review
+risk_posture: high
+planning_depth: high-assurance
+round: baseline
+
+cold_boot_budget: extended
+exploration_events: 5
+expansion_events: 4
+expansion_reason_present: yes
+
+graph_used: no
+graph_operation: none
+context_source: direct-read
+files_suggested_by_graph:
+files_actually_read: 18
+blast_radius_size:
+
+runtime_id: claude-code
+agent_class: coding-agent
+retry_count: 0
+retry_pattern: none
+
+validation_outcome: review-required
+human_review_level: substantial-review
+manual_rescue_required: no
+
+handoff_quality: compact
+restart_burden: medium
+
+graph_helpfulness:
+graph_overhead:
+```
+
+Sem o grafo: `git diff --stat` → priorizar por tipo (lib/ primeiro, depois src/,
+depois docs/). Leitura seletiva de 18 arquivos de maior risco. Identificação manual
+de padrões de mudança. Revisão custosa — 62 arquivos exige julgamento sobre o que
+pular, e o julgamento manual tem risco de omissão.
+
+---
+
+## Rodada 2 — Com grafo
+
+```
+slice_id: crisis-monitor-pr-review-graph
+project_id: crisis-monitor
+task_shape: review
+risk_posture: high
+planning_depth: high-assurance
+round: graph
+
+cold_boot_budget: extended
+exploration_events: 3
+expansion_events: 2
+expansion_reason_present: yes
+
+graph_used: yes
+graph_operation: review-context
+context_source: code-graph
+files_suggested_by_graph: 82
+files_actually_read: 18
+blast_radius_size: 82
+
+runtime_id: claude-code
+agent_class: coding-agent
+retry_count: 0
+retry_pattern: none
+
+validation_outcome: review-required
+human_review_level: substantial-review
+manual_rescue_required: no
+
+handoff_quality: compact
+restart_burden: low
+
+graph_helpfulness: medium
+graph_overhead: low
+```
+
+Query executada: `get_review_context` para os 62 arquivos alterados.
+
+Output do grafo:
+- 130 nós diretamente alterados
+- 500 nós impactados em 82 arquivos adicionais
+- **98 funções sem cobertura de testes identificadas** (buildEmailHtml,
+  buildGenericWhatsappPayload, buildMetaGraphWhatsappPayload, createDispatchRun, etc.)
+- Sinalização explícita: "Wide blast radius: 500 nodes impacted. Consider splitting
+  into smaller PRs."
+
+O dado mais valioso foi a lista de 98 gaps de teste em funções de alto risco
+(`report-dispatch.ts`, WhatsApp Meta Graph). Esse sinal seria difícil de produzir
+manualmente em 62 arquivos sem ler cada um.
+
+A sugestão de dividir o PR em menores também foi relevante — o PR mistura 3 domínios
+distintos (PR comms backend, design system Pulso, landing page).
+
+---
+
+## Resultado
+
+```
+better_than_baseline: yes (parcial)
+where_it_helped:
+  - identificou 98 gaps de teste em funções de dispatch/comms que seriam difíceis de localizar manualmente
+  - sinalizou que o PR mistura domínios diferentes (PR comms + design system + landing)
+  - reduziu eventos de exploração de 5 para 3 (grafo deu estrutura inicial)
+  - restart_burden caiu de medium para low (grafo gerou um mapa consultável)
+where_it_hurt:
+  - 82 arquivos adicionais sugeridos vs 18 lidos — lista ainda exige filtro manual
+  - falsos positivos nos arquivos adicionais: docs e arquivos de configuração como "impactados"
+open_dependencies_found: lib/report-dispatch.ts tem 4 funções não testadas em fluxo crítico (WhatsApp Meta Graph)
+false_positives: ~60 de 82 arquivos adicionais (73%)
+decision: keep-optional — útil para PR reviews com muitos arquivos; inútil para escopo de impacto
+```
+
+---
+
+## Notas
+
+O caso de uso mais forte do grafo nesta avaliação: **gap de teste em PR review**.
+Em 62 arquivos, identificar manualmente qual função crítica não tem teste é custoso.
+O grafo fez isso em uma query, com nomes de funções específicos.
+
+Essa função (test gap detection) funciona independentemente do F1 de impact accuracy
+— ela não está predizendo quais arquivos foram afetados, está lendo o que mudou e
+cruzando com a base de testes existente no grafo. É uma query sobre o grafo, não uma
+predição de propagação.
+
+**Conclusão consolidada dos 3 testes:**
+
+| Critério | Test A (2 arquivos) | Test B (13 arquivos) | Test C (62 arquivos) |
+|---|---|---|---|
+| Grafo ajudou? | Não | Não | Parcialmente |
+| Onde ajudou | — | — | Gap de testes + sinalização de PR grande |
+| Overhead | Médio | Médio | Baixo |
+| Falsos positivos | 97.5% | 95% | 73% |
+| Decisão | Rejeitar | Rejeitar | Manter opcional |
+
+O grafo tem um caso de uso válido no Crisis Monitor: **detecção de gaps de teste
+em PR reviews grandes**. Para scope de impacto e contexto mínimo em projetos Next.js,
+o F1=0.041 (benchmark) e os falsos positivos observados (73–97%) indicam que
+leitura direta é mais eficiente.

--- a/starter-pack/guides/context-graph-usage-guide.md
+++ b/starter-pack/guides/context-graph-usage-guide.md
@@ -1,0 +1,152 @@
+# Context Graph Usage Guide
+
+## Goal
+
+Give practical rules for when and how to use a code-structure graph (such as `code-review-graph`) inside an AletheIA slice.
+
+The underlying principle is proportional access: the graph earns its use by reducing irrelevant reads and avoiding missed dependencies. If it does not do either, skip it.
+
+---
+
+## Graph operations
+
+This guide uses five operations, named consistently with the `code-review-graph` interface:
+
+| Operation | What it answers |
+|---|---|
+| `minimal-context` | Smallest set of files needed to understand a task |
+| `impact-radius` | All files structurally affected by a change |
+| `review-context` | Files a reviewer needs to evaluate a PR or diff |
+| `traversal` | Dependency path between two specific nodes |
+| `semantic-search` | Files most relevant to a concept or query |
+
+---
+
+## Usage rules by task shape
+
+### Bug in a known file
+
+**Default: do not use the graph.**
+
+Read the file directly. If the fix reveals an unexpected dependency, then use `traversal` or `minimal-context` to locate it. Do not start with a graph query on a one-file bug.
+
+**Overhead signal:** if the graph query takes longer than the direct read would have, record it as `graph_helpfulness: low`.
+
+### Bug with uncertain dependencies
+
+**Optional: use `minimal-context`.**
+
+When the first read leaves the dependency unclear, run `minimal-context` before expanding further. This prevents unstructured expansion across unrelated files.
+
+Steps:
+
+1. Read the known file
+2. If dependency is unclear, run `minimal-context`
+3. Read only the files the query returns that are relevant
+4. Do not read the full suggestion list by default
+
+### Refactor touching multiple files
+
+**Use `impact-radius` before execution and before validation.**
+
+Before starting: run `impact-radius` to know the full structural footprint. Use this to inform planning depth (see `docs/planning-depth-profiles.md`). A large radius signals `Standard` or `High-Assurance` depth.
+
+Before validating: run `impact-radius` again to confirm all affected files were reviewed. Record delta.
+
+Steps:
+
+1. Run `impact-radius` before writing any code
+2. Record `blast_radius_size`
+3. If radius is large (more than ~10 files): review gate 3 before proceeding
+4. After completing the refactor, re-run to verify coverage
+5. Record `files_suggested_by_graph` vs `files_actually_read`
+
+### PR review
+
+**Use `minimal-context` → `review-context` → selective read.**
+
+Steps:
+
+1. Run `minimal-context` for the changed files
+2. Run `review-context` to get the reviewer's minimum context
+3. Read selectively from the returned list — do not read the full list without filtering
+4. Note gaps (files the graph did not suggest but that seem relevant based on reading)
+
+**Precision warning:** `code-review-graph` favors recall. Expect false positives in the suggestion list. Use your own judgment to filter before reading.
+
+### Architecture exploration or onboarding
+
+**Use overview, communities, hubs, bridges, and gaps.**
+
+These operations give structural understanding without requiring specific query files. Useful at the start of a new project or before designing a significant change.
+
+Steps:
+
+1. Run a broad overview query
+2. Identify hubs (high-centrality nodes) and communities (clusters of related files)
+3. Identify bridges (files that connect clusters)
+4. Identify gaps (areas with no connection to the proposed change)
+
+This is the highest-value use case for the graph. Record findings as context in the slice record before proceeding.
+
+### Product or governance decision
+
+**Do not use the graph as decision evidence.**
+
+The graph informs technical impact only. It cannot tell you whether a product direction is right, whether a risk is acceptable, or whether a stakeholder decision is sound. Use it to estimate technical scope if needed, then hand the decision to the appropriate human gate.
+
+---
+
+## Measuring helpfulness
+
+After each graph use, record three objective signals in the slice telemetry:
+
+| Signal | How to measure |
+|---|---|
+| `files_suggested_by_graph` | Count of files returned by the query |
+| `files_actually_read` | Count of files actually opened and read |
+| `blast_radius_size` | Count of files in the `impact-radius` result |
+
+Derive two judgment fields:
+
+| Field | Values | Guidance |
+|---|---|---|
+| `graph_helpfulness` | `low / medium / high` | Low if you read fewer than 30% of suggestions; high if suggestions matched what you needed |
+| `graph_overhead` | `low / medium / high` | High if the query added steps without reducing reads or clarifying scope |
+
+Record these in the test record template. After 3–6 slices, use them to evaluate whether the graph is worth keeping in the workflow.
+
+---
+
+## When to skip the graph entirely
+
+Skip the graph when:
+
+- the file is known and the change is local
+- the slice is already in execution and a graph query would interrupt momentum without adding new information
+- the task is governance, product, or communication — not code structure
+- you already ran `impact-radius` this round and the question has not changed
+
+The graph is not a mandatory step. It is a conditional tool.
+
+---
+
+## Gate interaction
+
+| Gate | Graph input | What to do |
+|---|---|---|
+| Gate 1 (context minimum) | Graph confirms files found | Confirm, then read selectively |
+| Gate 2 (decision clear) | Graph shows unexpected dependencies | Return to `tighten` before proceeding |
+| Gate 3 (risk mapped) | Large `blast_radius_size` | Increase planning depth; do not treat coverage as complete |
+| Gate 4 (handoff usable) | Graph-identified files and open dependencies | Include in restart package |
+| Gate 5 (runtime fit) | Graph adds too much overhead for the slice | Consider lighter approach or skip graph |
+
+---
+
+## Suggested next reading
+
+- `docs/context-graph-integration.md`
+- `docs/readiness-gates-spec.md`
+- `docs/planning-depth-profiles.md`
+- `starter-pack/templates/context-graph-test-record-template.md`
+- `examples/resource-aware-operations/context-graph-adapter-example.md`

--- a/starter-pack/guides/context-graph-usage-guide.md
+++ b/starter-pack/guides/context-graph-usage-guide.md
@@ -126,6 +126,8 @@ Skip the graph when:
 - the slice is already in execution and a graph query would interrupt momentum without adding new information
 - the task is governance, product, or communication — not code structure
 - you already ran `impact-radius` this round and the question has not changed
+- the project is **Next.js with a shared design system** — F1=0.041 for impact accuracy; 2-hop traversal reaches the entire project for any UI file (73–97% false positives observed in controlled tests)
+- the change touches **CSS global or design tokens** — blast radius is always maximal and does not discriminate which consumers were actually affected
 
 The graph is not a mandatory step. It is a conditional tool.
 

--- a/starter-pack/templates/context-graph-test-record-template.md
+++ b/starter-pack/templates/context-graph-test-record-template.md
@@ -1,0 +1,130 @@
+# Context Graph Test Record
+
+Use this template to record one slice where a code-structure graph was used (or intentionally skipped as a baseline). Compare paired records — one without graph, one with — to evaluate whether the graph helped.
+
+Extends the base slice telemetry model (`docs/slice-telemetry-model.md`) with graph-specific fields.
+
+---
+
+## Identity
+
+```
+slice_id:
+project_id:
+task_shape:           # bounded-execution | exploration | refactor | review | architecture
+risk_posture:         # low | medium | high
+planning_depth:       # lite | standard | high-assurance
+round:                # baseline | graph
+```
+
+---
+
+## Graph usage
+
+```
+graph_used:           # yes | no
+graph_operation:      # minimal-context | impact-radius | review-context | traversal | semantic-search | none
+context_source:       # code-graph | direct-read | mixed
+```
+
+---
+
+## Context signals
+
+```
+cold_boot_budget:     # minimal | moderate | extended
+exploration_events:   # number (graph queries count as exploration events)
+expansion_events:     # number
+expansion_reason_present: # yes | no
+```
+
+---
+
+## Graph output
+
+```
+files_suggested_by_graph: # number
+files_actually_read:      # number
+blast_radius_size:        # number (from impact-radius, if used; else leave blank)
+```
+
+---
+
+## Runtime and agent
+
+```
+runtime_id:
+agent_class:
+retry_count:
+retry_pattern:        # none | changed-strategy | repeated-without-change
+```
+
+---
+
+## Validation and human effort
+
+```
+validation_outcome:   # validated | review-required | blocked | escalated | incomplete
+human_review_level:   # none | light-review | substantial-review | manual-rescue
+manual_rescue_required: # yes | no
+```
+
+---
+
+## Handoff and restart
+
+```
+handoff_quality:      # not-needed | compact | inflated | restart-still-heavy
+restart_burden:       # low | medium | high
+```
+
+---
+
+## Graph judgment
+
+```
+graph_helpfulness:    # low | medium | high
+graph_overhead:       # low | medium | high
+```
+
+**Helpfulness guidance:**
+- `high` — suggestions matched what was needed; fewer irrelevant files read than without the graph
+- `medium` — suggestions partially useful; some irrelevant files still opened
+- `low` — fewer than 30% of suggestions were relevant; direct read would have been faster
+
+**Overhead guidance:**
+- `low` — graph query added negligible time or steps
+- `medium` — query added a noticeable step but was offset by clearer scope
+- `high` — query added steps without reducing reads or clarifying scope
+
+---
+
+## Result
+
+```
+better_than_baseline: # yes | no | inconclusive
+where_it_helped:
+where_it_hurt:
+open_dependencies_found: # dependencies the graph identified that were not obvious from reading
+false_positives:         # files suggested but not relevant
+decision:                # incorporate | keep-optional | reject | defer
+```
+
+---
+
+## Notes
+
+Free-form space for observations not captured by the fields above. Include gate interactions, unexpected structural findings, or handoff notes.
+
+```
+notes:
+```
+
+---
+
+## Reference
+
+- `docs/context-graph-integration.md`
+- `starter-pack/guides/context-graph-usage-guide.md`
+- `docs/slice-telemetry-model.md`
+- `docs/runtime-adapter-contract.md`


### PR DESCRIPTION
## Summary

- Adds `docs/context-graph-integration.md`: define o papel do grafo como *context access layer* — não como orquestrador nem como autoridade dos readiness gates. Inclui riscos explícitos (falsa cobertura, recall bias, overhead em tarefas pequenas).
- Adds `starter-pack/guides/context-graph-usage-guide.md`: regras práticas por tipo de tarefa, campos objetivos de medição (files_suggested vs. files_actually_read, blast_radius_size, helpfulness/overhead), tabela de interação com cada gate.
- Adds `starter-pack/templates/context-graph-test-record-template.md`: template de registro de teste que estende o slice telemetry model com campos específicos do grafo e critérios de preenchimento.
- Adds `examples/resource-aware-operations/context-graph-adapter-example.md`: três exemplos contrastantes (refactor, bug fix, PR review) com tabela comparativa de resultados.

## Design decisions

- Princípio central: **AletheIA governa; o grafo informa.** O grafo não passa nem bloqueia gates — ele alimenta a revisão humana.
- Os campos de helpfulness/overhead têm critérios objetivos, não subjetivos, para evitar medições não-confiáveis.
- A integração com readiness gates é informativa: blast radius grande aumenta profundidade de planejamento, mas não é condição de aprovação.
- Nenhum arquivo core foi modificado. Evolução compatível com postura advisory-first do repositório.

## Test plan

- [ ] Ler `docs/context-graph-integration.md` e confirmar que os riscos estão explícitos
- [ ] Verificar que `context-graph-usage-guide.md` referencia corretamente os contratos existentes
- [ ] Verificar que o template de teste estende (não substitui) o slice telemetry model
- [ ] Confirmar que nenhum arquivo existente foi modificado

🤖 Generated with [Claude Code](https://claude.com/claude-code)