### PR TITLE
docs: add premortem skill and AletheIA activation triggers

### DIFF
--- a/docs/aletheia/checks/premortem-activation-check.md
+++ b/docs/aletheia/checks/premortem-activation-check.md
@@ -1,0 +1,97 @@
+# AletheIA — Premortem Activation Check
+
+## Objetivo
+
+Checklist curto para decidir se a skill de premortem deve ser acionada antes da execução de uma tarefa, plano ou decisão.
+
+Este check é executado pelo AletheIA, não pela skill. O AletheIA decide quando acionar; a skill executa o método.
+
+---
+
+## Checklist de ativação
+
+Responder às perguntas abaixo antes de acionar:
+
+1. Existe um plano, decisão ou compromisso concreto?
+2. O erro teria custo relevante?
+3. Ainda é possível alterar o rumo?
+4. Há impacto em usuário, negócio, segurança, dados, reputação ou governança?
+5. Há premissas importantes sem evidência suficiente?
+6. A decisão é difícil de reverter?
+7. Há múltiplos stakeholders ou interesses conflitantes?
+8. Há pressão de prazo que pode reduzir qualidade?
+
+---
+
+## Regra de decisão
+
+### Não acionar
+
+Se a resposta para **1** for "não": não acionar premortem. Ajude a estruturar o plano primeiro.
+
+Se a resposta para **2** for "não": considerar checklist simples ou feedback comum.
+
+Se a resposta para **3** for "não": considerar postmortem, retrospectiva ou análise de aprendizado.
+
+### Considerar Lite
+
+Acionar Lite se:
+
+- há plano concreto;
+- o erro tem algum custo;
+- a decisão é reversível;
+- o impacto é limitado.
+
+### Considerar Standard
+
+Acionar Standard se:
+
+- há impacto em produto, time, cliente ou operação;
+- há incerteza relevante;
+- há dependências entre áreas;
+- há falta de critério de sucesso;
+- há possibilidade de corrigir o plano antes de executar.
+
+### Considerar High-Assurance
+
+Acionar High-Assurance se houver:
+
+- IA/autonomia/agentes;
+- dados sensíveis;
+- segurança;
+- privacidade/LGPD;
+- risco reputacional;
+- baixa reversibilidade;
+- impacto crítico em usuário;
+- decisão humana necessária;
+- ausência de rollback;
+- risco regulatório ou de governança.
+
+---
+
+## Saída do activation check
+
+Quando acionar, retornar:
+
+```txt
+Premortem recomendado: [Lite / Standard / High-Assurance]
+Motivo: [1–2 frases]
+Skill a acionar: docs/skills/premortem/premortem-core.md
+Gates a observar: [hard gate / soft gate / review trigger / human decision gate]
+```
+
+Quando não acionar:
+
+```txt
+Premortem não recomendado agora.
+Motivo: [falta plano concreto / baixo custo de erro / decisão já irreversível / pedido simples]
+Alternativa recomendada: [checklist / estruturação de plano / revisão simples / postmortem]
+```
+
+---
+
+## Leitura complementar
+
+- `docs/aletheia/triggers/premortem-triggers.md` — regras detalhadas de acionamento
+- `docs/skills/premortem/workflows/depth-profiles.md` — como escolher o perfil certo
+- `docs/skills/premortem/workflows/gate-mapping.md` — como mapear achados para gates

