### PR TITLE
docs(contracts): consumer-project-overlay contract + minimal example — Epic 4

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -19,6 +19,7 @@ If you need conceptual background, see [`concepts/`](../concepts/README.md). If 
 | [slice-telemetry-model.md](slice-telemetry-model.md) | Minimal model for recording slice-level telemetry |
 | [work-slice-spec-bundle.md](work-slice-spec-bundle.md) | Optional spec bundle for slices that need pre-execution clarity |
 | [durable-decision-finalization-context-prompt.md](durable-decision-finalization-context-prompt.md) | Accepted durable decision: require finalization context prompt at slice close |
+| [consumer-project-overlay.md](consumer-project-overlay.md) | How a consumer project instantiates the operating overlay (`ops/ai/` + harness shims). Reference example: [`examples/consumer-overlay-minimal/`](../../examples/consumer-overlay-minimal/) |
 
 ### Bootstrap contracts — note on relationship
 

--- a/docs/contracts/consumer-project-overlay.md
+++ b/docs/contracts/consumer-project-overlay.md
@@ -1,0 +1,259 @@
+# Consumer-project overlay contract
+
+> **Normative.** This contract specifies how a consumer project instantiates the AletheIA operating overlay. It does not dictate product architecture (see [operating-overlay](../concepts/operating-overlay.md) §"Antifragile patterns") and does not replace an application framework. It defines only the overlay surface.
+>
+> See also: [ADR-004](../adr/ADR-004-aletheia-as-operating-overlay.md), [operating-overlay](../concepts/operating-overlay.md), [project-extension-pattern](../concepts/project-extension-pattern.md), [project-local-constitution-context](../concepts/project-local-constitution-context.md).
+
+## 1. Scope
+
+This contract specifies:
+
+- The directory layout a consumer project MUST adopt to host the overlay.
+- The purpose, minimum content, and exclusion rules for each overlay folder.
+- The conformance level of each element: **MUST**, **SHOULD**, **MAY** (RFC 2119).
+- A minimum-viable adoption path for legacy projects.
+- File-naming conventions for overlay artifacts.
+
+This contract does NOT specify:
+
+- The product's source layout (`src/`, `services/`, `app/`, etc.).
+- Build, test, or deploy tooling for the product.
+- Harness-specific runtime behavior (those are harness shims; see [runtime-adapter-contract](runtime-adapter-contract.md)).
+
+## 2. Required directory layout
+
+```
+consumer-project/
+├── <product code>                   # OUT OF SCOPE — product layer
+├── AGENTS.md                        # MUST — cross-agent dispatcher
+├── CLAUDE.md                        # MUST (if Claude Code is used)
+├── .claude/                         # MUST (if Claude Code is used) — harness shim
+│   ├── rules/                       # SHOULD
+│   └── settings.json                # SHOULD
+└── ops/ai/                          # MUST — the overlay root
+    ├── constitution/                # MUST
+    ├── handoffs/                    # MUST
+    ├── reports/                     # MUST
+    ├── policies/                    # SHOULD
+    ├── schemas/                     # MAY
+    ├── skills/                      # MAY
+    └── learnings/                   # SHOULD
+```
+
+The overlay root MUST be `ops/ai/`. Renaming is non-conformant; the path is the contract.
+
+## 3. Folder specifications
+
+Each subsection states: **purpose**, **minimum content**, **examples**, **what NOT to put**, and **conformance**.
+
+### 3.1 `ops/ai/constitution/` — MUST
+
+**Purpose.** Fix the project's mission, scope, primary stack, principles, and non-negotiables. The constitution is the document an agent reads first to know what game it is playing.
+
+**Minimum content.**
+- `mission.md` — one paragraph: what the project exists to do, for whom.
+- `scope.md` — in/out of scope; what the project does NOT do.
+- `stack.md` — primary languages, frameworks, infra; one line each.
+- `principles.md` — 5–10 non-negotiable principles; no platitudes.
+
+**Examples of good entries.**
+- mission: *"Crisis Monitor surfaces emerging operational incidents across our regions in under 5 minutes, for the incident-response team."*
+- principle: *"Never silently drop an alert. If a sink fails, surface the failure as a higher-priority alert."*
+
+**What NOT to put.**
+- Product architecture diagrams (those belong in product docs).
+- API specifications (product docs).
+- Runtime credentials, tokens, environment URLs (harness).
+
+**Conformance.** MUST exist with at least the four files above non-empty.
+
+### 3.2 `ops/ai/handoffs/` — MUST
+
+**Purpose.** Capture transitions between sessions, agents, or humans. A handoff lets the next operator start without re-deriving context.
+
+**Minimum content.** At least the most recent handoff file. Naming: `YYYY-MM-DD-<slug>.md` (ISO date prefix, see §5).
+
+**Required handoff structure** (see [handoff-capture-pattern](../concepts/handoff-capture-pattern.md) for full pattern):
+- **Context** — what was being worked on and why.
+- **State** — what is done, in progress, blocked.
+- **Next** — concrete next steps for the resumer.
+- **Open questions** — anything that needs human input.
+
+**Examples.**
+- `2026-05-18-claude-to-codex-auth-refactor.md`
+- `2026-05-19-end-of-session-incident-pipeline.md`
+
+**What NOT to put.**
+- Long-form decision rationale (use `reports/` for closeouts or a project ADR for decisions).
+- Conversational session transcripts (those are harness state).
+
+**Conformance.** MUST contain at least one handoff after the first non-trivial session. Empty directory is acceptable only before first use.
+
+### 3.3 `ops/ai/reports/` — MUST
+
+**Purpose.** Closeouts and progress reports. A report makes a unit of work reviewable by someone who was not in the room.
+
+**Minimum content.** Closeout per work slice (or per sprint, depending on cadence). Naming: `YYYY-MM-DD-<slug>-closeout.md`.
+
+**Required closeout structure** (three layers, per the author's standard format):
+1. **Done** — what shipped.
+2. **Pending** — what was scoped but not shipped, with reason.
+3. **Frictions** — what got in the way; signal for overlay or local refinement.
+
+**Examples.**
+- `2026-05-15-alert-pipeline-v1-closeout.md`
+- `2026-05-19-onboarding-flow-closeout.md`
+
+**What NOT to put.**
+- Real-time status (Slack/standup is the right channel).
+- Marketing copy. Closeouts are operational, not promotional.
+
+**Conformance.** MUST contain at least one closeout per shipped slice.
+
+### 3.4 `ops/ai/policies/` — SHOULD
+
+**Purpose.** Local rules that constrain how the agent operates on this project, beyond what canonical AletheIA already imposes.
+
+**Minimum content.** One file per concern. Examples:
+- `pr-policy.md` — required reviewers, branch naming, commit conventions.
+- `data-handling-policy.md` — what data can/can't enter logs, prompts, or context windows.
+- `tool-use-policy.md` — which MCP servers or external services are permitted.
+
+**What NOT to put.**
+- Restatements of canonical AletheIA policies (link to them).
+- Hard-coded credentials or API keys.
+
+**Conformance.** SHOULD exist if the project has non-default operational constraints. MAY be omitted for purely exploratory projects.
+
+### 3.5 `ops/ai/schemas/` — MAY
+
+**Purpose.** Project-local data structures used by overlay operations (e.g., custom telemetry shapes, project-specific closeout extensions).
+
+**Minimum content.** JSON Schema or YAML; one file per structure.
+
+**What NOT to put.**
+- Product domain schemas (those belong in the product layer).
+- Schemas already specified in canonical AletheIA (link to them).
+
+**Conformance.** MAY be omitted entirely. If present, every schema MUST be valid JSON Schema / YAML and linked from the artifact that uses it.
+
+### 3.6 `ops/ai/skills/` — MAY
+
+**Purpose.** Reusable operating procedures specific to this project, packaged so the agent can invoke them by name.
+
+**Minimum content.** One folder per skill, each with a `SKILL.md` describing trigger, inputs, outputs, and steps.
+
+**Examples.**
+- `incident-triage/SKILL.md` — how to triage a Crisis Monitor incident.
+- `migration-checklist/SKILL.md` — pre-deploy checklist for schema migrations.
+
+**What NOT to put.**
+- Generic skills that would apply to any project (promote to canonical AletheIA via the [promotion gate](../concepts/operating-overlay.md#antifragile-patterns-how-to-avoid-drift)).
+- Product code disguised as a skill.
+
+**Conformance.** MAY be omitted.
+
+### 3.7 `ops/ai/learnings/` — SHOULD
+
+**Purpose.** Durable lessons that survive sessions and inform future work. A learning is the bridge between "we found this once" and "we now operate differently because of it."
+
+**Minimum content.** One file per learning, naming: `YYYY-MM-DD-<slug>.md`. Each learning MUST state:
+- **Context** — what was happening.
+- **Observation** — what we noticed.
+- **Change** — what we now do differently (or why we decided not to change).
+
+**What NOT to put.**
+- Bug reports (those are tickets).
+- One-off observations with no behavioral consequence (those are notes; keep them out of the canonical learnings stream).
+
+**Conformance.** SHOULD accumulate over time. Empty after several sprints is a smell.
+
+## 4. Harness shim files (project root)
+
+### 4.1 `AGENTS.md` — MUST
+
+**Purpose.** Cross-agent dispatcher. Any harness reads this first to learn the project shape.
+
+**Required sections** (see [project-extension-pattern](../concepts/project-extension-pattern.md)):
+1. **Project one-liner.**
+2. **Where the overlay lives** (`ops/ai/`).
+3. **Essential commands** (build, test, lint, run).
+4. **Validation gates** (what must pass before merge).
+5. **Non-negotiable rules** (3–5 max; link to `ops/ai/constitution/principles.md` for the full list).
+6. **Pointers** to overlay folders the agent should consult.
+
+**Size limit.** SHOULD be ≤150 lines. Longer means it is absorbing what belongs in overlay folders.
+
+### 4.2 `CLAUDE.md` — MUST if Claude Code is used
+
+**Purpose.** Claude Code-specific shim. Imports or links to `AGENTS.md`, adds at most a few Claude-specific notes.
+
+**Size limit.** SHOULD be ≤30 own lines (excluding imports).
+
+### 4.3 `.claude/` — SHOULD if Claude Code is used
+
+- `.claude/rules/` — path-scoped rules (one file per scope, e.g., `src.md`, `tests.md`).
+- `.claude/settings.json` — Claude Code configuration.
+
+Other harnesses (Codex, Cursor, Qwen) have their own shim directory; see the relevant adapter (e.g., [runtime-adapter-claude-code](../reference/runtime-adapter-claude-code.md), [runtime-adapter-codex](../reference/runtime-adapter-codex.md)). The overlay (`ops/ai/`) is identical across harnesses; only the shim changes.
+
+## 5. File-naming conventions
+
+- **Dated artifacts** (handoffs, reports, learnings): `YYYY-MM-DD-<kebab-slug>.md`.
+  - Date is the ISO date of the *event*, not the file's last edit.
+- **Closeouts**: append `-closeout` suffix: `YYYY-MM-DD-<slug>-closeout.md`.
+- **Slugs**: lowercase, kebab-case, ≤6 words; describe the subject, not the actor.
+  - Good: `2026-05-19-incident-pipeline-cutover.md`
+  - Bad: `2026-05-19-claude-finished-pipeline.md`
+- **Skills**: one folder per skill, `SKILL.md` inside.
+- **Schemas**: descriptive noun, `.schema.json` or `.schema.yaml`.
+
+## 6. Adopting in a legacy project (minimum-viable path)
+
+A legacy project SHOULD NOT be rewritten to adopt the overlay. The minimum adoption path is:
+
+1. **Create `ops/ai/`** with empty `constitution/`, `handoffs/`, `reports/` subfolders.
+2. **Fill the constitution** — mission, scope, stack, principles. Two paragraphs each is enough to start.
+3. **Add `AGENTS.md`** at the project root with sections from §4.1; point to `ops/ai/`.
+4. **Add `CLAUDE.md`** (or the relevant harness shim) — 10–30 lines, importing from `AGENTS.md`.
+5. **Write the first handoff** at the end of the next session, even if the session was small.
+
+That is the conformance floor. Everything else (`policies/`, `schemas/`, `skills/`, `learnings/`) accretes naturally as the project encounters the need.
+
+**Anti-pattern: don't backfill.** Do not generate fake historical handoffs, closeouts, or learnings. The overlay starts at adoption date; the past is the product's history, not the overlay's.
+
+## 7. Conformance summary
+
+| Element | Level | Empty allowed | Notes |
+|---|---|---|---|
+| `ops/ai/` (root) | MUST | No | The path is the contract |
+| `constitution/` | MUST | No | Four files non-empty |
+| `handoffs/` | MUST | Only pre-first-use | At least one after first non-trivial session |
+| `reports/` | MUST | Only pre-first-slice | One closeout per shipped slice |
+| `policies/` | SHOULD | Yes | MAY omit for exploratory projects |
+| `schemas/` | MAY | Yes | If present, must validate |
+| `skills/` | MAY | Yes | Project-specific only |
+| `learnings/` | SHOULD | Yes early on | Empty after several sprints is a smell |
+| `AGENTS.md` | MUST | No | ≤150 lines |
+| `CLAUDE.md` | MUST (if Claude) | No | ≤30 own lines |
+| `.claude/rules/` | SHOULD (if Claude) | Yes | Path-scoped |
+| `.claude/settings.json` | SHOULD (if Claude) | No | Required for non-default Claude config |
+
+## 8. Conformance test (minimum)
+
+A consumer project conforms to this contract when, given a fresh agent session pointed at the project root:
+
+1. The agent locates `AGENTS.md` without being told.
+2. The agent locates `ops/ai/constitution/` from `AGENTS.md` in ≤2 hops.
+3. The agent can describe mission, scope, and stack from the constitution in its first response.
+4. The agent finds the most recent handoff and continues from it without asking for context already captured there.
+
+Failing any of these indicates a shim or constitution gap; see §6 step 5 and §4.1.
+
+## 9. See also
+
+- **Reference example:** `examples/consumer-overlay-minimal/` — a navigable minimum-viable overlay instantiation.
+- **[operating-overlay](../concepts/operating-overlay.md)** — conceptual background and the three-layer model.
+- **[ADR-004](../adr/ADR-004-aletheia-as-operating-overlay.md)** — the boundary decision and its rationale.
+- **[handoff-capture-pattern](../concepts/handoff-capture-pattern.md)** — full pattern for handoff artifacts.
+- **[project-extension-pattern](../concepts/project-extension-pattern.md)** — how local extensions stay portable.

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,6 +33,8 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
   - mostra um loop de manutenção em três rodadas com regressão escalando o gate e gerando learning reutilizável
 - `pilot-conversion/`
   - mostra como uma validação real no Crisis Monitor vira endurecimento pequeno e reutilizável no framework
+- `consumer-overlay-minimal/`
+  - instância mínima viável do [consumer-project-overlay contract](../docs/contracts/consumer-project-overlay.md) — layout `ops/ai/` + shims Claude prontos para copiar
 
 ---
 

--- a/examples/consumer-overlay-minimal/.claude/rules/src.md
+++ b/examples/consumer-overlay-minimal/.claude/rules/src.md
@@ -1,0 +1,8 @@
+# Rules — `src/`
+
+Applies when editing files under `src/`.
+
+- All new modules MUST have at least one unit test in the matching `tests/` path.
+- Never introduce a new third-party dependency without recording the choice in `ops/ai/learnings/`.
+- Public APIs (anything exported from `src/index.ts`) MUST have a JSDoc comment with at least the parameters and return value documented.
+- Alert-sink modules (`src/sinks/`) MUST handle failures by emitting a higher-priority alert; never swallow.

--- a/examples/consumer-overlay-minimal/.claude/rules/tests.md
+++ b/examples/consumer-overlay-minimal/.claude/rules/tests.md
@@ -1,0 +1,8 @@
+# Rules — `tests/`
+
+Applies when editing files under `tests/`.
+
+- Use Vitest. Don't introduce a second test runner without an entry in `ops/ai/learnings/`.
+- Integration tests MUST hit a real Postgres (via the `docker-compose.test.yml` setup), not a mock. Mocks at the DB layer have masked migration breakage before.
+- Each test file MUST have a single top-level `describe` matching the module under test.
+- Snapshot tests are permitted only for alert payloads; use explicit assertions elsewhere.

--- a/examples/consumer-overlay-minimal/.claude/settings.json
+++ b/examples/consumer-overlay-minimal/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(pnpm install)",
+      "Bash(pnpm test*)",
+      "Bash(pnpm lint*)",
+      "Bash(pnpm build)",
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)"
+    ],
+    "deny": [
+      "Bash(rm -rf*)",
+      "Bash(git push --force*)"
+    ]
+  }
+}

