### PR TITLE
docs: add work slice spec bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ AletheIA decides the flow. Skills shape capability. Runtimes execute. Tools info
 2. `starter-pack/guides/daily-operations.md`
 3. `docs/apply-to-existing-project.md`
 4. `docs/project-extension-pattern.md`
+5. `docs/work-slice-spec-bundle.md` when a `Standard` or `High-Assurance` slice needs clearer pre-execution specification
 
 ### Work with handoffs and restart
 

--- a/docs/planning-depth-profiles.md
+++ b/docs/planning-depth-profiles.md
@@ -95,6 +95,13 @@ What `Standard` should usually make explicit:
 - expected proof shape
 - whether a handoff or review boundary is likely
 
+If requirements, technical decisions, or executable checkpoints are still ambiguous,
+`Standard` may use a small Work Slice Spec Bundle:
+
+- `spec.md`
+- `plan.md`
+- `tasks.md`
+
 What `Standard` should usually avoid:
 
 - turning into a full project plan
@@ -124,6 +131,10 @@ What `High-Assurance` should usually make explicit:
 - review and approval expectations
 - validation boundary
 - handoff expectations if execution crosses lanes or runtimes
+
+If the slice needs stronger pre-execution evidence, `High-Assurance` may use the full
+Work Slice Spec Bundle, including a `readiness-review.md` that instantiates the existing
+readiness gates for the slice.
 
 What `High-Assurance` should still avoid:
 
@@ -225,6 +236,7 @@ They are a proportional planning aid.
 ## Suggested next reading
 
 - `docs/readiness-gates-spec.md`
+- `docs/work-slice-spec-bundle.md`
 - `docs/work-slice-pattern.md`
 - `docs/progressive-policy-signals.md`
 - `docs/agent-runtime-decision-guide.md`

--- a/docs/readiness-gates-spec.md
+++ b/docs/readiness-gates-spec.md
@@ -179,6 +179,11 @@ A healthy rule is:
 - `Standard` -> more gates should be legible
 - `High-Assurance` -> the gates should be explicitly reviewable
 
+For slices that use a Work Slice Spec Bundle, `readiness-review.md` should instantiate
+these gates for that concrete slice. It should not redefine the gate model.
+
+See: `docs/work-slice-spec-bundle.md`.
+
 ---
 
 ## What this is not

--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -182,6 +182,7 @@ Current artifacts in this layer include:
 
 - `docs/work-slice-pattern.md`
 - `starter-pack/templates/work-slice-template.md`
+- `docs/work-slice-spec-bundle.md`
 - `starter-pack/guides/risk-to-gate-mapping.md`
 - `examples/work-slices/standard-slice/README.md`
 - `examples/handoffs/compact-reviewable-handoff.md`
@@ -196,6 +197,7 @@ Current artifacts in this layer include:
 This layer currently strengthens:
 
 - work-slice legibility
+- optional spec bundles for ambiguous `Standard` and `High-Assurance` slices
 - risk-to-gate mapping
 - stronger restart-package continuity
 - optional filesystem-based context routing experiments

--- a/docs/work-slice-pattern.md
+++ b/docs/work-slice-pattern.md
@@ -47,6 +47,13 @@ In practice, a work slice usually composes these artifacts:
 5. **restart package** when a clean execution surface is healthier
 6. **learning record** when the slice produces reusable learning
 
+For `Standard` or `High-Assurance` slices that need stronger pre-execution clarity,
+the slice may also include an optional **Work Slice Spec Bundle**.
+That bundle clarifies requirements, planning, executable tasks, and readiness evidence
+without replacing the Work Slice as the operating unit.
+
+See: `docs/work-slice-spec-bundle.md`.
+
 ---
 
 ## Why this matters
@@ -121,6 +128,7 @@ One healthy way to keep a slice legible is to group together:
 - `handoff-record.json` when needed
 - `restart-package.md` when the next boundary will resume on a clean surface
 - `learning-record.json` when generated