--- a/docs/aletheia/triggers/premortem-triggers.md
+++ b/docs/aletheia/triggers/premortem-triggers.md
@@ -1,0 +1,157 @@
+# AletheIA — Gatilhos para Premortem
+
+## Objetivo
+
+Definir quando o AletheIA deve acionar a skill de premortem do Adaptative Skills.
+
+O AletheIA não executa o método completo. Ele avalia contexto, risco, reversibilidade e custo de erro para decidir se a skill deve ser chamada e com qual profundidade.
+
+---
+
+## Regra central
+
+Acionar premortem quando existir:
+
+```txt
+plano ou decisão concreta + custo relevante de erro + possibilidade de mudar o rumo
+```
+
+Se uma dessas três condições não existir, o premortem provavelmente não é o método adequado.
+
+---
+
+## Gatilhos fortes
+
+Acionar premortem quando a tarefa envolver pelo menos um dos itens abaixo:
+
+1. Decisão concreta com custo relevante de erro.
+2. Baixa reversibilidade.
+3. Impacto direto em usuário.
+4. Uso de IA, agente, automação ou recomendação algorítmica.
+5. Dados sensíveis, segurança, privacidade ou LGPD.
+6. Risco de compliance, governança ou auditoria.
+7. Experiência crítica ou acessibilidade.
+8. Múltiplos stakeholders com interesses conflitantes.
+9. Ausência de critério claro de sucesso.
+10. Pressão de prazo com risco de qualidade.
+11. Dependência técnica crítica.
+12. Mudança com possível impacto reputacional.
+
+---
+
+## Gatilhos por linguagem do usuário
+
+A linguagem do usuário pode indicar necessidade de premortem, mas não deve ser suficiente sozinha.
+
+Exemplos:
+
+- "o que pode dar errado?"
+- "o que estou deixando passar?"
+- "fure esse plano"
+- "onde isso pode quebrar?"
+- "teste essa estratégia"
+- "quais são os pontos cegos?"
+- "faça um advogado do diabo"
+
+Antes de acionar, confirmar se há plano concreto e custo relevante de erro.
+
+---
+
+## Quando não acionar
+
+Não acionar premortem para:
+
+- pergunta factual;
+- edição de texto;
+- feedback simples;
+- brainstorming inicial;
+- ideia vaga sem plano;
+- pedido de explicação;
+- decisão já tomada e irreversível;
+- situação em que um checklist simples resolve.
+
+---
+
+## Seleção de profundidade
+
+```txt
+Baixo risco + decisão reversível → Lite
+Risco médio + impacto em produto/time → Standard
+Alto risco + IA/dados/segurança/reputação/baixa reversibilidade → High-Assurance
+```
+
+Para detalhes de cada perfil: `docs/skills/premortem/workflows/depth-profiles.md`.
+
+---
+
+## Exemplos
+
+### Exemplo 1 — Lite
+
+Entrada:
+
+```txt
+Quero publicar um post sobre esse tema. O que pode dar errado?
+```
+
+Decisão:
+
+```txt
+Premortem Lite, se houver risco reputacional moderado ou audiência sensível.
+```
+
+### Exemplo 2 — Standard
+
+Entrada:
+
+```txt
+Vamos lançar uma nova feature para times internos usarem agentes de IA na priorização de demandas.
+```
+
+Decisão:
+
+```txt
+Premortem Standard, pois há produto, usuários internos, adoção e decisão operacional.
+```
+
+### Exemplo 3 — High-Assurance
+
+Entrada:
+
+```txt
+Vamos permitir que um agente atualize configurações de monitoramento automaticamente com base em sinais de crise.
+```
+
+Decisão:
+
+```txt
+Premortem High-Assurance, pois há IA/autonomia, impacto operacional, risco reputacional e necessidade de auditoria.
+```
+
+---
+
+## Cenário de validação recomendado
+
+Use para testar os gatilhos:
+
+```txt
+Queremos criar quality gates para projetos com código gerado por IA, considerando engenharia, segurança, UX, acessibilidade, comportamento de agentes e decisão humana.
+```
+
+Resultado esperado:
+
+1. AletheIA detecta risco médio/alto.
+2. AletheIA aciona premortem Standard ou High-Assurance.
+3. A skill identifica modos de falha concretos (não genéricos).
+4. A saída recomenda gates.
+5. O plano revisado fica mais acionável que o plano inicial.
+
+---
+
+## Skill a acionar
+
+```txt
+docs/skills/premortem/premortem-core.md
+```
+
+Activation check: `docs/aletheia/checks/premortem-activation-check.md`