--- a/examples/consumer-overlay-minimal/AGENTS.md
+++ b/examples/consumer-overlay-minimal/AGENTS.md
@@ -1,0 +1,49 @@
+# Crisis Monitor — agent dispatcher
+
+Crisis Monitor surfaces emerging operational incidents across our regions in under 5 minutes, for the incident-response team. This file is the first thing any AI agent should read when working on this repo.
+
+## Where the overlay lives
+
+All operating-overlay artifacts live under `ops/ai/`. Read in this order before acting:
+
+1. [`ops/ai/constitution/mission.md`](ops/ai/constitution/mission.md)
+2. [`ops/ai/constitution/scope.md`](ops/ai/constitution/scope.md)
+3. [`ops/ai/constitution/stack.md`](ops/ai/constitution/stack.md)
+4. [`ops/ai/constitution/principles.md`](ops/ai/constitution/principles.md)
+5. The most recent file in [`ops/ai/handoffs/`](ops/ai/handoffs/)
+
+## Essential commands
+
+```bash
+pnpm install            # install deps
+pnpm test               # run unit + contract tests
+pnpm lint               # eslint + prettier --check
+pnpm build              # production build
+pnpm dev                # local dev server (port 3000)
+```
+
+## Validation gates
+
+Before merge, all of the following MUST be green:
+
+- `pnpm test` — full test suite
+- `pnpm lint` — zero warnings
+- `pnpm build` — clean build
+- At least one human reviewer approves
+- A closeout exists in `ops/ai/reports/` for the slice being merged
+
+## Non-negotiable rules
+
+1. **Never silently drop an alert.** If a sink fails, surface the failure as a higher-priority alert. (See `ops/ai/constitution/principles.md` for full list.)
+2. **No PII in logs or prompts.** Region IDs are fine; person IDs are not. (See `ops/ai/policies/data-handling-policy.md` if/when created.)
+3. **No direct writes to the `incidents` table.** All writes go through the `incident-service` API.
+4. **No new external dependencies without an entry in `ops/ai/learnings/` justifying the choice.**
+
+The full principles list lives in [`ops/ai/constitution/principles.md`](ops/ai/constitution/principles.md). The four above are the ones with the highest blast radius if violated.
+
+## Pointers
+
+- For closeouts and progress, see [`ops/ai/reports/`](ops/ai/reports/).
+- For local policies that constrain operation, see [`ops/ai/policies/`](ops/ai/policies/).
+- For durable lessons that should inform future work, see [`ops/ai/learnings/`](ops/ai/learnings/).
+- For framework background, see the AletheIA repo and the [operating-overlay concept doc](https://github.com/nevitonsantana/AletheIA/blob/main/docs/concepts/operating-overlay.md).

--- a/examples/consumer-overlay-minimal/CLAUDE.md
+++ b/examples/consumer-overlay-minimal/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md
+
+Read [`AGENTS.md`](AGENTS.md) first. It is the source of truth for project shape, commands, gates, and rules. This file adds only Claude-specific notes.
+
+## Claude-specific notes
+
+- Path-scoped rules live in [`.claude/rules/`](.claude/rules/). Honor them when editing files under the matching paths.
+- When in doubt about scope, prefer asking over inventing. The constitution is short on purpose.
+- End every non-trivial session with a handoff in [`ops/ai/handoffs/`](ops/ai/handoffs/) following the four-section structure (Context, State, Next, Open questions).

--- a/examples/consumer-overlay-minimal/README.md
+++ b/examples/consumer-overlay-minimal/README.md
@@ -1,0 +1,54 @@
+# Example — consumer-overlay-minimal
+
+A navigable minimum-viable instantiation of the [consumer-project-overlay contract](../../docs/contracts/consumer-project-overlay.md). Models a fictional consumer project ("Crisis Monitor") at its very first day of overlay adoption.
+
+## What this example shows
+
+- The exact directory layout required by the contract.
+- Realistic-but-fictional content in each MUST and SHOULD folder.
+- A working `AGENTS.md` and `CLAUDE.md` that a real Claude Code session could load.
+- The shape of a first handoff and a first closeout.
+- Empty placeholder folders for elements that accrue over time (`schemas/`, `skills/`).
+
+## What this example does NOT show
+
+- Product source code. The product layer is intentionally absent — this example exists only to demonstrate the overlay surface.
+- Multiple cumulative slices. This is day-one state; a real project's `handoffs/`, `reports/`, and `learnings/` grow over time.
+- Multi-harness configuration. Only the Claude shim is included.
+
+## How to use it
+
+**Reading.** Walk the tree in this order:
+
+1. [`AGENTS.md`](AGENTS.md) — what any harness sees first.
+2. [`CLAUDE.md`](CLAUDE.md) — the Claude-specific shim.
+3. [`ops/ai/constitution/`](ops/ai/constitution/) — mission, scope, stack, principles.
+4. [`ops/ai/handoffs/`](ops/ai/handoffs/) — the latest transition.
+5. [`ops/ai/reports/`](ops/ai/reports/) — the latest closeout.
+6. [`ops/ai/policies/`](ops/ai/policies/) and [`ops/ai/learnings/`](ops/ai/learnings/) — supporting surfaces.
+
+**Adapting for a real project.** Copy `examples/consumer-overlay-minimal/` to your project root, then:
+
+1. Replace `Crisis Monitor` with your project name across all files.
+2. Rewrite the four `constitution/` files for your project.
+3. Trim or extend the rules in `.claude/rules/`.
+4. Delete the seed handoff/closeout/learning files; they are fiction.
+5. Update `AGENTS.md` essential-commands section with your actual build/test/run commands.
+
+## Conformance trace
+
+Each file in this example maps to a contract clause:
+
+| Path | Contract clause |
+|---|---|
+| `ops/ai/constitution/{mission,scope,stack,principles}.md` | §3.1 MUST |
+| `ops/ai/handoffs/2026-05-20-initial-overlay-adoption.md` | §3.2 MUST, §5 naming |
+| `ops/ai/reports/2026-05-20-overlay-bootstrap-closeout.md` | §3.3 MUST, three-layer structure |
+| `ops/ai/policies/pr-policy.md` | §3.4 SHOULD |
+| `ops/ai/learnings/2026-05-20-overlay-adoption-cost.md` | §3.7 SHOULD |
+| `AGENTS.md` | §4.1 MUST, ≤150 lines |
+| `CLAUDE.md` | §4.2 MUST, ≤30 own lines |
+| `.claude/rules/{src,tests}.md` | §4.3 SHOULD, path-scoped |
+| `.claude/settings.json` | §4.3 SHOULD |
+
+`ops/ai/schemas/` and `ops/ai/skills/` are MAY-level and omitted here.

--- a/examples/consumer-overlay-minimal/ops/ai/constitution/mission.md
+++ b/examples/consumer-overlay-minimal/ops/ai/constitution/mission.md
@@ -1,0 +1,5 @@
+# Mission
+
+Crisis Monitor surfaces emerging operational incidents across our regions in under 5 minutes, for the incident-response team. The team consumes alerts via a single dashboard and routes them to on-call engineers through PagerDuty.
+
+We exist so that an incident that began somewhere quiet does not reach a customer-facing failure before a human has been told.

--- a/examples/consumer-overlay-minimal/ops/ai/constitution/principles.md
+++ b/examples/consumer-overlay-minimal/ops/ai/constitution/principles.md
@@ -1,0 +1,11 @@
+# Principles
+
+Non-negotiable rules. Violating these is a stop-the-world event, not a code-review comment.
+
+1. **Never silently drop an alert.** Every ingested event reaches a sink, or a higher-priority alert is emitted explaining why it did not.
+2. **No PII in logs or prompts.** Region IDs, service names, and incident IDs are fine. Person identifiers, customer names, and account numbers are not.
+3. **No direct writes to the `incidents` table.** All writes go through the `incident-service` API so that dedup, audit, and webhook fan-out remain consistent.
+4. **Detection latency budget is 5 minutes p95.** Any change that pushes p95 above 5 minutes must be feature-flagged and rolled back if the budget is exceeded for 24h.
+5. **No new external dependencies without a `learnings/` entry.** Cost: every dep is a supply-chain surface and a runtime risk. The justification must be durable, not Slack-thread.
+6. **Schema migrations require a paired rollback migration.** No exceptions.
+7. **Alert sinks fail loud.** A sink that swallows a failure is a worse outcome than one that double-alerts. Prefer the latter.

--- a/examples/consumer-overlay-minimal/ops/ai/constitution/scope.md
+++ b/examples/consumer-overlay-minimal/ops/ai/constitution/scope.md
@@ -1,0 +1,15 @@
+# Scope
+
+## In scope
+
+- Ingesting telemetry from approved sources (Datadog, CloudWatch, internal `events-bus`).
+- Classifying events into incident candidates using rule-based heuristics and a small model.
+- Emitting alerts to PagerDuty, Slack `#incidents`, and the in-house dashboard.
+- Maintaining a 90-day rolling history of classified events for retrospectives.
+
+## Out of scope
+
+- **Incident remediation.** Crisis Monitor detects and alerts; remediation lives in other systems.
+- **Root cause analysis.** RCA is a downstream activity performed by the responding engineer with separate tooling.
+- **Customer-facing communication.** Status-page updates are handled by the comms tool, not Crisis Monitor.
+- **Long-term analytics.** Anything older than 90 days is exported and dropped from operational stores.

--- a/examples/consumer-overlay-minimal/ops/ai/constitution/stack.md
+++ b/examples/consumer-overlay-minimal/ops/ai/constitution/stack.md
@@ -1,0 +1,9 @@
+# Stack
+
+- **Language.** TypeScript (Node 20).
+- **Runtime.** AWS Lambda for ingestion; ECS Fargate for the dashboard API; React/Vite for the dashboard UI.
+- **Datastore.** Postgres 15 (RDS) for event/incident records; Redis (ElastiCache) for the dedup window.
+- **Messaging.** SQS for ingestion fan-out; SNS for alert egress.
+- **Build.** pnpm + Turborepo monorepo. Vitest for tests. ESLint + Prettier.
+- **Deploy.** Terraform-managed infra; GitHub Actions for CI; Argo CD for cluster apps.
+- **Observability.** Datadog APM + logs; PagerDuty for alerts.

--- a/examples/consumer-overlay-minimal/ops/ai/handoffs/2026-05-20-initial-overlay-adoption.md
+++ b/examples/consumer-overlay-minimal/ops/ai/handoffs/2026-05-20-initial-overlay-adoption.md
@@ -1,0 +1,34 @@
+# Handoff — initial overlay adoption
+
+**Date:** 2026-05-20
+**From:** Neviton (human) + Claude Code session
+**To:** Next session (any agent)
+
+## Context
+
+First adoption of the AletheIA operating overlay in Crisis Monitor. Until today this project had no `AGENTS.md`, no `ops/ai/`, and a Claude session was spending its first 5–10 turns asking about project shape and conventions.
+
+## State
+
+**Done.**
+- Created `ops/ai/{constitution,handoffs,reports,policies,learnings}/`.
+- Wrote the four constitution files (mission, scope, stack, principles).
+- Added `AGENTS.md`, `CLAUDE.md`, `.claude/rules/{src,tests}.md`, `.claude/settings.json`.
+- Wrote `ops/ai/policies/pr-policy.md`.
+
+**In progress.**
+- None.
+
+**Blocked.**
+- Nothing blocked.
+
+## Next
+
+1. In the next non-trivial session, write a handoff at session-end. This file is the seed; don't let it become the only one.
+2. After the first slice ships post-overlay, write its closeout in `ops/ai/reports/`.
+3. Watch whether agent sessions on this repo now reach productive work in ≤2 turns (current baseline: 5–10). Record as a learning if the answer is clear after 3–4 sessions.
+
+## Open questions
+
+- Do we want `ops/ai/skills/` for the incident-triage procedure? Defer until the procedure is stable enough to be reusable.
+- Should the data-handling policy live in `ops/ai/policies/data-handling-policy.md` or stay in the legal/security wiki? Pending decision; for now, link from `policies/` rather than duplicating.

--- a/examples/consumer-overlay-minimal/ops/ai/learnings/2026-05-20-overlay-adoption-cost.md
+++ b/examples/consumer-overlay-minimal/ops/ai/learnings/2026-05-20-overlay-adoption-cost.md
@@ -1,0 +1,23 @@
+# Learning — overlay adoption is cheaper than the first session it pays back
+
+## Context
+
+Crisis Monitor adopted the AletheIA operating overlay on 2026-05-20 (see closeout in `reports/`). Total elapsed time to set up the overlay: ~2 hours of focused work by one human + Claude, plus 30 minutes of writing the principles.
+
+## Observation
+
+Two things showed up immediately, before we'd measured anything formally:
+
+1. Writing `scope.md` forced a decision (90-day retrospective scope) that had been drifting for weeks. The document made the drift visible.
+2. The principle "no PII in logs or prompts" surfaced an existing violation in `logger.info(event)` that we already knew about but hadn't escalated. Having a written principle turned "we should fix that someday" into "this is now a follow-up slice."
+
+Neither of these was about the overlay's runtime value to agents. They were about the act of writing the constitution forcing latent decisions to the surface.
+
+## Change
+
+- We will treat constitution-writing as a recurring forcing function. When scope or principles feel fuzzy, rewriting the relevant file is a legitimate slice, not procrastination.
+- We will measure agent-session warmup over the next 3–4 sessions (turns until productive work) and add a follow-up learning when the answer is clear. Hypothesis: drops from 5–10 turns to ≤2.
+
+## Anti-change
+
+- We will NOT preemptively write `policies/` files for problems we haven't encountered. Empty is fine until a real constraint shows up.

--- a/examples/consumer-overlay-minimal/ops/ai/policies/pr-policy.md
+++ b/examples/consumer-overlay-minimal/ops/ai/policies/pr-policy.md
@@ -1,0 +1,31 @@
+# PR policy
+
+## Branch naming
+
+- `feat/<slug>` — new functionality.
+- `fix/<slug>` — bug fix.
+- `refactor/<slug>` — internal change, no behavior change.
+- `chore/<slug>` — deps, CI, tooling.
+- `docs/<slug>` — documentation only.
+
+## Required state before opening a PR
+
+- `pnpm test`, `pnpm lint`, `pnpm build` all green locally.
+- Closeout drafted in `ops/ai/reports/` for the slice the PR ships.
+- If the PR adds an external dependency, an entry in `ops/ai/learnings/` justifies the choice.
+
+## Required state before merge
+
+- At least one human reviewer approves.
+- All CI checks green.
+- Closeout in `ops/ai/reports/` matches what actually shipped (update before merge if scope drifted).
+
+## What MAY be merged without human review
+
+Nothing in this project. The team is small; the cost of a stuck PR is lower than the cost of a missed regression.
+
+## What MUST NEVER be merged
+
+- Direct writes to the `incidents` table (see `constitution/principles.md` rule 3).
+- Schema migrations without a paired rollback migration (rule 6).
+- Changes that take p95 detection latency above 5 minutes without a feature flag (rule 4).

--- a/examples/consumer-overlay-minimal/ops/ai/reports/2026-05-20-overlay-bootstrap-closeout.md
+++ b/examples/consumer-overlay-minimal/ops/ai/reports/2026-05-20-overlay-bootstrap-closeout.md
@@ -1,0 +1,26 @@
+# Closeout — overlay bootstrap
+
+**Date:** 2026-05-20
+**Slice:** Adopt the AletheIA operating overlay in Crisis Monitor.
+
+## Done
+
+- `ops/ai/` created with the five required and recommended folders.
+- Constitution written (mission, scope, stack, principles).
+- `AGENTS.md` and `CLAUDE.md` added at the project root.
+- `.claude/rules/` populated with path-scoped rules for `src/` and `tests/`.
+- `pr-policy.md` written.
+- First handoff committed.
+
+## Pending
+
+- **`learnings/` is empty.** Expected; it accrues over time.
+- **`schemas/` and `skills/` not created.** Deferred until a real need appears, per contract §3.5/§3.6.
+- **No data-handling policy yet.** Open question recorded in the handoff.
+- **No measurement of agent-session-warmup yet.** Will be evaluated after 3–4 sessions.
+
+## Frictions
+
+- The principle "no PII in logs or prompts" surfaced a gap: the existing `logger.info(event)` calls log the whole event object, which sometimes contains a `userId`. Not in scope for this slice (overlay-only) but flagged as the first follow-up slice.
+- The `tests.md` rule ("integration tests hit a real Postgres") doesn't match the current CI, which uses a mock. Either the rule or the CI is wrong; both should not coexist. Decision deferred to the next session.
+- Writing the constitution forced a question we'd been avoiding: are 90-day retrospectives actually in scope? The scope.md says yes by listing 90-day rolling history; if we change our mind, scope.md is now the single place to fix it.


### PR DESCRIPTION
## Summary

- New normative contract at [docs/contracts/consumer-project-overlay.md](docs/contracts/consumer-project-overlay.md) — specifies the required `ops/ai/` layout, per-folder purpose / minimum content / exclusion rules, RFC 2119 conformance levels (MUST / SHOULD / MAY), file-naming conventions, a legacy-adoption path, and a four-step conformance test.
- New reference example at [examples/consumer-overlay-minimal/](examples/consumer-overlay-minimal/) — a navigable instantiation modeling a fictional "Crisis Monitor" at day-one of overlay adoption. Each file maps to a contract clause via the conformance trace in its README.
- Index updates in [docs/contracts/README.md](docs/contracts/README.md) and [examples/README.md](examples/README.md).

## Plan alignment

Closes Épico 4 of `aletheia-plano-melhoria-estrutura.md` v1.0:

- ✅ Per-folder purpose, minimum content, examples, and "what NOT to put"
- ✅ Mandatory / recommended / optional explicit (RFC 2119)
- ✅ Section on legacy-project adoption (§6 minimum-viable path)
- ✅ Example navigable, with README explaining usage and a clause-by-clause conformance trace
- ✅ Applicable to a Crisis-Monitor-shaped project without inventing new folders
- ✅ Does not dictate product architecture (§1 scope)

## Test plan

- [ ] Walk the contract end-to-end; confirm §3 folder specs match the §2 layout and §7 conformance summary
- [ ] Walk `examples/consumer-overlay-minimal/` in the order suggested by its README; confirm an agent could navigate it cold
- [ ] Spot-check that the example's `AGENTS.md` stays ≤150 lines and `CLAUDE.md` ≤30 own lines per contract §4
- [ ] Verify governance check still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)