+- optional spec bundle artifacts when planning depth justifies them
 - `README.md` to explain the slice in plain language
 
 This is still a convenience pattern, not a required filesystem contract.

--- a/docs/work-slice-spec-bundle.md
+++ b/docs/work-slice-spec-bundle.md
@@ -1,0 +1,221 @@
+# Work Slice Spec Bundle
+
+## Goal
+
+Define an optional specification bundle for AletheIA Work Slices that need more clarity before execution.
+
+The bundle helps a slice make ambiguity, requirements, technical decisions, tasks, and readiness evidence reviewable without turning AletheIA into a heavyweight delivery methodology.
+
+---
+
+## Core rule
+
+The Work Slice remains the operational unit.
+
+The spec bundle is only an optional artifact group inside a Work Slice.
+It is not a new lifecycle, a new state machine, or a replacement for the task brief, decision record, execution record, handoff, restart package, or learning record.
+
+Healthy reading:
+
+```text
+Work Slice -> optional spec bundle -> execution / validation / closeout
+```
+
+Unhealthy reading:
+
+```text
+Spec bundle -> project lifecycle -> every task must fill every document
+```
+
+---
+
+## Why this exists
+
+AletheIA already has:
+
+- Work Slices as bounded operational units;
+- planning-depth profiles;
+- readiness gates;
+- task briefs and work-slice templates;
+- handoff and restart discipline.
+
+What is still useful for some `Standard` and `High-Assurance` slices is a clearer intermediate bundle between initial framing and execution.
+
+The bundle is meant to reduce four common failure modes:
+
+1. implementation begins while requirements are still implicit;
+2. technical choices appear before the `what` and `why` are clear;
+3. tasks become a backlog instead of an executable slice plan;
+4. readiness review becomes a narrative claim instead of inspectable evidence.
+
+---
+
+## When to use
+
+### Lite
+
+Do not use the bundle by default.
+
+A `Lite` slice should normally stay with the task brief, work-slice framing, and proportional validation.
+
+Use one small section from the bundle only if it removes immediate ambiguity faster than a longer discussion.
+
+### Standard
+
+Use the bundle when the slice is still bounded but has meaningful ambiguity, cross-artifact coordination, or moderate semantic risk.
+
+Recommended artifacts:
+
+- `spec.md`
+- `plan.md`
+- `tasks.md`
+
+`readiness-review.md` is optional unless review burden is already visible.
+
+### High-Assurance
+
+Use the bundle when the slice is hard to reverse, trust-sensitive, review-heavy, or likely to cross a boundary.
+
+Recommended artifacts:
+
+- `spec.md`
+- `plan.md`
+- `tasks.md`
+- `readiness-review.md`
+
+For `High-Assurance`, the readiness review should instantiate existing AletheIA gates rather than define new ones.
+
+---
+
+## Artifact roles
+
+### `spec.md`
+
+Clarifies the `what` and `why` before the technical plan.
+
+It should include:
+
+- problem and objective;
+- user, operator, or system outcomes;
+- functional expectations;
+- explicit assumptions;
+- open questions;
+- `[NEEDS CLARIFICATION]` items that should not be silently inferred.
+
+The spec should avoid premature architecture, stack choices, or implementation detail unless those are already a governing constraint.
+
+### `plan.md`
+
+Explains the `how` after the spec is clear enough.
+
+It should include:
+
+- proposed approach;
+- requirement-to-decision traceability;
+- key risks and tradeoffs;
+- non-goals and stop lines;
+- validation approach;
+- boundary or handoff expectations.
+
+A technical decision should point back to a requirement, risk, constraint, or explicit human choice.
+
+### `tasks.md`
+
+Turns the plan into executable slice work.
+
+It should include:
+
+- ordered checkpoints;
+- implementation tasks for the current slice;
+- validation tasks;
+- dependency or handoff notes.
+
+Tasks should describe executable slice steps, not a roadmap, product backlog, or full project phase plan.
+
+### `readiness-review.md`
+
+Instantiates existing readiness gates for this slice.
+
+It should answer whether the slice should:
+
+- `continue`;
+- `tighten`;
+- `review`;
+- `handoff`;
+- `escalate`;
+- `stop`.
+
+It should not redefine readiness gates or duplicate `docs/readiness-gates-spec.md`.
+
+---
+
+## Clarification first
+
+The highest-value behavior in this bundle is not the file structure.
+It is the discipline of clarifying before planning.
+
+Before writing or accepting `plan.md`, inspect `spec.md` for:
+
+- unresolved open questions;
+- assumptions that affect architecture, risk, scope, or validation;
+- hidden decisions that would change the execution path;
+- `[NEEDS CLARIFICATION]` markers that should become human decisions, explicit defaults, or stop lines.
+
+If a question changes scope, risk, or validation, do not bury it in the plan.
+Either answer it, tighten the slice, or route it to the relevant decision boundary.
+
+---
+
+## Relationship to Adaptive Skills
+
+AletheIA should decide when this bundle is justified and what readiness posture applies.
+
+A companion skill library may help execute the method by:
+
+- eliciting clarification questions;
+- shaping the spec;
+- decomposing the plan;
+- checking for overengineering;
+- stress-testing consequential plans.
+
+The method should stay outside the AletheIA core when it becomes specialist facilitation.
+AletheIA governs the slice; skills shape capability.
+
+---
+
+## Anti-ceremony guardrails
+
+Do not use the bundle to:
+
+- make every small task fill four documents;
+- import a full external specification lifecycle;
+- create a project backlog inside one slice;
+- duplicate the Work Slice template;
+- redefine readiness gates;
+- hide uncertainty behind polished language;
+- promote a skill method into framework core truth.
+
+A healthy bundle is smaller than the risk it reduces.
+
+---
+
+## Starter templates
+
+Use these starter-pack templates when the bundle is justified:
+
+- `starter-pack/templates/work-slice-spec-template.md`
+- `starter-pack/templates/work-slice-plan-template.md`
+- `starter-pack/templates/work-slice-tasks-template.md`
+- `starter-pack/templates/work-slice-readiness-review-template.md`
+
+For narrow slices, copy only the sections that are useful.
+
+---
+
+## Suggested next reading
+
+- `docs/work-slice-pattern.md`
+- `docs/planning-depth-profiles.md`
+- `docs/readiness-gates-spec.md`
+- `starter-pack/templates/work-slice-template.md`
+- `starter-pack/guides/risk-to-gate-mapping.md`

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -81,6 +81,11 @@ If you want to make bounded work more tangible without changing the core contrac
 - `starter-pack/templates/work-item-template.md`
 - `docs/work-slice-pattern.md`
 - `starter-pack/templates/work-slice-template.md`