--- a/docs/skills/premortem/premortem-core.md
+++ b/docs/skills/premortem/premortem-core.md
@@ -1,0 +1,152 @@
+# Premortem Skill — Core
+
+## Objetivo
+
+Executar uma análise premortem sobre planos, produtos, decisões, lançamentos, estratégias ou compromissos com custo relevante de erro.
+
+A skill assume que a iniciativa falhou em um horizonte futuro definido e trabalha retroativamente para identificar:
+
+- causas prováveis de falha;
+- premissas frágeis;
+- sinais de alerta observáveis;
+- ajustes preventivos;
+- gates necessários antes da execução.
+
+## Definição
+
+Premortem é uma técnica de análise preventiva. Em vez de perguntar "o que pode dar errado?", ela estabelece o enquadramento: "esta iniciativa já falhou; explique por quê".
+
+Esse enquadramento reduz otimismo automático e força uma análise mais específica de causalidade, dependências, riscos e pontos cegos.
+
+**Premortem ≠ Postmortem.** Postmortem reconstrói causas depois de uma falha real. Premortem antecipa causas antes da execução.
+
+## Quando usar
+
+Use esta skill quando houver:
+
+- uma decisão concreta;
+- um plano minimamente formado;
+- custo relevante de erro;
+- possibilidade de ajuste antes da execução;
+- incerteza importante;
+- impacto em produto, negócio, usuário, dados, segurança, reputação ou governança.
+
+Exemplos adequados:
+
+- lançamento de produto ou feature;
+- mudança de estratégia ou posicionamento;
+- experimento com IA/agentes;
+- alteração em fluxo crítico de usuário;
+- decisão arquitetural difícil de reverter;
+- plano com múltiplos stakeholders;
+- mudança de processo com impacto em time ou cliente;
+- proposta comercial ou institucional com risco reputacional.
+
+## Quando não usar
+
+Não use esta skill para:
+
+- perguntas factuais;
+- revisão textual simples;
+- feedback criativo sem decisão operacional;
+- ideias vagas demais;
+- brainstorming inicial;
+- decisões já tomadas e irreversíveis;
+- situações em que um checklist simples resolve melhor.
+
+Se o usuário ainda não tem um plano concreto, ajude primeiro a estruturar o plano. Depois execute o premortem.
+
+## Contexto mínimo necessário
+
+Antes de executar, confirme se há contexto suficiente para responder a cinco perguntas:
+
+1. O que é a iniciativa?
+2. Para quem é ou quem será afetado?
+3. Como sucesso será definido?
+4. Qual é o custo do erro?
+5. Ainda é possível mudar o rumo?
+
+Se faltar uma informação essencial, faça no máximo 1–3 perguntas objetivas. Se for possível inferir com segurança, declare a inferência e prossiga.
+
+## Enquadramento obrigatório
+
+Toda execução deve começar com um enquadramento explícito:
+
+```txt
+Passaram-se [horizonte]. A iniciativa falhou. O objetivo agora é entender por que ela falhou antes de executá-la de verdade.
+```
+
+O horizonte padrão é 6 meses, salvo se o contexto indicar outro período mais adequado.
+
+## Fluxo de execução
+
+1. Confirmar contexto mínimo.
+2. Escolher perfil de profundidade: Lite, Standard ou High-Assurance.
+3. Estabelecer o enquadramento de falha futura.
+4. Gerar modos de falha específicos.
+5. Identificar premissas frágeis.
+6. Priorizar:
+   - falha mais provável;
+   - falha mais perigosa;
+   - falha mais difícil de detectar;
+   - falha mais barata de prevenir.
+7. Definir sinais de alerta observáveis.
+8. Mapear gates necessários.
+9. Revisar o plano.
+10. Gerar checklist pré-execução.
+
+## Qualidade dos modos de falha
+
+Cada modo de falha deve ser:
+
+- específico ao plano analisado;
+- causal, não apenas descritivo;
+- plausível;
+- relevante;
+- conectado a uma premissa ou decisão;
+- acompanhado de pelo menos um sinal observável quando possível.
+
+Evite falhas genéricas como:
+
+- "falta de comunicação";
+- "problemas de alinhamento";
+- "baixa adoção";
+- "falta de métricas".
+
+Reescreva essas falhas de forma específica:
+
+```txt
+A adoção caiu porque o fluxo exige que PMs preencham campos que só fazem sentido para engenharia, criando atrito no primeiro uso.
+```
+
+## Formato mínimo de saída
+
+Toda execução deve retornar, no mínimo:
+
+- modos de falha;
+- falha mais provável;
+- falha mais perigosa;
+- premissa oculta;
+- sinais de alerta;
+- plano revisado;
+- gates recomendados, se aplicável.
+
+Use o template em `docs/skills/premortem/templates/premortem-report.md`.
+
+## Princípios
+
+- Seja direto.
+- Não suavize riscos relevantes.
+- Não invente evidências.
+- Marque inferências quando necessário.
+- Evite excesso de ritual em decisões simples.
+- A profundidade deve ser proporcional ao risco.
+- A saída deve melhorar a decisão, não apenas listar problemas.
+
+## Leitura complementar
+
+- `docs/skills/premortem/workflows/depth-profiles.md`
+- `docs/skills/premortem/workflows/gate-mapping.md`
+- `docs/skills/premortem/templates/premortem-report.md`
+- `docs/aletheia/triggers/premortem-triggers.md`
+- `docs/aletheia/checks/premortem-activation-check.md`

