### PR TITLE
docs: tighten core operating path navigation

### DIFF
--- a/docs/REPORT_core-operating-path-friction-test.md
+++ b/docs/REPORT_core-operating-path-friction-test.md
@@ -1,0 +1,83 @@
+# Core Operating Path Friction Test
+
+## Goal
+
+Validate whether `docs/core-operating-path.md` is sufficient for a reader to reconstruct and operate one AletheIA Work Slice with minimal repository reading.
+
+## Test boundary
+
+The test intentionally started from the minimum path requested for P0.5:
+
+1. `docs/getting-started.md`
+2. `docs/core-operating-path.md`
+
+The anchor slice was Issue `#100` — Hermes Agent + Agentic Stack controlled sandbox readiness.
+
+## Documents opened
+
+### Minimum path
+
+- `docs/getting-started.md`
+- `docs/core-operating-path.md`
+
+### Additional repository document required
+
+- `docs/aletheia/closeouts/2026-04-25-hermes-agentic-stack-sandbox-readiness.md`
+
+Justification: `docs/core-operating-path.md` is sufficient to reconstruct the operating shape of the slice, but the closeout is the single evidence artifact needed to verify exact Issue #100 details such as command checks, harness absence, upstream references, blocked contract test, and final no-go wording.
+
+Additional repository document count: **1**.
+
+### Supporting GitHub artifacts checked outside the repo-document count
+
+- Issue `#100` comments
+- PR `#118` metadata and diff summary
+
+These were used to confirm the task history and P0 context, not as additional repository documents required by a first reader.
+
+## Reconstruction result
+
+| Path step | Reconstructed from minimum path? | Notes |
+|---|---:|---|
+| Signal / intent | Yes | The core path gives the exact anchor intent: determine controlled Hermes + Agentic Stack sandbox readiness without treating Codex simulation as Hermes telemetry. |
+| Work Slice | Yes | Goal, scope, out of scope, risk posture, expected evidence, and stop line are present. |
+| Minimum context | Partially | The core path lists Issue `#100`, Hermes policy/pre-pilot artifacts, upstream repos, local command checks, and clean worktree harness check. Exact evidence still requires the closeout. |
+| Decision | Yes | The decision path and outcome are explicit: controlled no-go for real Hermes runtime execution; next boundary is a separate sandbox-install diagnostics slice if approved. |
+| Execution | Yes | The guide states what happened and what did not happen: checks and documentation only, no install, no productive Hermes task, no memory/skill promotion, no automation. |
+| Validation | Partially | The validation categories are present, but the closeout is needed to verify exact evidence and blocked local contract-test state. |
+| Closeout / restart | Partially | The operating conclusion is present; the closeout is needed as the restart/evidence artifact. |
+
+## Friction points
+
+1. `docs/getting-started.md` does not currently point directly to `docs/core-operating-path.md` as the next step for a reader who wants to run one Work Slice.
+   - Impact: the README has the fastest understanding path, but a reader who starts inside `getting-started.md` can miss the new operating path.
+   - Actionable follow-up: add `docs/core-operating-path.md` to the suggested next steps in `docs/getting-started.md`.
+
+2. `docs/core-operating-path.md` compresses the anchor slice well, but it does not clearly label the closeout as the one acceptable extra evidence artifact for the friction test.
+   - Impact: a reader may over-open Hermes policy, readiness gates, restart docs, or templates to verify the anchor slice, even though the closeout is enough.
+   - Actionable follow-up: add one sentence near the anchor slice or friction-test section: for exact reconstruction, the closeout is the only expected extra repository document.
+
+3. The `Suggested next reading` section in `docs/core-operating-path.md` lists multiple documents immediately after the friction-test section.
+   - Impact: for first-use validation, this can blur the difference between required path and optional deeper reading.
+   - Actionable follow-up: split the section into `Optional deeper reading` or explicitly state that these are not required to run the first Work Slice.
+
+## Verdict
+
+The success criterion is met with a caveat.
+
+Issue `#100` can be reconstructed with **one additional repository document**: the completed closeout. The operating path is sufficient for the slice shape and decision path, but the navigation and optional-reading labels should be tightened so the minimum path remains obvious.
+
+## Recommendation for next issue
+
+Recommended next issue: **small correction to `core-operating-path.md`**, paired with a tiny navigation update in `docs/getting-started.md` if allowed in the same documentation-validation slice.
+
+Do **not** create `slice-record-template.md` yet. The friction found does not prove a missing template; it proves that the existing compressed guide needs clearer evidence/navigation boundaries.
+
+Do **not** create `kanban-decision-protocol.md` yet. The friction was not about board state or Kanban decision semantics; it was about first-reader navigation and evidence scope.
+
+## Validation
+
+- Repository documents required beyond the minimum path: **1**.
+- Required extra document explicitly justified: yes.
+- Gaps recorded as actionable follow-ups: yes.
+- Next issue recommendation explicit: yes.

