### PR TITLE
docs: refresh AletheIA README flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
 # AletheIA
 
-**AletheIA** is an operating framework for AI-assisted work.
+**AletheIA** is an operating framework for AI-assisted work: a portable layer that turns model or agent output into bounded, reviewable, validated action.
 
-It adds an explicit layer between model output and execution so teams can work with:
+![AletheIA operating flow](docs/assets/aletheia-operating-flow.svg)
 
-- clearer framing
-- bounded execution
-- reviewable decisions
-- proportional validation
-- reusable learnings
+AletheIA exists because capable agents still need an operating system around the work: scope, context, governance, validation, handoff and learning. The framework is not trying to replace human judgment or project-local rules. It makes the decision path visible enough that people can trust, review and restart the work.
 
 In short:
 
-`model or agent output -> AletheIA -> governed action`
+```text
+model or agent output -> AletheIA -> governed action
+```
 
 ---
 
@@ -20,10 +18,12 @@ In short:
 
 AletheIA is:
 
-- provider-agnostic
-- reusable across projects
-- focused on bounded, reviewable work
-- designed to preserve continuity across agents, runtimes, and handoffs
+- **provider-agnostic** — it can be applied across models, agents and local runtimes
+- **work-slice oriented** — every meaningful task has a bounded goal, scope, risk and validation path
+- **governance-first** — risky or unclear work can slow down, escalate, require review or stop
+- **restartable** — continuity is carried through handoffs and restart packages, not fragile transcript memory
+- **evidence-seeking** — proof is part of closure, not a decorative afterthought
+- **learning-oriented** — repeated friction and validation failures can become durable, reviewable improvements
 
 ## What AletheIA is not
 
@@ -31,66 +31,99 @@ AletheIA is not:
 
 - a chatbot
 - a single-runtime wrapper
-- a hidden auto-router
+- a hidden autonomous router
+- a replacement for human accountability
 - a substitute for project-local operating rules
+- a claim that every future tooling or enterprise track is already complete
 
 ---
 
-## How AletheIA works
+## How the operating loop works
 