--- a/docs/skills/premortem/runtime-adapters/claude-code.md
+++ b/docs/skills/premortem/runtime-adapters/claude-code.md
@@ -1,0 +1,70 @@
+# Runtime Adapter — Claude Code
+
+## Objetivo
+
+Orientar como o Claude Code deve executar ou apoiar a skill de premortem sem acoplar o core da skill ao runtime do Claude Code.
+
+## Princípios
+
+1. Ler arquivos relevantes antes de criar qualquer coisa.
+2. Seguir os padrões existentes de documentação e nomenclatura do repositório.
+3. Fazer mudanças mínimas e localizadas.
+4. Não criar scripts, automações ou integrações sem pedido explícito.
+5. Não alterar arquivos não relacionados.
+6. Manter a skill em Markdown, salvo se o projeto já usar outro formato.
+7. Separar método, gatilhos, templates e adapters.
+
+## Execução recomendada
+
+Ao receber uma tarefa de análise premortem via Claude Code:
+
+1. Ler `CLAUDE.md` e `AGENTS.md`, se existirem.
+2. Ler `docs/skills/premortem/premortem-core.md` para entender o método.
+3. Ler `docs/aletheia/checks/premortem-activation-check.md` para confirmar que premortem é o método adequado.
+4. Selecionar o perfil de profundidade usando `docs/skills/premortem/workflows/depth-profiles.md`.
+5. Executar o premortem seguindo o fluxo definido no core.
+6. Mapear achados para gates usando `docs/skills/premortem/workflows/gate-mapping.md`.
+7. Gerar saída usando o template em `docs/skills/premortem/templates/premortem-report.md`.
+8. Se for uma implementação documental da skill, seguir o runtime adapter do Codex (`runtime-adapters/codex.md`) adaptando para as ferramentas disponíveis no Claude Code (Read, Write, Edit, Bash).
+
+## Ferramentas disponíveis no Claude Code
+
+| Operação | Ferramenta preferida |
+|---|---|
+| Ler arquivos | Read |
+| Criar arquivos | Write |
+| Editar arquivos | Edit |
+| Buscar padrões | Bash (grep/find) |
+| Inspecionar estrutura | Bash (ls/find) |
+
+Usar Bash apenas quando Read/Write/Edit não forem suficientes.
+
+## Validação mínima antes de finalizar
+
+- A skill deixa claro quando usar e quando não usar.
+- A skill possui Lite, Standard e High-Assurance.
+- Os gatilhos não disparam premortem para qualquer feedback simples.
+- O AletheIA decide quando acionar, mas não contém o método inteiro.
+- Os gates estão conectados a achados do premortem.
+- O template de saída é utilizável em Markdown.
+
+## Resposta final esperada
+
+Ao concluir uma implementação ou análise, responder com:
+
+```txt
+Arquivos criados/alterados:
+- ...
+
+Decisões tomadas:
+- ...
+
+Adaptações à estrutura existente:
+- ...
+
+Pendências:
+- ...
+
+Teste recomendado:
+- Rodar premortem sobre quality gates para desenvolvimento assistido por IA.
+```