+- `docs/work-slice-spec-bundle.md`
+- `starter-pack/templates/work-slice-spec-template.md`
+- `starter-pack/templates/work-slice-plan-template.md`
+- `starter-pack/templates/work-slice-tasks-template.md`
+- `starter-pack/templates/work-slice-readiness-review-template.md`
 - `starter-pack/guides/risk-to-gate-mapping.md`
 - `examples/work-slices/standard-slice/README.md`
 - `examples/handoffs/compact-reviewable-handoff.md`
@@ -95,6 +100,7 @@ It now also makes iterative maintenance rounds and regression-aware continuation
 Taken together, the current starter-pack now covers both:
 
 - advisory model strategy for choosing fit-for-task model profiles
+- optional pre-execution specification for ambiguous `Standard` and `High-Assurance` slices
 - operational maintenance guidance for carrying bounded work safely across repeated rounds
 - a clearer bridge between real pilot evidence and lightweight reusable framework guidance
 

--- a/starter-pack/templates/work-slice-plan-template.md
+++ b/starter-pack/templates/work-slice-plan-template.md
@@ -1,0 +1,69 @@
+# Work Slice Plan Template
+
+Use this after the spec is clear enough to plan execution.
+
+The plan should explain `how` without expanding the Work Slice into a project lifecycle.
+
+---
+
+## Slice reference
+
+- Slice ID:
+- Spec ref:
+- Planning depth: `Standard` / `High-Assurance`
+
+---
+
+## Proposed approach
+
+Describe the smallest coherent approach that satisfies the spec.
+
+---
+
+## Requirement-to-decision trace
+
+| Requirement / risk / constraint | Decision | Why this decision is proportional | Evidence expected |
+| --- | --- | --- | --- |
+|  |  |  |  |
+
+---
+
+## Non-goals and stop lines
+
+- Non-goal:
+- Stop line:
+
+---
+
+## Risks and tradeoffs
+
+| Risk or tradeoff | Impact | Mitigation or gate |
+| --- | --- | --- |
+|  |  |  |
+
+---
+
+## Boundary expectations
+
+- Handoff likely? `yes` / `no` / `maybe later`
+- Restart package likely? `yes` / `no` / `only if boundary changes`
+- Boundary reason:
+
+---
+
+## Validation approach
+
+List the proof needed before closure.
+
+- Proof:
+
+---
+
+## Plan readiness
+
+Before moving to tasks, confirm:
+
+- unresolved `[NEEDS CLARIFICATION]` items are answered, bounded, or promoted to a decision boundary;
+- technical decisions trace back to requirements, risks, constraints, or human choices;
+- the plan does not introduce hidden scope;
+- the validation approach is proportional to the risk.

