### PR TITLE
docs: fix stale Adaptative Skills references in premortem docs

### DIFF
--- a/docs/aletheia/triggers/premortem-triggers.md
+++ b/docs/aletheia/triggers/premortem-triggers.md
@@ -2,7 +2,7 @@
 
 ## Objetivo
 
-Definir quando o AletheIA deve acionar a skill de premortem do Adaptative Skills.
+Definir quando o AletheIA deve acionar a skill de premortem do Adaptive Skills.
 
 O AletheIA não executa o método completo. Ele avalia contexto, risco, reversibilidade e custo de erro para decidir se a skill deve ser chamada e com qual profundidade.
 

--- a/docs/skills/premortem/runtime-adapters/codex.md
+++ b/docs/skills/premortem/runtime-adapters/codex.md
@@ -37,7 +37,7 @@ Antes de finalizar, verificar:
 - A skill possui Lite, Standard e High-Assurance.
 - Os gatilhos não disparam premortem para qualquer feedback simples.
 - O AletheIA decide quando acionar, mas não contém o método inteiro.
-- O Adaptative Skills executa o método, mas não decide sozinho a criticidade.
+- O Adaptive Skills executa o método, mas não decide sozinho a criticidade.
 - Os gates estão conectados a achados do premortem.
 - O template de saída é utilizável em Markdown.
 


### PR DESCRIPTION
## Summary

Two premortem files created in this session still referenced the old repo name (`Adaptative Skills`) after the rename was completed in `adaptive-skills#23` and `AletheIA#123`.

- `docs/aletheia/triggers/premortem-triggers.md` — line 5
- `docs/skills/premortem/runtime-adapters/codex.md` — line 40

Note: references in `docs/dev-handoff-2026-05.md` are intentionally preserved — they describe the historical rename event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)