--- a/docs/skills/premortem/templates/premortem-report.md
+++ b/docs/skills/premortem/templates/premortem-report.md
@@ -1,0 +1,83 @@
+# Premortem — [Nome da iniciativa]
+
+## Enquadramento
+
+Passaram-se [horizonte]. Esta iniciativa falhou. O objetivo é entender por que ela falhou antes de executá-la de verdade.
+
+## Contexto
+
+- **Iniciativa:** [descrever]
+- **Público / afetados:** [descrever]
+- **Critério de sucesso:** [descrever]
+- **Custo do erro:** [baixo / médio / alto + justificativa]
+- **Reversibilidade:** [alta / média / baixa + justificativa]
+- **Perfil de profundidade usado:** [Lite / Standard / High-Assurance]
+
+## Modos de falha
+
+1. **[Modo de falha]**
+   [Explicação causal específica.]
+
+2. **[Modo de falha]**
+   [Explicação causal específica.]
+
+3. **[Modo de falha]**
+   [Explicação causal específica.]
+
+## Falha mais provável
+
+[Descrever a falha mais provável e por que ela merece atenção primeiro.]
+
+## Falha mais perigosa
+
+[Descrever a falha que causaria mais dano, mesmo que não seja a mais provável.]
+
+## Falha mais difícil de detectar
+
+[Opcional. Usar principalmente em Standard e High-Assurance.]
+
+## Premissa oculta
+
+[Descrever a suposição mais importante que o plano parece tratar como verdade sem evidência suficiente.]
+
+## Sinais de alerta
+
+- [Sinal observável 1]
+- [Sinal observável 2]
+- [Sinal observável 3]
+
+## Gates recomendados
+
+### Hard gates
+
+- [Condição bloqueante, se houver. Se nenhum, declarar: nenhum.]
+
+### Soft gates
+
+- [Condição para avançar com segurança, se houver.]
+
+### Review triggers
+
+- [Especialidade/papel que precisa revisar, se houver.]
+
+### Human decision gates
+
+- [Decisão humana necessária, se houver.]
+
+## Plano revisado
+
+1. [Mudança concreta no plano]
+2. [Mudança concreta no plano]
+3. [Mudança concreta no plano]
+
+## Checklist pré-execução
+
+- [ ] [Verificação 1]
+- [ ] [Verificação 2]
+- [ ] [Verificação 3]
+- [ ] [Verificação 4]
+- [ ] [Verificação 5]
+
+## Pendências
+
+- [Dado ausente, decisão pendente ou validação necessária.]