--- a/docs/core-operating-path.md
+++ b/docs/core-operating-path.md
@@ -26,6 +26,8 @@ This guide is anchored in a real completed slice:
 
 The slice is a good anchor because it had a clear intent, explicit stop lines, real validation evidence, and a non-trivial decision: it advanced readiness without pretending that Codex simulation was Hermes telemetry.
 
+For exact reconstruction of Issue `#100`, the linked closeout is the only expected additional repository document beyond this guide.
+
 ---
 
 ## 1. Start from a signal or intent
@@ -194,8 +196,9 @@ After writing or changing this guide, test it against the anchor slice:
 
 1. Start from `docs/getting-started.md`.
 2. Use only this file to reconstruct the path of Issue `#100`.
-3. Count every additional repository document you must open.
-4. If you need more than one extra document, the operating path still has a gap.
+3. Open the linked closeout only if exact evidence or restart detail is needed.
+4. Count every additional repository document you must open.
+5. If you need more than one extra document, the operating path still has a gap.
 
 Expected first-use result:
 
@@ -218,7 +221,9 @@ Do not use this guide to add:
 
 Those may be useful in later slices, but this P0 path exists to compress the core operating route first.
 
-## Suggested next reading
+## Optional deeper reading
+
+These documents are not required to run the first Work Slice. Use them only when the slice needs deeper gates, restart mechanics, or template detail.
 
 - `docs/getting-started.md`
 - `docs/readiness-gates-spec.md`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,15 @@ Read in this order:
 6. `docs/durable-decisions.md`
 7. `docs/enforcement-boundaries.md`
 
-### 2. I want to try the framework quickly
+### 2. I want to operate one Work Slice
+
+Read next:
+
+1. `docs/core-operating-path.md`
+
+Use this when you want the shortest path from intent to a bounded, validated, restartable slice without reading the whole repository first.
+
+### 3. I want to try the framework quickly
 
 Read and run in this order:
 
@@ -51,7 +59,7 @@ Read and run in this order:
 3. `tests/`
 4. `bash scripts/check-governance.sh`
 
-### 3. I want to apply it to an existing project
+### 4. I want to apply it to an existing project
 
 Read in this order:
 
@@ -85,6 +93,7 @@ If you are unsure what counts as a Work Item, Work Slice, Restart Package, or Ex
 If you only have a few minutes, look at:
 
 - `README.md`
+- `docs/core-operating-path.md`
 - `docs/00-overview.md`
 - `docs/roadmap-alpha.md`
 - `docs/governance.md`
@@ -114,6 +123,7 @@ If you want to test AletheIA in practice, start with one of these:
 ### Option B — pilot one real slice in your own project
 
 - choose one bounded slice
+- use `docs/core-operating-path.md` to shape the minimum operating path
 - define the local extension boundary
 - apply the minimum operating layer
 - validate what helped and what remained local
@@ -141,6 +151,7 @@ AletheIA works best when adoption starts small and becomes more explicit through
 
 After `getting-started.md`, choose one of these paths:
 
+- **operate one Work Slice** -> `docs/core-operating-path.md`
 - **understand the core** -> `docs/00-overview.md`
 - **pilot in an existing project** -> `docs/apply-to-existing-project.md`
 - **inspect the operating method** -> `starter-pack/README.md`


### PR DESCRIPTION
## What changed
- Adds `docs/REPORT_core-operating-path-friction-test.md` with a P0.5 friction test for `docs/core-operating-path.md`.
- Updates `docs/getting-started.md` so readers can go directly to `docs/core-operating-path.md` when they want to operate one Work Slice.
- Clarifies in `docs/core-operating-path.md` that exact Issue #100 reconstruction should require only the linked closeout as the optional extra evidence artifact.
- Renames the final reading section to optional deeper reading so it does not blur the minimum first-use path.

## Why it changed
The P0 operating path from PR #118 needed validation against its anchor slice, then a tiny navigation/evidence-boundary correction before adding any new framework surface.

## How to validate
- Read `docs/getting-started.md` and confirm `docs/core-operating-path.md` is the direct path for operating one Work Slice.
- Read `docs/core-operating-path.md` and confirm the minimum path remains `getting-started` -> `core-operating-path`, with the Issue #100 closeout as the only expected extra repository document for exact evidence.
- `bash scripts/check-governance.sh` ✅
- GitHub branch compare: branch is 3 commits ahead of `main`, changing only the report plus the two planned docs.

## Risks, assumptions or follow-ups
- No `slice-record-template.md`, `kanban-decision-protocol.md`, Hermes, Agentic Stack, telemetry, Adaptative Skills, image, or architecture changes are included.
- Follow-up, if desired after review: create a separate issue only for the next small operating-path correction or template work; this PR does not create that next issue.