-```mermaid
-flowchart LR
-    A["Model or agent output"] --> B["Intent and context framing"]
-    B --> C["Decision and governance"]
-    C --> D["Bounded execution"]
-    D --> E["Validation and review"]
-    E --> F["Learnings and durable continuity"]
-    F --> G["Governed action or restartable handoff"]
+AletheIA moves work from a loose prompt-output pattern into an explicit operating loop:
+
+```text
+signal -> framing -> context -> governance -> bounded execution -> validation -> learning / restartable handoff
 ```
 
-The framework helps teams move from:
+That means the framework asks practical questions before treating output as executable:
 
-`prompt -> output -> execution`
-
-into:
-
-`intent -> context -> decision -> execution -> validation -> learning`
-
-That shift is the core value of AletheIA.
+1. **What is the work slice?**  
+   Define the goal, scope, risk, assumptions and stop line.
+2. **What context is enough?**  
+   Load the context needed for the slice without turning every transcript into mandatory state.
+3. **What decision is being made?**  
+   Allow, slow down, escalate, block, hand off or restart.
+4. **What execution surface is appropriate?**  
+   Keep runtime choice explicit instead of pretending every agent has the same trust boundary.
+5. **What proof closes the slice?**  
+   Use proportional validation: tests, review, smoke checks, artifacts or documented evidence.
+6. **What survives the boundary?**  
+   Preserve durable decisions, restart packages, handoffs and learnings.
 
 ---
 
-## What makes AletheIA different
+## Current status
 
-AletheIA is not only a workflow-control layer.
-It also provides:
+AletheIA is at **1.0.0**.
 
-- **Governed decisions** — the framework can help decide when work should continue, slow down, escalate, or require review
-- **Context and token discipline** — context expansion is treated as something to justify, not something to do by reflex
-- **Runtime and trust-boundary awareness** — hosted vs local posture, runtime fit, and operational boundaries are part of the model
-- **Restartable continuity** — handoffs, restart packages, and finalization are designed to survive runtime changes without transcript replay
-- **Validation before closure** — proof is part of the work, not an optional afterthought
-- **Learning from real work** — pilot evidence, failed validation, and repeated friction can become durable learnings instead of disappearing into chat history
+What 1.0 means:
+
+- the Alpha 1–7 baseline is complete enough for public reuse
+- the core vocabulary and adoption path are stable enough to teach and apply
+- new work now belongs to **1.x evolution tracks**, not unfinished baseline buildup
+
+What 1.0 does **not** mean:
+
+- enterprise-ready by default
+- fully automated orchestration
+- completed domain governance packs
+- active delivery tooling implementation
+- universal runtime enforcement
+
+### Recent evolution
+
+The active post-1.0 work has moved in three important directions:
+
+- **1.1 constrained adoption / trust-boundary hardening**  
+  Guidance for safer adoption in local, regulated or high-context environments.
+- **1.2 resource-aware operations**  
+  Advisory observability for context size, restart cost, handoff weight, retry waste, runtime fit and human review effort.
+- **clean restart and project-local constitution patterns**  
+  Stronger restart packages, local governing-context prompts and explicit fresh-thread signaling without making any one runtime command part of the portable core.
+
+For release framing, see:
+
+- `CHANGELOG.md`
+- `docs/release-1.0-readiness.md`
+- `docs/roadmap-alpha.md`
+- `docs/enterprise-readiness-roadmap.md`
+- `docs/resource-aware-operations-roadmap.md`
 
 ---
 
 ## Core concepts
 
-AletheIA keeps a stable core vocabulary so the framework does not get redefined by one tracker, one chat surface, or one runtime.
+AletheIA keeps a stable vocabulary so the framework is not redefined by one tracker, one chat surface or one runtime.
 
 The most important concepts are:
 
 - **Work Slice** — the bounded unit of operational work
 - **Work Item** — the external coordination unit a slice may point to
-- **Restart Package** — the compact continuity artifact used after a boundary
-- **Handoff** — the transition artifact that carries work across a meaningful boundary
+- **Context Pack** — the explicit context selected for a slice
+- **Decision Record** — the reviewable reason for continuing, slowing down, escalating or stopping
 - **Execution Surface** — the local runtime where work happens
-- **Agent Role** — the portable semantic responsibility of an agent boundary
 - **Runtime Adapter** — the runtime-local mapping that preserves framework meaning
+- **Handoff** — the transition artifact for a meaningful boundary
+- **Restart Package** — the compact continuity artifact used after a boundary
+- **Learning Record** — a reviewable improvement extracted from real work
 
-For the canonical definitions, start with:
+Canonical definitions start here:
 
 - `docs/canonical-vocabulary.md`
+- `docs/canonical-definitions.md`
+- `docs/work-slice-pattern.md`
+- `docs/runtime-adapter-contract.md`
 
 ---
 
@@ -98,109 +131,57 @@ For the canonical definitions, start with:
 
 The repository is organized around four practical blocks:
 
-1. **framework core**
-   - contracts, governance, token discipline, quality, learnings, examples, tests
-2. **starter-pack**
-   - reusable guides, templates, and practical operating materials
-3. **pilot materials**
-   - self-application, Crisis Monitor grounding, pilot conversion, project extension
-4. **post-1.0 tracks**
-   - constrained adoption, resource-aware operations, and later evolution paths
+1. **Framework core**
+   - `engine/`, schemas, governance, token discipline, quality, learnings, examples and tests
+2. **Starter pack**
+   - reusable guides, templates, checklists and playbooks for applying AletheIA in a project
+3. **Pilot and adoption materials**
+   - self-application, Crisis Monitor grounding, constrained adoption, project extension and pilot conversion
+4. **1.x evolution tracks**
+   - trust-boundary hardening, resource-aware operations, runtime-adapter guidance and future domain governance work
+
+Crisis Monitor remains an important pilot source, but its product-specific runtime, UI, assistant behavior and project-management rules are not the portable AletheIA core.
 
 ---
 
 ## Where to start
 
-### If you want the fastest understanding path
-
-Read in this order:
+### Fastest understanding path
 
 1. `docs/getting-started.md`
 2. `docs/00-overview.md`
 3. `docs/governance.md`
-4. `docs/canonical-vocabulary.md`
+4. `docs/token-policy.md`
+5. `docs/canonical-vocabulary.md`
 
-### If you want practical operating guidance
-
-Start with:
+### Apply AletheIA to a project
 
 1. `starter-pack/README.md`
 2. `starter-pack/guides/daily-operations.md`
 3. `docs/apply-to-existing-project.md`
+4. `docs/project-extension-pattern.md`
 
-### If you want examples first
+### Work with handoffs and restart
 
-Start with:
+1. `docs/agent-handoffs.md`
+2. `docs/slice-finalization-and-restart.md`
+3. `starter-pack/guides/clean-restart-command-adapters.md`
+4. `starter-pack/templates/restart-bootstrap-prompt-template.md`
+
+### Work with runtime fit and resource-aware operations
+
+1. `docs/runtime-adapter-contract.md`
+2. `docs/agent-runtime-decision-guide.md`
+3. `docs/context-resource-telemetry-spec.md`
+4. `docs/slice-telemetry-model.md`
+5. `docs/waste-heuristics.md`
+
+### Inspect examples first
 
 1. `examples/hello-world/`
 2. `examples/handoffs/compact-reviewable-handoff.md`
 3. `examples/work-slices/standard-slice/README.md`
-
----
-
-## Current status
-
-AletheIA is now at **1.0.0**.
-
-What 1.0 means:
-
-- the Alpha 1–7 baseline is complete enough for public reuse
-- the framework has a stable adoption path
-- new work now belongs to **1.x evolution tracks**, not to unfinished baseline buildup
-
-The two most relevant post-1.0 tracks today are:
-
-- **1.1 constrained adoption / trust-boundary hardening**
-- **1.2 resource-aware operations**
-
-For the roadmap and release framing, see:
-
-- `docs/roadmap-alpha.md`
-- `docs/release-1.0-readiness.md`
-- `docs/enterprise-readiness-roadmap.md`
-- `docs/resource-aware-operations-roadmap.md`
-
----
-
-## Practical reading paths
-
-### Understand the framework
-
-- `docs/getting-started.md`
-- `docs/00-overview.md`
-- `docs/governance.md`
-- `docs/token-policy.md`
-- `docs/durable-decisions.md`
-
-### Adopt AletheIA in a real project
-
-- `docs/apply-to-existing-project.md`
-- `docs/project-extension-pattern.md`
-- `docs/pilot-conversion.md`
-- `starter-pack/README.md`
-
-### Work with handoffs and continuity
-
-- `docs/agent-handoffs.md`
-- `starter-pack/guides/agent-handoff-generation.md`
-- `starter-pack/templates/agent-handoff-template.md`
-- `docs/slice-finalization-and-restart.md`
-
-### Work with agent roles and runtime fit
-
-- `docs/agent-role-adoption-guide.md`
-- `docs/agent-role-catalog.md`
-- `docs/runtime-adapter-contract.md`
-- `docs/agent-runtime-decision-guide.md`
-
-### Inspect the Hermes pre-pilot guardrails
-
-- `docs/hermes/README.md`
-- `docs/adr/ADR-001-hermes-role.md`
-- `docs/adr/ADR-002-memory-and-skill-promotion-policy.md`
-- `docs/hermes/phase-minus-1-operational-matrix.md`
-- `starter-pack/templates/hermes-closeout-template.md`
-- `docs/hermes/manual-simulation-closeout.md`
+4. `examples/resource-aware-operations/`
 
 ---
 
@@ -212,16 +193,30 @@ For the roadmap and release framing, see:
 4. Reuse before duplication
 5. Validation before closure
 6. Learnings must stay reviewable
+7. Project-local rules stay project-local
 
 ---
 
 ## Quick check
 
-If you want one lightweight sanity pass after cloning:
+After cloning, run the lightweight governance check:
 
 ```bash
 bash scripts/check-governance.sh
 ```
+
+If you are changing the TypeScript engine or examples, run the package tests as well:
+
+```bash
+pnpm install
+pnpm test
+```
+
+---
+
+## License
+
+AletheIA is released under the Apache License 2.0. See `LICENSE`.
 
 ---
 
@@ -230,3 +225,4 @@ bash scripts/check-governance.sh
 - `docs/launch-kit.md`
 - `CHANGELOG.md`
 - `CONTRIBUTING.md`
+- `SECURITY.md`

--- a/docs/assets/aletheia-operating-flow.svg
+++ b/docs/assets/aletheia-operating-flow.svg
@@ -1,0 +1,97 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">AletheIA operating flow</title>
+  <desc id="desc">A diagram showing how a signal becomes a governed action through framing, context, governance, bounded execution, validation, learning and restartable continuity.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1280" y2="720" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0B1020"/>
+      <stop offset="0.55" stop-color="#101827"/>
+      <stop offset="1" stop-color="#162033"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="142" y1="0" x2="1138" y2="0" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7DD3FC"/>
+      <stop offset="0.5" stop-color="#A78BFA"/>
+      <stop offset="1" stop-color="#34D399"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-30%" width="140%" height="160%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+      <path d="M2 2L10 6L2 10" stroke="#94A3B8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <style>
+      .eyebrow{font:600 18px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;letter-spacing:.12em;text-transform:uppercase;fill:#93C5FD}
+      .title{font:750 48px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;fill:#F8FAFC}
+      .subtitle{font:450 22px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;fill:#CBD5E1}
+      .label{font:700 20px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;fill:#F8FAFC}
+      .small{font:450 15px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;fill:#CBD5E1}
+      .pill{font:650 14px Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;fill:#0B1020}
+    </style>
+  </defs>
+
+  <rect width="1280" height="720" rx="34" fill="url(#bg)"/>
+  <path d="M88 118C198 45 330 42 438 114C522 170 603 180 702 139C843 81 993 107 1106 215C1193 298 1226 427 1180 540C1127 670 974 700 842 654C725 613 640 616 526 660C381 716 210 665 128 536C44 404-24 194 88 118Z" fill="#1E293B" opacity="0.38"/>
+  <path d="M0 0H1280V720H0V0Z" fill="url(#accent)" opacity="0.05"/>
+
+  <text x="80" y="82" class="eyebrow">AletheIA operating framework</text>
+  <text x="80" y="138" class="title">From model output to governed action</text>
+  <text x="80" y="178" class="subtitle">A portable loop for bounded AI-assisted work: explicit scope, reviewable decisions, proportional proof and durable continuity.</text>
+
+  <g transform="translate(80 248)" filter="url(#shadow)">
+    <rect width="160" height="118" rx="24" fill="#111827" stroke="#334155"/>
+    <text x="28" y="42" class="label">Signal</text>
+    <text x="28" y="70" class="small">Request, model</text>
+    <text x="28" y="92" class="small">or agent output</text>
+  </g>
+  <path d="M252 307H310" stroke="#94A3B8" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <g transform="translate(322 248)" filter="url(#shadow)">
+    <rect width="170" height="118" rx="24" fill="#111827" stroke="#334155"/>
+    <text x="26" y="42" class="label">Framing</text>
+    <text x="26" y="70" class="small">Work Slice, risk</text>
+    <text x="26" y="92" class="small">and assumptions</text>
+  </g>
+  <path d="M504 307H562" stroke="#94A3B8" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <g transform="translate(574 248)" filter="url(#shadow)">
+    <rect width="170" height="118" rx="24" fill="#111827" stroke="#334155"/>
+    <text x="26" y="42" class="label">Context</text>
+    <text x="26" y="70" class="small">Enough input,</text>
+    <text x="26" y="92" class="small">not transcript flood</text>
+  </g>
+  <path d="M756 307H814" stroke="#94A3B8" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <g transform="translate(826 248)" filter="url(#shadow)">
+    <rect width="180" height="118" rx="24" fill="#111827" stroke="#334155"/>
+    <text x="26" y="42" class="label">Governance</text>
+    <text x="26" y="70" class="small">Allow, slow down,</text>
+    <text x="26" y="92" class="small">escalate or block</text>
+  </g>
+  <path d="M1018 307H1076" stroke="#94A3B8" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <g transform="translate(1088 248)" filter="url(#shadow)">
+    <rect width="152" height="118" rx="24" fill="#111827" stroke="#334155"/>
+    <text x="24" y="42" class="label">Action</text>
+    <text x="24" y="70" class="small">Bounded</text>
+    <text x="24" y="92" class="small">execution</text>
+  </g>
+
+  <path d="M1164 380C1164 464 1065 512 958 512H322C228 512 160 470 160 393" stroke="#475569" stroke-width="3" stroke-dasharray="8 10" marker-end="url(#arrow)"/>
+
+  <g transform="translate(338 470)">
+    <rect width="220" height="64" rx="32" fill="#DBEAFE"/>
+    <text x="36" y="39" class="pill">Validation before closure</text>
+  </g>
+  <g transform="translate(588 470)">
+    <rect width="230" height="64" rx="32" fill="#EDE9FE"/>
+    <text x="38" y="39" class="pill">Learning stays reviewable</text>
+  </g>
+  <g transform="translate(848 470)">
+    <rect width="240" height="64" rx="32" fill="#D1FAE5"/>
+    <text x="36" y="39" class="pill">Restartable handoff</text>
+  </g>
+
+  <g transform="translate(80 598)">
+    <rect width="1120" height="54" rx="18" fill="#0F172A" stroke="#334155"/>
+    <text x="28" y="35" class="small">Core posture: provider-agnostic • advisory-first where signals are immature • human review for meaningful boundaries • local rules remain project-local</text>
+  </g>
+</svg>


### PR DESCRIPTION
## What changed
- Refreshes the public README to reflect the current AletheIA 1.0 posture and recent 1.1/1.2 evolution.
- Adds a versioned SVG operating-flow diagram for the README.
- Keeps Apache-2.0 as the repository license.

## Why it changed
- Crisis-Monitor/Crisis-Monitor#222 confirmed `nevitonsantana/AletheIA` as the target repo and requested editorial polish before publication/preparation.
- The README needed to represent the recent evolution around constrained adoption, trust boundaries, resource-aware operations, clean restart, and project-local constitution patterns without importing Crisis Monitor-specific rules into the public core.

## How to validate
- `bash scripts/check-governance.sh`
- SVG parsed successfully with Python `xml.etree.ElementTree` before commit.

## Risks, assumptions or follow-ups
- This is docs-only and does not change engine/runtime behavior.
- The SVG is intentionally versioned as text for reviewability.
- Broader publication/announcement remains a separate human decision.