--- a/docs/skills/premortem/workflows/depth-profiles.md
+++ b/docs/skills/premortem/workflows/depth-profiles.md
@@ -1,0 +1,145 @@
+# Premortem — Perfis de Profundidade
+
+## Objetivo
+
+Definir o nível de profundidade adequado para cada execução de premortem. A skill não deve executar análises longas quando uma checagem curta é suficiente.
+
+A seleção de perfil deve ser proporcional ao risco. Use o menor perfil que ainda torne a decisão revisável.
+
+---
+
+## Perfil 1 — Lite
+
+### Quando usar
+
+Use Lite quando:
+
+- o risco é baixo ou médio;
+- a decisão é reversível;
+- o impacto é limitado;
+- o usuário precisa de uma checagem rápida;
+- ainda não há necessidade de gates formais.
+
+### Saída esperada
+
+```txt
+- 3 a 5 modos de falha
+- premissa oculta principal
+- revisão mais importante do plano
+```
+
+### Sinais de que Lite é insuficiente
+
+- envolve IA/autonomia/agentes;
+- há risco de dados, segurança ou compliance;
+- há impacto direto em usuário;
+- há risco reputacional;
+- a decisão é difícil de reverter;
+- múltiplos stakeholders discordam sobre sucesso.
+
+---
+
+## Perfil 2 — Standard
+
+### Quando usar
+
+Use Standard quando:
+
+- há uma feature, produto, campanha, processo ou estratégia com impacto real;
+- existe custo relevante de erro;
+- há dependências entre áreas;
+- há incerteza sobre adoção, valor ou execução;
+- gates podem ser úteis, mas não necessariamente bloqueantes.
+
+### Saída esperada
+
+```txt
+- enquadramento
+- contexto resumido
+- 5 a 8 modos de falha
+- falha mais provável
+- falha mais perigosa
+- premissa oculta
+- sinais de alerta
+- gates recomendados
+- plano revisado
+- checklist pré-execução
+```
+
+### Sinais de que Standard é insuficiente
+
+- risco legal, segurança, privacidade ou LGPD;
+- impacto em usuário vulnerável;
+- decisão de baixa reversibilidade;
+- agente de IA com autonomia operacional;
+- possível dano reputacional;
+- ausência de rollback;
+- ausência de critério de sucesso verificável.
+
+---
+
+## Perfil 3 — High-Assurance
+
+### Quando usar
+
+Use High-Assurance quando:
+
+- o custo do erro é alto;
+- a decisão é difícil ou cara de reverter;
+- há risco de segurança, dados, governança, compliance ou reputação;
+- há impacto crítico na experiência do usuário;
+- há uso de IA com autonomia, recomendação ou ação operacional;
+- há conflito entre prazo, qualidade e risco;
+- uma decisão humana explícita é necessária.
+
+### Saída esperada
+
+```txt
+- enquadramento
+- contexto estruturado
+- modos de falha detalhados
+- matriz severidade / probabilidade / detectabilidade
+- falha mais provável
+- falha mais perigosa
+- falha mais difícil de detectar
+- premissas ocultas críticas
+- sinais de alerta mensuráveis
+- hard gates
+- soft gates
+- review triggers
+- human decision gates
+- plano revisado
+- checklist pré-execução
+- pendências e decisões humanas
+```
+
+### Sinais de excesso de profundidade
+
+High-Assurance está exagerado quando:
+
+- a decisão é simples e reversível;
+- não há impacto relevante;
+- não há dependências críticas;
+- a resposta longa atrasaria mais do que ajudaria;
+- um checklist resolveria o risco.
+
+---
+
+## Regra prática de seleção
+
+```txt
+Baixo risco + reversível → Lite
+Risco médio + impacto em produto/time → Standard
+Alto risco + IA/dados/segurança/reputação/baixa reversibilidade → High-Assurance
+```
+
+---
+
+## Relação com Planning Depth Profiles do AletheIA
+
+Os perfis de profundidade desta skill (Lite / Standard / High-Assurance) compartilham nomenclatura com os `Planning Depth Profiles` do AletheIA (`docs/planning-depth-profiles.md`), mas têm finalidade distinta:
+
+- **Planning Depth Profiles**: quanto de estrutura de planejamento um work slice precisa antes da execução.
+- **Premortem Depth Profiles**: quão profunda deve ser a análise preventiva de falha de um plano, produto ou decisão.
+
+Os dois podem ser usados juntos: um slice High-Assurance provavelmente merece um premortem Standard ou High-Assurance antes de ser executado.

