### PR TITLE
docs: add Codex runtime adapter and runtime-adapters README

### DIFF
--- a/docs/skills/premortem/runtime-adapters/README.md
+++ b/docs/skills/premortem/runtime-adapters/README.md
@@ -1,0 +1,29 @@
+# Runtime Adapters
+
+Este diretório contém orientações específicas por runtime para execução da skill de premortem.
+
+## Princípio
+
+O core da skill (`premortem-core.md`) é agnóstico de runtime. Ele define o método, o fluxo e os critérios de qualidade sem depender de nenhuma ferramenta, modelo ou plataforma específica.
+
+Os adapters traduzem esse método para as convenções e ferramentas de cada runtime. Um adapter não altera o método — ele orienta como executá-lo no contexto de um ambiente específico.
+
+## Adapters disponíveis
+
+| Runtime | Arquivo |
+|---|---|
+| Claude Code (CLI/IDE) | `claude-code.md` |
+| Codex | `codex.md` |
+
+## Criando um novo adapter
+
+Para adicionar suporte a um novo runtime, criar um arquivo `<runtime>.md` neste diretório com:
+
+1. **Objetivo** — o que este adapter cobre.
+2. **Princípios** — restrições ou convenções do runtime.
+3. **Execução recomendada** — como invocar o fluxo do core neste runtime.
+4. **Ferramentas disponíveis** — mapeamento de operações para ferramentas do runtime.
+5. **Validação mínima** — o que verificar antes de considerar concluído.
+6. **Resposta final esperada** — formato de saída para este runtime.
+
+O adapter não deve replicar o método. Deve apenas indicar como executá-lo.

--- a/docs/skills/premortem/runtime-adapters/codex.md
+++ b/docs/skills/premortem/runtime-adapters/codex.md
@@ -1,0 +1,63 @@
+# Runtime Adapter — Codex
+
+## Objetivo
+
+Orientar como o Codex deve executar ou implementar a skill de premortem sem acoplar o core da skill ao runtime do Codex.
+
+## Princípios
+
+1. Inspecionar a estrutura do repositório antes de criar arquivos.
+2. Seguir padrões existentes de documentação e nomenclatura.
+3. Fazer mudanças mínimas e localizadas.
+4. Não criar scripts, automações ou integrações sem pedido explícito.
+5. Não alterar arquivos não relacionados.
+6. Manter a skill em Markdown, salvo se o projeto já usar outro formato.
+7. Separar método, gatilhos, templates e adapters.
+
+## Execução recomendada
+
+Ao receber uma tarefa de implementação ou análise via Codex:
+
+1. Ler `AGENTS.md`, se existir.
+2. Inspecionar a estrutura do repositório.
+3. Localizar padrões de skills existentes.
+4. Adaptar os caminhos sugeridos ao padrão real.
+5. Executar o premortem seguindo o fluxo definido em `premortem-core.md`.
+6. Mapear achados para gates usando `workflows/gate-mapping.md`.
+7. Gerar saída usando o template em `templates/premortem-report.md`.
+8. Se for uma implementação documental, criar ou atualizar os arquivos da skill e os gatilhos do AletheIA.
+9. Verificar consistência entre core, profiles, gates e triggers.
+10. Documentar arquivos criados/alterados.
+
+## Validação mínima
+
+Antes de finalizar, verificar:
+
+- A skill deixa claro quando usar e quando não usar.
+- A skill possui Lite, Standard e High-Assurance.
+- Os gatilhos não disparam premortem para qualquer feedback simples.
+- O AletheIA decide quando acionar, mas não contém o método inteiro.
+- O Adaptative Skills executa o método, mas não decide sozinho a criticidade.
+- Os gates estão conectados a achados do premortem.
+- O template de saída é utilizável em Markdown.
+
+## Resposta final esperada
+
+Ao concluir, responder com:
+
+```txt
+Arquivos criados/alterados:
+- ...
+
+Decisões tomadas:
+- ...
+
+Adaptações à estrutura existente:
+- ...
+
+Pendências:
+- ...
+
+Teste recomendado:
+- Rodar premortem sobre quality gates para desenvolvimento assistido por IA.
+```


### PR DESCRIPTION
## Summary

- Adds `codex.md` adapter alongside the existing `claude-code.md` — the flow includes Codex and other models
- Adds `runtime-adapters/README.md` documenting the runtime-agnostic pattern and instructions for adding new adapters

The core skill (`premortem-core.md`) remains runtime-agnostic. Adapters only translate the method to each runtime's conventions without replicating the method itself.

## Adapters now available

| Runtime | Arquivo |
|---|---|
| Claude Code | `claude-code.md` |
| Codex | `codex.md` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)