--- a/starter-pack/templates/work-slice-readiness-review-template.md
+++ b/starter-pack/templates/work-slice-readiness-review-template.md
@@ -1,0 +1,70 @@
+# Work Slice Readiness Review Template
+
+Use this to instantiate existing AletheIA readiness gates for one Work Slice.
+
+Do not redefine the gates here. See `docs/readiness-gates-spec.md` for the canonical gate descriptions.
+
+---
+
+## Slice reference
+
+- Slice ID:
+- Spec ref:
+- Plan ref:
+- Tasks ref:
+- Planning depth: `Standard` / `High-Assurance`
+
+---
+
+## Gate review
+
+### Context minimum exists
+
+- Status: `pass` / `tighten` / `review`
+- Evidence:
+- Gap, if any:
+
+### Decision is clear enough
+
+- Status: `pass` / `tighten` / `review`
+- Evidence:
+- Gap, if any:
+
+### Risk is mapped enough
+
+- Status: `pass` / `tighten` / `review`
+- Evidence:
+- Gap, if any:
+
+### Handoff is usable enough
+
+- Status: `pass` / `not_needed` / `tighten` / `review`
+- Evidence:
+- Gap, if any:
+
+### Runtime / agent fit is acceptable enough
+
+- Status: `pass` / `tighten` / `review`
+- Evidence:
+- Gap, if any:
+
+---
+
+## Outcome
+
+Choose one:
+
+- `continue`
+- `tighten`
+- `review`
+- `handoff`
+- `escalate`
+- `stop`
+
+Reason:
+
+---
+
+## Required adjustment before execution or closure
+
+- [ ] Adjustment:

--- a/starter-pack/templates/work-slice-spec-template.md
+++ b/starter-pack/templates/work-slice-spec-template.md
@@ -1,0 +1,94 @@
+# Work Slice Spec Template
+
+Use this template when a `Standard` or `High-Assurance` Work Slice needs clearer `what` and `why` before technical planning.
+
+Keep it proportional. Delete sections that do not help this slice.
+
+---
+
+## Slice reference
+
+- Slice ID:
+- Related Work Item ref:
+- Planning depth: `Standard` / `High-Assurance`
+
+---
+
+## Problem
+
+What problem, opportunity, or ambiguity makes this slice necessary?
+
+---
+
+## Objective
+
+What should be true when this slice closes?
+
+---
+
+## Outcomes
+
+List the user, operator, system, or governance outcomes this slice must support.
+
+- Outcome 1:
+- Outcome 2:
+
+---
+
+## Requirements
+
+State requirements as observable expectations.
+
+- Requirement 1:
+- Requirement 2:
+
+---
+
+## Scope
+
+### In scope
+
+- Item:
+
+### Out of scope
+
+- Item:
+
+---
+
+## Assumptions
+
+List assumptions the slice is currently treating as true.
+
+- Assumption:
+  - Why it matters:
+  - How it will be validated or bounded:
+
+---
+
+## Open questions
+
+List questions that can be answered during exploration without blocking the slice.
+
+- Question:
+  - Current owner / source:
+  - Expected resolution point:
+
+---
+
+## Needs clarification
+
+Use this section for questions that should not be silently inferred.
+
+- `[NEEDS CLARIFICATION]`:
+  - Why it matters:
+  - Decision options or expected human input:
+  - Default if unanswered:
+
+---
+
+## Acceptance evidence
+
+What evidence should prove that the spec has been satisfied?
+
+- Evidence:

--- a/starter-pack/templates/work-slice-tasks-template.md
+++ b/starter-pack/templates/work-slice-tasks-template.md
@@ -1,0 +1,53 @@
+# Work Slice Tasks Template
+
+Use this to convert a plan into executable checkpoints for the current Work Slice.
+
+Tasks should be slice-sized. Do not turn this into a roadmap or backlog.
+
+---
+
+## Slice reference
+
+- Slice ID:
+- Plan ref:
+- Planning depth: `Standard` / `High-Assurance`
+
+---
+
+## Execution checkpoints
+
+1. Checkpoint:
+   - Purpose:
+   - Tasks:
+     - [ ] Task:
+   - Evidence before moving on:
+
+2. Checkpoint:
+   - Purpose:
+   - Tasks:
+     - [ ] Task:
+   - Evidence before moving on:
+
+---
+
+## Validation tasks
+
+- [ ] Task:
+
+---
+
+## Review or handoff tasks
+
+Use only if the plan identified a boundary.
+
+- [ ] Task:
+
+---
+
+## Out-of-slice backlog
+
+Record items discovered during planning that should not be executed in this slice.
+
+- Item:
+  - Why out of slice:
+  - Suggested next Work Slice or Work Item:

--- a/starter-pack/templates/work-slice-template.md
+++ b/starter-pack/templates/work-slice-template.md
@@ -86,6 +86,7 @@ Explain why the next boundary exists or why clean restart may be needed.
 Fill these with file paths, IDs, or references.
 
 - Task brief:
+- Spec bundle:
 - Decision record:
 - Execution record:
 - Handoff record:


### PR DESCRIPTION
## What changed
- Added a docs-first Work Slice Spec Bundle for Standard and High-Assurance slices that need stronger pre-execution clarity.
- Added starter-pack templates for spec, plan, tasks, and readiness review artifacts.
- Linked the bundle from Work Slice, planning depth, readiness gates, starter-pack, roadmap, and README entrypoints.

## Why it changed
- Improves planning/specification robustness while keeping AletheIA centered on Work Slice governance.
- Adapts the useful Spec Kit discipline of clarification before planning without copying its CLI, directory structure, or full methodology.
- Keeps Lite slices lightweight and preserves Adaptive Skills as the micro facilitation layer.

## How to validate
- `git diff --check`
- `bash scripts/check-governance.sh`
- Direct trailing-whitespace scan over new docs/templates

## Risks, assumptions or follow-ups
- Docs-only change; no runtime, schema, CLI, or automation introduced.
- Assumes the parallel Adaptive Skills front will decide whether to update existing skills or create a separate specification facilitation skill.
- Main risk is ceremony creep; the new guide explicitly frames the bundle as optional and proportional.