--- a/docs/skills/premortem/workflows/gate-mapping.md
+++ b/docs/skills/premortem/workflows/gate-mapping.md
@@ -1,0 +1,157 @@
+# Premortem — Mapeamento para Gates
+
+## Objetivo
+
+Converter achados do premortem em mecanismos de decisão operacional. Um bom premortem não termina em uma lista de riscos; ele define o que precisa ser bloqueado, condicionado, revisado ou decidido por humanos.
+
+---
+
+## Tipos de gate
+
+### 1. Hard gate
+
+Bloqueia o avanço até que uma condição mínima seja atendida.
+
+Use quando o premortem identificar:
+
+- ausência de critério de sucesso;
+- ausência de rollback;
+- risco legal ou regulatório não avaliado;
+- risco de segurança não avaliado;
+- uso de dados sensíveis sem governança clara;
+- impacto em usuário vulnerável sem mitigação;
+- dependência crítica sem responsável;
+- comportamento de agente de IA sem limite claro de ação.
+
+Formato:
+
+```txt
+Hard gate: não avançar até que [condição verificável] esteja resolvida.
+```
+
+Exemplo:
+
+```txt
+Hard gate: não liberar a automação até que exista mecanismo de rollback e log de auditoria para cada ação executada pelo agente.
+```
+
+### 2. Soft gate
+
+Permite avançar com condição explícita, piloto, escopo reduzido ou mitigação.
+
+Use quando:
+
+- a hipótese é fraca, mas testável;
+- há risco conhecido com mitigação razoável;
+- o impacto é controlável;
+- o plano pode seguir em piloto;
+- ainda faltam evidências, mas o custo de aprender é aceitável.
+
+Formato:
+
+```txt
+Soft gate: avançar somente se [condição] e com [limite de exposição].
+```
+
+Exemplo:
+
+```txt
+Soft gate: testar primeiro com uma squad piloto por duas semanas antes de tornar o checklist obrigatório para todos os times.
+```
+
+### 3. Review trigger
+
+Exige revisão especializada antes de avançar.
+
+Use quando houver impacto em:
+
+- UX;
+- acessibilidade;
+- segurança;
+- privacidade;
+- LGPD;
+- arquitetura;
+- comportamento de agente;
+- marca ou reputação;
+- operação crítica.
+
+Formato:
+
+```txt
+Review trigger: envolver [especialidade/papel] antes de [marco].
+```
+
+Exemplo:
+
+```txt
+Review trigger: envolver Product Design e Segurança antes do release, porque o fluxo altera comportamento de usuário e manipula dados sensíveis.
+```
+
+### 4. Human decision gate
+
+A IA não decide. Ela estrutura trade-offs e recomenda alternativas para decisão humana.
+
+Use quando:
+
+- há conflito entre prazo e qualidade;
+- há risco reputacional;
+- há impacto em pessoas;
+- há ambiguidade ética;
+- há decisão estratégica;
+- há decisão política ou institucional;
+- a escolha depende de apetite de risco.
+
+Formato:
+
+```txt
+Human decision gate: decisão humana necessária entre [opções], considerando [trade-off].
+```
+
+Exemplo:
+
+```txt
+Human decision gate: liderança precisa decidir se aceita lançar com cobertura parcial de acessibilidade ou se reduz escopo para preservar qualidade mínima.
+```
+
+---
+
+## Como mapear achados para gates
+
+Para cada modo de falha relevante, responder:
+
+1. Esta falha bloqueia avanço?
+2. Pode ser mitigada com piloto ou limite de escopo?
+3. Exige revisão especializada?
+4. Exige decisão humana explícita?
+
+---
+
+## Saída recomendada
+
+```md
+## Gates recomendados
+
+### Hard gates
+- ...
+
+### Soft gates
+- ...
+
+### Review triggers
+- ...
+
+### Human decision gates
+- ...
+```
+
+Se nenhum gate for necessário, declarar:
+
+```txt
+Nenhum gate formal recomendado. A decisão pode seguir com checklist simples de acompanhamento.
+```
+
+---
+
+## Relação com gates existentes no AletheIA
+
+O AletheIA já usa gates de prontidão no contexto de work slices (`starter-pack/guides/quality-gates.md`, `starter-pack/guides/risk-to-gate-mapping.md`). Os gates do premortem são complementares: enquanto os gates de prontidão validam se um slice pode avançar, os gates do premortem identificam condições que deveriam bloquear ou condicionar a execução antes de o slice sequer começar.


### PR DESCRIPTION
## Summary

- Implements the **premortem skill** under `docs/skills/premortem/` (Adaptative Skills layer): method definition, Lite/Standard/High-Assurance depth profiles, gate mapping, Markdown report template, and Claude Code runtime adapter
- Implements the **AletheIA activation layer** under `docs/aletheia/triggers/` and `docs/aletheia/checks/`: trigger rules that decide when/at what depth to invoke the skill, plus an activation checklist with structured output

Separation of responsibility is preserved: AletheIA decides when and with what criticality; Adaptative Skills executes the method. v0.1 is Markdown-only with no runtime dependencies.

## Test plan

- [ ] Run activation check against the validation scenario from the brief: *"Queremos criar quality gates para projetos com código gerado por IA, considerando engenharia, segurança, UX, acessibilidade, comportamento de agentes e decisão humana."*
- [ ] Confirm AletheIA routes to High-Assurance (IA + segurança + decisão humana explícita)
- [ ] Confirm skill returns specific (non-generic) failure modes connected to premises and gates
- [ ] Confirm no premortem is triggered for a simple factual question or plain text edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)