### PR TITLE
docs: clarify AletheIA operational boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ The repository is organized around four practical blocks:
 
 Crisis Monitor remains an important pilot source, but its product-specific runtime, UI, assistant behavior and project-management rules are not the portable AletheIA core.
 
+For the current ownership and re-entry boundary, see `docs/migration-from-crisis-monitor.md`.
+
 ---
 
 ## Full-system ecosystem and optional dependencies

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -93,12 +93,13 @@ AletheIA should be reusable outside the original pilot while still preserving th
 
 That reuse depends on an explicit boundary between the framework core and each project's local extension layer.
 
-At this point, Alpha 2 is organized around four explicit bridge artifacts and is supported by stronger real-world validation from the Crisis Monitor pilot:
+At this point, Alpha 2 is organized around five explicit bridge artifacts and is supported by stronger real-world validation from the Crisis Monitor pilot:
 
 - `docs/self-application.md`
 - `docs/pilot-crisis-monitor.md`
 - `docs/pilot-conversion.md`
 - `docs/project-extension-pattern.md`
+- `docs/migration-from-crisis-monitor.md`
 
 ---
 

--- a/docs/migration-from-crisis-monitor.md
+++ b/docs/migration-from-crisis-monitor.md
@@ -1,3 +1,64 @@
 # Migration from Crisis Monitor
 
-This document should map the extraction path from the Crisis Monitor repository into the standalone AletheIA repository.
+This document records the operational boundary between the original Crisis Monitor
+pilot and the standalone AletheIA repository.
+
+## Current boundary
+
+AletheIA is a standalone macro framework.
+Crisis Monitor is now a consumer and field case, not the backlog or source of
+truth for AletheIA evolution.
+
+Operationally:
+
+- Crisis Monitor product delivery is owned by the Crisis Monitor team.
+- AletheIA framework evolution is owned in this repository.
+- Adaptive Skills remains a separate micro-capability layer in its own
+  repository.
+- Pulso Design System remains a separate design-system repository.
+
+This repository may continue to cite Crisis Monitor as a pilot because the pilot
+generated real evidence.
+Those references should not import Crisis Monitor's product ownership,
+launch priorities, UI decisions, assistant behavior, or project-management rules
+into the AletheIA core.
+
+## Migration rule
+
+Reusable learnings may move from Crisis Monitor into AletheIA only when they can
+be expressed as framework-level guidance.
+
+Do migrate:
+
+- bounded operating patterns;
+- restart, handoff, validation, and governance lessons;
+- runtime-adapter constraints that stay project-agnostic;
+- examples that make the pilot evidence understandable.
+
+Do not migrate:
+
+- Crisis Monitor backlog ownership;
+- product roadmap commitments;
+- Cris-specific assistant behavior;
+- Pulso UI/design-system decisions;
+- Adaptive Skills implementation details.
+
+## Re-entry rule
+
+Future Crisis Monitor work should affect AletheIA only through an explicit
+integration issue or equivalent decision record that states:
+
+1. what framework-level problem was found;
+2. why the problem cannot stay local to Crisis Monitor;
+3. what portable AletheIA concept or contract needs to change;
+4. what validation proves the change remains reusable outside Crisis Monitor.
+
+## Related external evidence
+
+The Adaptive Skills repository keeps a matching case-study boundary in:
+
+- `docs/crisis-monitor-case-study.md`
+
+That document is external evidence for the macro/micro split.
+It is not imported here as an AletheIA source file because Adaptive Skills has
+its own repository and ownership boundary.


### PR DESCRIPTION
## What changed
- Replaced the placeholder Crisis Monitor migration note with an explicit operational boundary.
- Clarified that Crisis Monitor is a consumer/field case, not the backlog or source of truth for AletheIA evolution.
- Linked the boundary doc from the README and overview.

## Why it changed
- Crisis Monitor has been handed off to the development team.
- AletheIA, Adaptive Skills, and Pulso now evolve in their own repositories and ownership boundaries.

## How to validate
- `pnpm install --frozen-lockfile`
- `pnpm run test:all`
- `git diff --check`
- `git worktree list`

Validation run locally: `pnpm run test:all` passed after temporary dependency install; `node_modules` was removed afterward.

## Risks, assumptions or follow-ups
- Docs-only change; no runtime, schema, or API behavior changed.
- The repo currently uses the public wording “Adaptive Skills”; this PR preserves that wording.
- Future Crisis Monitor re-entry should happen through an explicit integration issue or equivalent decision record.