### PR TITLE
docs(adr): ADR-004 — AletheIA as operating overlay

### DIFF
--- a/docs/adr/ADR-004-aletheia-as-operating-overlay.md
+++ b/docs/adr/ADR-004-aletheia-as-operating-overlay.md
@@ -1,0 +1,72 @@
+# ADR 004 — AletheIA as operating overlay
+
+| Field | Value |
+|---|---|
+| Status | Accepted |
+| Date | 2026-05-20 |
+| Author | Neviton Santana |
+| Deciders | Neviton Santana |
+| Related | ADR-001 (Hermes role), ADR-002 (Memory and skill promotion), ADR-003 (Slice record / closeout) |
+| Supersedes | — |
+
+## 1. Context
+
+AletheIA's information surface conflates three concerns: the **product** being built, the **operating discipline** for building it with AI, and the **runtime** that executes the agent. The ambiguity produces recurring friction — PRs stuck on "overlay or app?", runtime patterns pressing to be absorbed into the core, and documents drifting into `docs/` without a clear owner-category. The boundary must be fixed before reorganizing `docs/` (Epic 1 of the 2026-05-20 structural plan); otherwise reorganization only relocates the ambiguity.
+
+## 2. Decision
+
+**AletheIA is the operating overlay — a portable layer between the consumer project and the execution harness.** It does not absorb product architecture and does not absorb runtime state.
+
+| Layer | Question it answers | Where it lives |
+|---|---|---|
+| Product / app | *How to build it?* | Consumer project repository |
+| Operating overlay (AletheIA) | *How to operate, decide, validate, hand off?* | Dedicated directory in the consumer project + canonical framework in AletheIA repo |
+| Harness runtime | *Where and with what resources to execute?* | `~/.claude/`, `~/.codex/`, `~/.hermes/`, etc. |
+
+### 2.1 Membership criterion
+
+- About *how the code is built* → **product**.
+- About *how to decide what to do, validate, deliver, hand off, learn* → **overlay**.
+- About *credentials, sessions, plugins, local agent logs* → **harness**.
+
+When an artifact appears to belong to two layers, it is mis-factored, not evidence the boundary is wrong. Refactor before relocating.
+
+### 2.2 Resolved examples (normative)
+
+1. **Hermes session DB / cron / plugin state** → harness, not AletheIA core.
+2. **Crisis Monitor local `constitution/`** → overlay, but inside the *consumer project*.
+3. **Canonical vocabulary, planning depth profiles, waste heuristics** → overlay in AletheIA core.
+4. **Hermes logging plugin or message gateway adapter** → harness.
+5. **Delivery output contract, runtime adapter contract, readiness gates spec** → overlay in AletheIA core.
+6. **Closeout templates and handoff schemas** → overlay in AletheIA core.
+7. **`src/`, `services/`, framework-of-choice conventions** → product. AletheIA does not opine.
+
+## 3. Consequences
+
+**Positive**: PRs gain an explicit "does this belong here?" criterion; pressure to absorb runtime capabilities is bounded by rule, not taste; `docs/` reorganization has a fixed reference; harness shims are defined as thin adapters, not standalone surfaces.
+
+**Negative**: judgment is still required in genuinely ambiguous zones; some natural-feeling integrations (e.g., logging plugins in core) are deliberately excluded; consumer projects must accept a dedicated overlay directory.
+
+**Accepted tradeoff**: a narrower core with a defended boundary beats a broader core that drifts into product or runtime.
+
+## 4. Alternatives considered
+
+- **A. Extract the bootstrap into a separate repo now.** Rejected — crystallizes conventions before evidence they generalize.
+- **B. AletheIA absorbs Hermes-style runtime state.** Rejected — conflates governing with executing; inflates core, reduces portability.
+- **C. AletheIA dictates product architecture.** Rejected — invades the consumer project's territory.
+- **D. Keep the ambiguity, decide case by case.** Rejected — re-litigation cost already exceeds the cost of this ADR.
+
+## 5. Relationship
+
+ADR-001 is the runtime-specific instance of this principle. ADR-002 and ADR-003 describe artifacts that live inside the overlay layer. The 2026-05-20 structural plan consumes this ADR as prerequisite for Epic 1; the `consumer-project-overlay` contract (Epic 4) is its normative instantiation.
+
+## 6. Review
+
+Reopen when:
+
+- **3+ consumer projects** adopt the same overlay with diffs <20% → consider extracting the bootstrap.
+- A recurring pattern genuinely belongs to two layers and splitting produces two worse artifacts → revisit section 2.1.
+- A harness arrives whose state cannot be cleanly separated from overlay → revisit the harness layer definition.
+- The term "operating overlay" starts being cited with materially different meaning → re-tighten section 2.
+
+If a review confirms the decision unchanged, record the confirmation date here and continue.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,68 @@
+# Architecture Decision Records (ADRs)
+
+This directory holds **durable architectural decisions** for AletheIA. ADRs are written when a decision is hard to reverse, affects multiple parts of the framework, or settles a recurring ambiguity that has cost time to re-litigate.
+
+## What an ADR is — and is not
+
+- **Is**: a record of *why* we decided something at a specific date, with the alternatives we rejected and the conditions that would reopen the decision.
+- **Is not**: a tutorial, a roadmap, or a contract spec. Those live in `docs/concepts/`, `docs/roadmaps/`, and `docs/contracts/` (taxonomy in progress — see the structural improvement plan).
+
+If a document explains *how* to do something, it is a guide. If it specifies *what must be true*, it is a contract. ADRs answer *why this path and not another*.
+
+## Convention
+
+- **Format**: lightweight, repo-native. Not strict [MADR](https://adr.github.io/madr/) — adopted incrementally as needed.
+- **Filename**: `ADR-NNN-<kebab-case-title>.md`, with `NNN` zero-padded.
+- **Numbering**: monotonic, never reused. If an ADR is superseded, the new ADR gets the next number and links back via the `Supersedes` field.
+- **Status values**: `Proposed`, `Accepted`, `Superseded by ADR-XXX`, `Rejected`, `Deprecated`.
+- **Length**: prefer ≤2 pages. If an ADR grows past that, the decision is probably mixing two concerns.
+
+## Required structure
+
+Every ADR starts with a metadata table:
+
+```markdown
+| Field | Value |
+|---|---|
+| Status | Accepted |
+| Date | YYYY-MM-DD |
+| Author | <name> |
+| Deciders | <names> |
+| Related | ADR-XXX — <title> |
+| Supersedes | — or ADR-XXX |
+```
+
+Followed by numbered sections:
+
+1. **Context** — what is the state of the world and what is the open question.
+2. **Decision** — what we decided, in normative voice.
+3. **Consequences** — positive, negative, and accepted tradeoffs.
+4. **Alternatives considered** — what we rejected and why.
+5. **Relationship** — to other ADRs, phases, or artifacts that depend on this decision.
+6. **Review** — conditions that would reopen the ADR.
+
+See [ADR-001](ADR-001-hermes-role.md) as the canonical example.
+
+## When to write an ADR
+
+Write one when:
+
+- A decision will be cited or contested across multiple PRs or sessions.
+- A boundary is being drawn (what belongs / what does not belong).
+- An autonomy or safety threshold is being fixed.
+- A path is being chosen that closes off other paths for a non-trivial period.
+
+Do *not* write one for:
+
+- Implementation choices that are obvious from the code.
+- Decisions that only affect a single PR's scope.
+- Documentation reorganization (use the docs index + migration table instead).
+
+## Current ADRs
+
+| ID | Title | Status |
+|---|---|---|
+| [ADR-001](ADR-001-hermes-role.md) | Hermes role in the AletheIA pipeline | Accepted |
+| [ADR-002](ADR-002-memory-and-skill-promotion-policy.md) | Memory and skill promotion policy | Accepted |
+| [ADR-003](ADR-003-slice-record-closeout-relationship.md) | Slice record / closeout relationship | Accepted |
+| [ADR-004](ADR-004-aletheia-as-operating-overlay.md) | AletheIA as operating overlay | Accepted |


### PR DESCRIPTION
## Summary

- Adds `docs/adr/README.md`: documents the repo's ADR convention (format, naming, required structure, when to write).
- Adds `docs/adr/ADR-004-aletheia-as-operating-overlay.md`: fixes the conceptual boundary between product, operating overlay, and harness runtime — prerequisite for the `docs/` reorganization (Epic 1 of the 2026-05-20 structural improvement plan).

## Why now

The `docs/` audit and taxonomy (Epic 1) depends on a clear membership criterion. Without this ADR, classifying ~70 documents would require case-by-case negotiation. With it, every ambiguous case has an explicit decision to cite.

## Key decisions recorded

- AletheIA is the operating overlay: portable layer between consumer project and execution harness.
- Three-layer boundary with membership criterion by "question it answers".
- 7 normative examples (§2.2) resolving the most common ambiguous cases (Hermes runtime state, Crisis Monitor constitution, canonical contracts).
- Bootstrap extraction gated on 3+ consumer projects with <20% overlay diffs (not yet).

## Scope

Epic 0 of the AletheIA structural improvement plan. No files moved or renamed. No content created beyond the ADR and its convention README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)