### PR TITLE
docs: update README diagrams for current AletheIA posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **AletheIA** is an operating framework for AI-assisted work: a portable layer that turns model or agent output into bounded, reviewable, validated action.
 
-![AletheIA architecture and operating flow](docs/assets/aletheia-architecture-flow.png)
+![AletheIA ecosystem and operating boundary](docs/assets/aletheia-architecture-flow.svg)
 
 AletheIA exists because capable agents still need an operating system around the work: scope, context, governance, validation, handoff and learning. The framework is not trying to replace human judgment or project-local rules. It makes the decision path visible enough that people can trust, review and restart the work.
 
@@ -42,7 +42,7 @@ AletheIA is not:
 
 The first image above shows AletheIA inside the broader AI-assisted work ecosystem. The diagram below zooms in on the AletheIA core itself: how a signal becomes a bounded slice, a decision, validated execution, closeout, restartable continuity and learning.
 
-![AletheIA framework core](docs/assets/aletheia-core-framework.png)
+![AletheIA core operating loop](docs/assets/aletheia-core-framework.svg)
 
 AletheIA moves work from a loose prompt-output pattern into an explicit operating loop:
 

--- a/docs/assets/aletheia-architecture-flow.svg
+++ b/docs/assets/aletheia-architecture-flow.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1800 1120" role="img" aria-labelledby="title desc">
+  <title id="title">AletheIA ecosystem and operating boundary</title>
+  <desc id="desc">Diagram showing AletheIA as the governance core between signals and governed action, with Adaptive Skills, runtime adapters, Hermes Agent and advisory tooling as bounded ecosystem components.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#32445A"/>
+    </marker>
+    <marker id="arrow-muted" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#73808E"/>
+    </marker>
+    <style>
+      .bg{fill:#F7F8FA}.ink{fill:#18202A}.muted{fill:#596575}.accent{fill:#32445A}.line{stroke:#AAB4C0;stroke-width:2;fill:none}.core-line{stroke:#1F2937;stroke-width:4;fill:none}.arrow{stroke:#32445A;stroke-width:4;fill:none;marker-end:url(#arrow)}.arrow-muted{stroke:#73808E;stroke-width:3;fill:none;marker-end:url(#arrow-muted)}.title{font:700 42px Arial, sans-serif}.subtitle{font:400 23px Arial, sans-serif}.box-title{font:700 24px Arial, sans-serif}.body{font:400 19px Arial, sans-serif}.small{font:400 16px Arial, sans-serif}.small-bold{font:700 16px Arial, sans-serif}
+    </style>
+  </defs>
+  <rect class="bg" width="1800" height="1120"/>
+  <text x="80" y="82" class="title ink">AletheIA ecosystem and operating boundary</text>
+  <text x="82" y="134" class="subtitle muted">AletheIA governs the flow. Skills shape capability. Runtimes execute. Tools inform.</text>
+
+  <rect x="80" y="250" width="330" height="200" rx="22" fill="#EAF2FF" stroke="#AAB4C0" stroke-width="2"/>
+  <text x="102" y="288" class="box-title ink">Signals</text>
+  <text x="102" y="326" class="body muted"><tspan x="102" dy="0">Human request</tspan><tspan x="102" dy="25">Project work item</tspan><tspan x="102" dy="25">Model / agent output</tspan><tspan x="102" dy="25">Pilot evidence</tspan></text>
+
+  <rect x="550" y="190" width="700" height="330" rx="34" fill="#E9EEF5" stroke="#1F2937" stroke-width="4"/>
+  <text x="900" y="262" text-anchor="middle" class="title ink">AletheIA Core</text>
+  <text x="900" y="305" text-anchor="middle" class="small-bold accent">Stable 1.0 baseline</text>
+  <text x="900" y="355" text-anchor="middle" class="body ink"><tspan x="900" dy="0">Work Slice · context · decision kernel · governance</tspan><tspan x="900" dy="28">validation · handoff · restart package · learning record</tspan></text>
+  <text x="900" y="430" text-anchor="middle" class="small muted"><tspan x="900" dy="0">Not a chatbot, auto-router, runtime wrapper,</tspan><tspan x="900" dy="22">or replacement for human accountability.</tspan></text>
+
+  <rect x="1390" y="250" width="330" height="200" rx="22" fill="#EAF7F0" stroke="#AAB4C0" stroke-width="2"/>
+  <text x="1412" y="288" class="box-title ink">Governed action</text>
+  <text x="1412" y="326" class="body muted"><tspan x="1412" dy="0">Bounded execution</tspan><tspan x="1412" dy="25">Validated change</tspan><tspan x="1412" dy="25">Reviewable evidence</tspan><tspan x="1412" dy="25">Restartable continuity</tspan></text>
+
+  <path class="arrow" d="M410 350 H550"/>
+  <path class="arrow" d="M1250 350 H1390"/>
+
+  <rect x="80" y="670" width="360" height="240" rx="22" fill="#F1EDFF" stroke="#AAB4C0" stroke-width="2"/>
+  <text x="102" y="708" class="box-title ink">Adaptive Skills</text>
+  <text x="102" y="748" class="body muted"><tspan x="102" dy="0">External micro-capability layer</tspan><tspan x="102" dy="25">for specialist patterns: UX,</tspan><tspan x="102" dy="25">product, QA, technical review,</tspan><tspan x="102" dy="25">observability and domain</tspan><tspan x="102" dy="25">analysis.</tspan></text>
+
+  <rect x="500" y="670" width="360" height="240" rx="22" fill="#FFF7DF" stroke="#AAB4C0" stroke-width="2"/>
+  <text x="522" y="708" class="box-title ink">Runtime adapters</text>
+  <text x="522" y="748" class="body muted"><tspan x="522" dy="0">Local mappings that preserve</tspan><tspan x="522" dy="25">AletheIA meaning across Codex,</tspan><tspan x="522" dy="25">Claude Code, Qwen or other</tspan><tspan x="522" dy="25">execution surfaces.</tspan></text>
+
+  <rect x="940" y="670" width="360" height="240" rx="22" fill="#FFF0F0" stroke="#AAB4C0" stroke-width="2"/>
+  <text x="962" y="708" class="box-title ink">Hermes Agent</text>
+  <text x="962" y="748" class="body muted"><tspan x="962" dy="0">Candidate controlled executor.</tspan><tspan x="962" dy="25">Current posture: pre-pilot /</tspan><tspan x="962" dy="25">guarded. Must not govern</tspan><tspan x="962" dy="25">process, memory or skills.</tspan></text>
+
+  <rect x="1360" y="670" width="360" height="240" rx="22" fill="#EEF1F4" stroke="#AAB4C0" stroke-width="2"/>
+  <text x="1382" y="708" class="box-title ink">Advisory tooling</text>
+  <text x="1382" y="748" class="body muted"><tspan x="1382" dy="0">Context graph, Agentic Stack or</tspan><tspan x="1382" dy="25">local infrastructure may inform</tspan><tspan x="1382" dy="25">work, but do not replace</tspan><tspan x="1382" dy="25">validation or governance.</tspan></text>
+
+  <path class="arrow-muted" d="M700 520 L260 670"/>
+  <path class="arrow-muted" d="M820 520 L680 670"/>
+  <path class="arrow-muted" d="M980 520 L1120 670"/>
+  <path class="arrow-muted" d="M1100 520 L1540 670"/>
+
+  <rect x="80" y="980" width="1640" height="70" rx="18" fill="#FFFFFF" stroke="#D8DEE6" stroke-width="1"/>
+  <text x="110" y="1012" class="small-bold accent"><tspan x="110" dy="0">Current posture: 1.0 core is stable. 1.1 hardens constrained adoption and trust boundaries. 1.2 adds resource-aware operations without becoming benchmark,</tspan><tspan x="110" dy="22">auto-routing or orchestration automation.</tspan></text>
+</svg>

--- a/docs/assets/aletheia-core-framework.svg
+++ b/docs/assets/aletheia-core-framework.svg
@@ -1,0 +1,96 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1800 1200" role="img" aria-labelledby="title desc">
+  <title id="title">AletheIA core operating loop</title>
+  <desc id="desc">Diagram showing the AletheIA core loop from signal, framing, context and governance through execution, validation, handoff and learning, with resource-aware signals in the 1.2 layer.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#32445A"/></marker>
+    <marker id="arrow-muted" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#73808E"/></marker>
+    <style>
+      .bg{fill:#F7F8FA}.ink{fill:#18202A}.muted{fill:#596575}.accent{fill:#32445A}.arrow{stroke:#32445A;stroke-width:4;fill:none;marker-end:url(#arrow)}.arrow-muted{stroke:#73808E;stroke-width:3;fill:none;marker-end:url(#arrow-muted)}.title{font:700 42px Arial, sans-serif}.subtitle{font:400 23px Arial, sans-serif}.box-title{font:700 24px Arial, sans-serif}.body{font:400 19px Arial, sans-serif}.small{font:400 16px Arial, sans-serif}.small-bold{font:700 16px Arial, sans-serif}.tiny{font:400 13px Arial, sans-serif}
+    </style>
+  </defs>
+  <rect class="bg" width="1800" height="1200"/>
+  <text x="80" y="82" class="title ink">AletheIA core operating loop</text>
+  <text x="82" y="134" class="subtitle muted">A bounded slice moves from signal to evidence, handoff and learning through explicit gates.</text>
+
+  <g id="loop-boxes">
+    <rect x="80" y="240" width="280" height="160" rx="22" fill="#EAF2FF" stroke="#AAB4C0" stroke-width="2"/>
+    <text x="102" y="278" class="box-title ink">1. Signal</text>
+    <text x="102" y="318" class="body muted"><tspan x="102" dy="0">Request, issue, risk,</tspan><tspan x="102" dy="25">pilot evidence or</tspan><tspan x="102" dy="25">model output.</tspan></text>
+
+    <rect x="430" y="240" width="280" height="160" rx="22" fill="#EAF2FF" stroke="#AAB4C0" stroke-width="2"/>
+    <text x="452" y="278" class="box-title ink">2. Framing</text>
+    <text x="452" y="318" class="body muted"><tspan x="452" dy="0">Define Work Slice,</tspan><tspan x="452" dy="25">scope, assumptions</tspan><tspan x="452" dy="25">and stop line.</tspan></text>
+
+    <rect x="780" y="240" width="280" height="160" rx="22" fill="#EAF2FF" stroke="#AAB4C0" stroke-width="2"/>
+    <text x="802" y="278" class="box-title ink">3. Context</text>
+    <text x="802" y="318" class="body muted"><tspan x="802" dy="0">Load enough context</tspan><tspan x="802" dy="25">without treating every</tspan><tspan x="802" dy="25">transcript as state.</tspan></text>
+
+    <rect x="1130" y="240" width="280" height="160" rx="22" fill="#FFF7DF" stroke="#AAB4C0" stroke-width="2"/>
+    <text x="1152" y="278" class="box-title ink">4. Governance</text>
+    <text x="1152" y="318" class="body muted"><tspan x="1152" dy="0">Allow, tighten, review,</tspan><tspan x="1152" dy="25">escalate, block,</tspan><tspan x="1152" dy="25">handoff or restart.</tspan></text>
+
+    <rect x="1450" y="510" width="280" height="160" rx="22" fill="#EAF7F0" stroke="#AAB4C0" stroke-width="2"/>
+    <text x="1472" y="548" class="box-title ink">5. Execution</text>
+    <text x="1472" y="588" class="body muted"><tspan x="1472" dy="0">Use the selected</tspan><tspan x="1472" dy="25">surface inside the</tspan><tspan x="1472" dy="25">approved boundary.</tspan></text>
+
+    <rect x="1130" y="780" width="280" height="160" rx="22" fill="#EAF7F0" stroke="#AAB4C0" stroke-width="2"/>
+    <text x="1152" y="818" class="box-title ink">6. Validation</text>
+    <text x="1152" y="858" class="body muted"><tspan x="1152" dy="0">Close with tests,</tspan><tspan x="1152" dy="25">review, artifacts or</tspan><tspan x="1152" dy="25">documented proof.</tspan></text>
+
+    <rect x="780" y="780" width="280" height="160" rx="22" fill="#F1EDFF" stroke="#AAB4C0" stroke-width="2"/>
+    <text x="802" y="818" class="box-title ink">7. Handoff</text>
+    <text x="802" y="858" class="body muted"><tspan x="802" dy="0">Preserve restart</tspan><tspan x="802" dy="25">package and continuity</tspan><tspan x="802" dy="25">at boundaries.</tspan></text>
+
+    <rect x="430" y="780" width="280" height="160" rx="22" fill="#F1EDFF" stroke="#AAB4C0" stroke-width="2"/>
+    <text x="452" y="818" class="box-title ink">8. Learning</text>
+    <text x="452" y="858" class="body muted"><tspan x="452" dy="0">Promote reusable,</tspan><tspan x="452" dy="25">reviewable improvements</tspan><tspan x="452" dy="25">from real friction.</tspan></text>
+  </g>
+
+  <path class="arrow" d="M360 320 H430"/>
+  <path class="arrow" d="M710 320 H780"/>
+  <path class="arrow" d="M1060 320 H1130"/>
+  <path class="arrow" d="M1410 360 L1510 510"/>
+  <path class="arrow" d="M1450 640 L1410 820"/>
+  <path class="arrow" d="M1130 860 H1060"/>
+  <path class="arrow" d="M780 860 H710"/>
+  <path class="arrow-muted" d="M430 860 C300 760 230 520 260 400"/>
+
+  <rect x="630" y="470" width="540" height="240" rx="34" fill="#E9EEF5" stroke="#1F2937" stroke-width="4"/>
+  <text x="900" y="542" text-anchor="middle" class="title ink">Decision Kernel</text>
+  <text x="900" y="595" text-anchor="middle" class="body muted"><tspan x="900" dy="0">The kernel decides the operating posture,</tspan><tspan x="900" dy="28">not the content by itself.</tspan></text>
+  <text x="900" y="666" text-anchor="middle" class="small-bold accent">continue · tighten · review · escalate · handoff · restart · stop</text>
+
+  <path class="arrow-muted" d="M1270 400 L1040 470"/>
+  <path class="arrow-muted" d="M1170 620 L1450 590"/>
+  <path class="arrow-muted" d="M630 600 L360 380"/>
+  <path class="arrow-muted" d="M900 710 V780"/>
+
+  <rect x="80" y="1010" width="1640" height="125" rx="24" fill="#FFFFFF" stroke="#D8DEE6" stroke-width="2"/>
+  <text x="110" y="1062" class="box-title ink">1.2 Resource-aware signals</text>
+
+  <g id="signals" class="tiny muted">
+    <rect x="440" y="1030" width="190" height="85" rx="18" fill="#EEF1F4" stroke="#D8DEE6"/>
+    <text x="535" y="1064" text-anchor="middle" class="small-bold ink">Context drag</text>
+    <text x="535" y="1087" text-anchor="middle" class="tiny muted">context growth cost</text>
+
+    <rect x="645" y="1030" width="190" height="85" rx="18" fill="#EEF1F4" stroke="#D8DEE6"/>
+    <text x="740" y="1064" text-anchor="middle" class="small-bold ink">Retry waste</text>
+    <text x="740" y="1087" text-anchor="middle" class="tiny muted">failed loops</text>
+
+    <rect x="850" y="1030" width="190" height="85" rx="18" fill="#EEF1F4" stroke="#D8DEE6"/>
+    <text x="945" y="1064" text-anchor="middle" class="small-bold ink">Handoff inflation</text>
+    <text x="945" y="1087" text-anchor="middle" class="tiny muted">continuity burden</text>
+
+    <rect x="1055" y="1030" width="190" height="85" rx="18" fill="#EEF1F4" stroke="#D8DEE6"/>
+    <text x="1150" y="1064" text-anchor="middle" class="small-bold ink">Runtime fit</text>
+    <text x="1150" y="1087" text-anchor="middle" class="tiny muted">surface / task match</text>
+
+    <rect x="1260" y="1030" width="190" height="85" rx="18" fill="#EEF1F4" stroke="#D8DEE6"/>
+    <text x="1355" y="1064" text-anchor="middle" class="small-bold ink">Readiness</text>
+    <text x="1355" y="1087" text-anchor="middle" class="tiny muted">continue or stop</text>
+
+    <rect x="1465" y="1030" width="190" height="85" rx="18" fill="#EEF1F4" stroke="#D8DEE6"/>
+    <text x="1560" y="1064" text-anchor="middle" class="small-bold ink">Clean restart</text>
+    <text x="1560" y="1087" text-anchor="middle" class="tiny muted">fresh thread signal</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Updates the README diagrams to better match the current AletheIA posture after the 1.0 baseline and the active 1.1 / 1.2 evolution tracks.

## Changes

- Adds `docs/assets/aletheia-architecture-flow.svg` as a clearer ecosystem / operating-boundary diagram.
- Adds `docs/assets/aletheia-core-framework.svg` as an updated core-loop diagram.
- Updates `README.md` to reference the new SVG diagrams instead of the older PNG files.

## Rationale

The previous PNG diagrams still represented the core idea correctly, but under-expressed the current state of the framework:

- 1.0 stable baseline
- 1.1 constrained adoption / trust-boundary hardening
- 1.2 resource-aware operations
- clean restart and restart burden
- runtime fit without auto-routing claims
- Hermes as pre-pilot / guarded, not an active runtime
- advisory tooling as informative, not governing

## Validation

Docs-only visual update. No runtime behavior changes.