### PR TITLE
docs(starter-pack): Claude harness shim pack + setup guide — Epic 5

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -27,3 +27,4 @@ If you need conceptual background, see [`concepts/`](../concepts/README.md). If 
 | [resource-aware-bounded-pilot.md](resource-aware-bounded-pilot.md) | Running a resource-aware bounded pilot |
 | [pilot-conversion.md](pilot-conversion.md) | How pilot learnings become framework improvements |
 | [github-project-operations.md](github-project-operations.md) | Using GitHub Projects for repo coordination |
+| [setting-up-harnesses.md](setting-up-harnesses.md) | Wiring a consumer project to Claude Code via the shim pack |

--- a/docs/guides/setting-up-harnesses.md
+++ b/docs/guides/setting-up-harnesses.md
@@ -1,0 +1,127 @@
+# Setting up harnesses
+
+How to wire a consumer project to a harness (currently: Claude Code) so the harness reads the AletheIA operating overlay correctly. Five steps; ~15 minutes.
+
+For the **what** and **why**, see:
+- [operating-overlay](../concepts/operating-overlay.md) — three-layer model.
+- [consumer-project-overlay](../contracts/consumer-project-overlay.md) — normative spec for the overlay surface.
+- [`examples/consumer-overlay-minimal/`](../../examples/consumer-overlay-minimal/) — fully populated reference instantiation.
+
+This guide assumes you already have at least a draft overlay (`ops/ai/` with the four constitution files) or are about to write one alongside the shim setup.
+
+## Step 1 — Copy the Claude shim pack
+
+From the AletheIA repo root, copy the shim directory into your consumer project root:
+
+```bash
+cp -R starter-pack/harness-shims/claude/. /path/to/consumer-project/
+```
+
+The `.` after `claude/` is intentional — it copies the directory's *contents* (including the dotfile `.claude/`) into the destination, not the `claude/` directory itself.
+
+After the copy, your project root should contain:
+
+```
+consumer-project/
+├── AGENTS.md.template
+├── CLAUDE.md.template
+├── README.md                 (the shim pack's own — delete after reading)
+└── .claude/
+    ├── settings.json.template
+    └── rules/
+        ├── src.md
+        ├── tests.md
+        └── ops-ai.md
+```
+
+## Step 2 — Rename templates
+
+Strip the `.template` suffix on the three template files:
+
+```bash
+cd /path/to/consumer-project
+mv AGENTS.md.template AGENTS.md
+mv CLAUDE.md.template CLAUDE.md
+mv .claude/settings.json.template .claude/settings.json
+rm README.md   # the shim pack's README; not for the consumer repo
+```
+
+The path-scoped rules in `.claude/rules/` are not templated — they're starter content, edit in place.
+
+## Step 3 — Substitute variables
+
+Three variables in `AGENTS.md`, six in `.claude/settings.json`. List them:
+
+```bash
+grep -rh '{{' AGENTS.md .claude/settings.json | sort -u
+```
+
+You'll see:
+
+```
+{{BUILD_CMD}}
+{{DEV_CMD}}
+{{INSTALL_CMD}}
+{{LINT_CMD}}
+{{PRIMARY_STACK}}
+{{PROJECT_NAME}}
+{{PROJECT_ONE_LINER}}
+{{TEST_CMD}}
+```
+
+Substitute with `sed` (one pass per variable). On macOS use `sed -i ''`; on GNU/Linux use `sed -i`:
+
+```bash
+# macOS
+sed -i '' \
+  -e 's|{{PROJECT_NAME}}|Crisis Monitor|g' \
+  -e 's|{{PROJECT_ONE_LINER}}|Crisis Monitor surfaces emerging operational incidents in under 5 minutes|g' \
+  -e 's|{{PRIMARY_STACK}}|TypeScript, Node 20, Postgres|g' \
+  -e 's|{{INSTALL_CMD}}|pnpm install|g' \
+  -e 's|{{TEST_CMD}}|pnpm test|g' \
+  -e 's|{{LINT_CMD}}|pnpm lint|g' \
+  -e 's|{{BUILD_CMD}}|pnpm build|g' \
+  -e 's|{{DEV_CMD}}|pnpm dev|g' \
+  AGENTS.md .claude/settings.json
+```
+
+Re-run the `grep` from above to confirm no `{{...}}` markers remain.
+
+## Step 4 — Adapt the path-scoped rules
+
+The three rules in `.claude/rules/` ship with reasonable defaults. Open each and:
+
+- `src.md` — confirm the path matches your project's source path (rename the file if your code lives in `app/`, `lib/`, etc.). Adjust docstring conventions for your language.
+- `tests.md` — confirm the test runner mention matches your stack. If you mock at the DB boundary by policy, edit accordingly.
+- `ops-ai.md` — usually unchanged; the rules here are normative across all consumers.
+
+Delete the `> Adapt to this project's…` notes once you've adapted.
+
+## Step 5 — Verify with a fresh session
+
+From the consumer project root, open a new Claude Code session and check the conformance test from the contract ([§8](../contracts/consumer-project-overlay.md#8-conformance-test-minimum)):
+
+1. The agent locates `AGENTS.md` without being told.
+2. The agent locates `ops/ai/constitution/` from `AGENTS.md` in ≤2 hops.
+3. The agent can describe mission, scope, and stack from the constitution in its first response.
+4. The agent finds the most recent handoff (or notes none exists yet) and proceeds without asking for context that should be in the constitution.
+
+If any of those fail, the gap is usually:
+
+- A missing constitution file → fill it.
+- `AGENTS.md` linking to a path that doesn't exist → fix the link.
+- The agent ignoring `AGENTS.md` → confirm the file is at the project root, not in a subdirectory.
+
+## When to update the shims
+
+Re-copy the shim pack when:
+
+- A new template variable is added in canonical AletheIA.
+- A new path-scoped rule is promoted from a consumer project to the canonical pack.
+- A new harness (Codex, Cursor) is added — at which point its directory will appear alongside `claude/`.
+
+Day-to-day edits to your project's `AGENTS.md`, `CLAUDE.md`, and rules are expected and local — don't push those back upstream unless they generalize.
+
+## Other harnesses
+
+Codex and Cursor shims are not yet packaged. See [ADR-004 §4](../adr/ADR-004-aletheia-as-operating-overlay.md) on the "no premature shims" position — a harness gets a shim pack when a real project adopts it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,9 +39,10 @@ Reading map organized by intent. Each entry links to the most useful starting po
 1. [Runtime adapter — Claude Code](reference/runtime-adapter-claude-code.md)
 2. [Runtime adapter — Codex](reference/runtime-adapter-codex.md)
 3. [Runtime adapter — Qwen](reference/runtime-adapter-qwen.md)
-4. [Runtime adapter contract](contracts/runtime-adapter-contract.md) — what any adapter must honor
-5. [Agent role catalog](reference/agent-role-catalog.md) — portable roles across runtimes
-6. [Agent runtime decision guide](guides/agent-runtime-decision-guide.md) — choosing between runtimes
+4. [Setting up harnesses](guides/setting-up-harnesses.md) — wire a consumer project to Claude Code via the shim pack
+5. [Runtime adapter contract](contracts/runtime-adapter-contract.md) — what any adapter must honor
+6. [Agent role catalog](reference/agent-role-catalog.md) — portable roles across runtimes
+7. [Agent runtime decision guide](guides/agent-runtime-decision-guide.md) — choosing between runtimes
 
 ---
 

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -37,6 +37,14 @@ If you are adopting AletheIA inside a real project and need to make the local la
 - `starter-pack/templates/project-extension-template.md`
 
 
+## Harness shims
+
+If you are wiring a consumer project to a harness (currently: Claude Code), use:
+
+- `starter-pack/harness-shims/claude/` — copy-and-substitute pack for `AGENTS.md`, `CLAUDE.md`, and `.claude/`
+- `docs/guides/setting-up-harnesses.md` — five-step adoption walkthrough
+
+
 ## Alpha 4 baseline
 
 The current practical Alpha 4 handoff baseline now includes:

--- a/starter-pack/harness-shims/claude/.claude/rules/ops-ai.md
+++ b/starter-pack/harness-shims/claude/.claude/rules/ops-ai.md
@@ -1,0 +1,11 @@
+# Rules — `ops/ai/`
+
+Applies when editing files under `ops/ai/` (the operating overlay folder).
+
+- **Never invent historical artifacts.** Don't backfill handoffs, closeouts, or learnings dated before the project adopted the overlay.
+- **Naming is `YYYY-MM-DD-<kebab-slug>.md`** for handoffs, learnings, and reports (`-closeout.md` suffix on closeouts). The date is when the event happened, not when the file was written.
+- **Constitution edits are decisions, not refactors.** Treat changes to `mission.md`, `scope.md`, or `principles.md` as durable decisions: capture the why in the commit message (or a `reports/` closeout) so the change survives.
+- **Promotion gate.** If a pattern in this project looks generalizable to other projects, do not silently move it to canonical AletheIA. Wait for a second project to need it; record the candidacy in `ops/ai/learnings/`.
+- **No secrets, credentials, or PII**, even in examples or "this used to fail" anecdotes inside learnings.
+
+See the [consumer-project-overlay contract](https://github.com/nevitonsantana/AletheIA/blob/main/docs/contracts/consumer-project-overlay.md) for the normative rules these enforce.

--- a/starter-pack/harness-shims/claude/.claude/rules/src.md
+++ b/starter-pack/harness-shims/claude/.claude/rules/src.md
@@ -1,0 +1,10 @@
+# Rules — `src/`
+
+Applies when editing files under `src/` (or this project's primary source path).
+
+- All new modules MUST have at least one unit test in the matching `tests/` path.
+- Never introduce a new third-party dependency without recording the choice in `ops/ai/learnings/` — the justification must be durable, not chat-thread.
+- Public APIs MUST have a docstring or JSDoc comment with parameters and return value documented.
+- If a change touches a module that has historically broken (per `ops/ai/learnings/`), re-read the relevant learning before editing.
+
+> Adapt the path and language-specific bits (JSDoc vs docstring vs Javadoc, etc.) to this project's stack on first use, then delete this note.

--- a/starter-pack/harness-shims/claude/.claude/rules/tests.md
+++ b/starter-pack/harness-shims/claude/.claude/rules/tests.md
@@ -1,0 +1,10 @@
+# Rules — `tests/`
+
+Applies when editing files under `tests/`.
+
+- Honor the project's chosen test runner. Don't introduce a second one without an entry in `ops/ai/learnings/`.
+- Integration tests SHOULD hit real dependencies (DB, queues) rather than mocks, unless the project's policy says otherwise. Mocks at the boundary have masked real regressions before.
+- Each test file SHOULD have a single top-level `describe` (or equivalent) matching the module under test.
+- Snapshot tests are permitted only when the asserted value is intentionally opaque (e.g., a large rendered payload). Prefer explicit assertions elsewhere.
+
+> Adapt to this project's runner conventions on first use, then delete this note.

--- a/starter-pack/harness-shims/claude/.claude/settings.json.template
+++ b/starter-pack/harness-shims/claude/.claude/settings.json.template
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash({{INSTALL_CMD}})",
+      "Bash({{TEST_CMD}}*)",
+      "Bash({{LINT_CMD}}*)",
+      "Bash({{BUILD_CMD}})",
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)"
+    ],
+    "deny": [
+      "Bash(rm -rf*)",
+      "Bash(git push --force*)"
+    ]
+  }
+}

--- a/starter-pack/harness-shims/claude/AGENTS.md.template
+++ b/starter-pack/harness-shims/claude/AGENTS.md.template
@@ -1,0 +1,58 @@
+# {{PROJECT_NAME}} — agent dispatcher
+
+{{PROJECT_ONE_LINER}}. This file is the first thing any AI agent should read when working on this repo.
+
+## Where the overlay lives
+
+All operating-overlay artifacts live under `ops/ai/`. Read in this order before acting:
+
+1. [`ops/ai/constitution/mission.md`](ops/ai/constitution/mission.md)
+2. [`ops/ai/constitution/scope.md`](ops/ai/constitution/scope.md)
+3. [`ops/ai/constitution/stack.md`](ops/ai/constitution/stack.md)
+4. [`ops/ai/constitution/principles.md`](ops/ai/constitution/principles.md)
+5. The most recent file in [`ops/ai/handoffs/`](ops/ai/handoffs/)
+
+If `ops/ai/` does not yet exist or is empty beyond the constitution, this project is fresh on the overlay — your job is to start populating it as work proceeds.
+
+## Stack at a glance
+
+{{PRIMARY_STACK}}
+
+## Essential commands
+
+```bash
+{{INSTALL_CMD}}            # install deps
+{{TEST_CMD}}               # run the test suite
+{{LINT_CMD}}               # lint and format check
+{{BUILD_CMD}}              # production build
+{{DEV_CMD}}                # local dev
+```
+
+## Validation gates
+
+Before merge, all of the following MUST be green:
+
+- `{{TEST_CMD}}` — full test suite
+- `{{LINT_CMD}}` — zero warnings
+- `{{BUILD_CMD}}` — clean build
+- At least one human reviewer approves
+- A closeout exists in `ops/ai/reports/` for the slice being merged
+
+## Non-negotiable rules
+
+The full list lives in [`ops/ai/constitution/principles.md`](ops/ai/constitution/principles.md). Keep these top-of-mind:
+
+1. **Honor the constitution.** If a request conflicts with `principles.md`, stop and surface the conflict.
+2. **Stay inside scope.** If a task drifts past `scope.md`, flag it before acting.
+3. **No credentials, secrets, or PII in code, logs, or prompts.**
+4. **End every non-trivial session with a handoff** in `ops/ai/handoffs/` (Context / State / Next / Open questions).
+
+If this section grows past 5–7 items, the extras belong in `principles.md`, not here.
+
+## Pointers
+
+- For closeouts and progress, see [`ops/ai/reports/`](ops/ai/reports/).
+- For local policies that constrain operation, see [`ops/ai/policies/`](ops/ai/policies/).
+- For durable lessons that should inform future work, see [`ops/ai/learnings/`](ops/ai/learnings/).
+- For path-scoped rules consumed by Claude Code, see [`.claude/rules/`](.claude/rules/).
+- For framework background, see the [AletheIA operating-overlay concept](https://github.com/nevitonsantana/AletheIA/blob/main/docs/concepts/operating-overlay.md) and [contract](https://github.com/nevitonsantana/AletheIA/blob/main/docs/contracts/consumer-project-overlay.md).

--- a/starter-pack/harness-shims/claude/CLAUDE.md.template
+++ b/starter-pack/harness-shims/claude/CLAUDE.md.template
@@ -1,0 +1,9 @@
+# CLAUDE.md
+
+Read [`AGENTS.md`](AGENTS.md) first. It is the source of truth for project shape, commands, gates, and rules. This file adds only Claude-specific notes.
+
+## Claude-specific notes
+
+- Path-scoped rules live in [`.claude/rules/`](.claude/rules/). Honor them when editing files under the matching paths.
+- When in doubt about scope, prefer asking over inventing. The constitution is short on purpose.
+- End every non-trivial session with a handoff in [`ops/ai/handoffs/`](ops/ai/handoffs/) using the four-section structure (Context, State, Next, Open questions).

--- a/starter-pack/harness-shims/claude/README.md
+++ b/starter-pack/harness-shims/claude/README.md
@@ -1,0 +1,47 @@
+# Claude Code harness shims
+
+Thin adapters that let a Claude Code session consume the AletheIA operating overlay in a consumer project. The shims do not contain the overlay — they point at it.
+
+See [docs/contracts/consumer-project-overlay.md §4](../../../docs/contracts/consumer-project-overlay.md) for the normative spec these templates satisfy, and [docs/guides/setting-up-harnesses.md](../../../docs/guides/setting-up-harnesses.md) for the adoption walkthrough.
+
+## What's here
+
+| File | Purpose | Goes to |
+|---|---|---|
+| [`AGENTS.md.template`](AGENTS.md.template) | Cross-agent dispatcher (contract §4.1, MUST, ≤150 lines) | `<project>/AGENTS.md` |
+| [`CLAUDE.md.template`](CLAUDE.md.template) | Claude-specific shim (contract §4.2, MUST if Claude, ≤30 own lines) | `<project>/CLAUDE.md` |
+| [`.claude/settings.json.template`](.claude/settings.json.template) | Claude Code configuration (contract §4.3, SHOULD) | `<project>/.claude/settings.json` |
+| [`.claude/rules/src.md`](.claude/rules/src.md) | Path-scoped rule example for product source | `<project>/.claude/rules/src.md` |
+| [`.claude/rules/tests.md`](.claude/rules/tests.md) | Path-scoped rule example for tests | `<project>/.claude/rules/tests.md` |
+| [`.claude/rules/ops-ai.md`](.claude/rules/ops-ai.md) | Path-scoped rule for the overlay folder itself | `<project>/.claude/rules/ops-ai.md` |
+
+## Template variables
+
+| Variable | Replace with |
+|---|---|
+| `{{PROJECT_NAME}}` | Display name of the project (e.g., `Crisis Monitor`) |
+| `{{PROJECT_ONE_LINER}}` | One-sentence description: what the project does, for whom |
+| `{{PRIMARY_STACK}}` | Comma-separated primary languages/frameworks (e.g., `TypeScript, Node 20, Postgres`) |
+| `{{INSTALL_CMD}}` | Install command (e.g., `pnpm install`) |
+| `{{TEST_CMD}}` | Test command (e.g., `pnpm test`) |
+| `{{LINT_CMD}}` | Lint command (e.g., `pnpm lint`) |
+| `{{BUILD_CMD}}` | Build command (e.g., `pnpm build`) |
+| `{{DEV_CMD}}` | Local dev command, or `n/a` (e.g., `pnpm dev`) |
+
+A trivial substitution one-liner that works on macOS and Linux is in the setup guide.
+
+## Adoption
+
+Three steps; the full walkthrough lives in [setting-up-harnesses.md](../../../docs/guides/setting-up-harnesses.md):
+
+1. Copy this directory's contents into the consumer project root.
+2. Rename each `*.template` file by removing the suffix.
+3. Substitute the template variables.
+
+After that, the project must also have `ops/ai/` populated per the contract (see [`examples/consumer-overlay-minimal/`](../../../examples/consumer-overlay-minimal/) for a reference instantiation).
+
+## What this is not
+
+- **Not the overlay.** The overlay lives in `ops/ai/`; these shims only point at it.
+- **Not Codex- or Cursor-aware.** Other harnesses get their own shim directory when a real project needs one.
+- **Not a generator.** This is a copy-and-substitute pack, intentionally static and reviewable.


### PR DESCRIPTION
## Summary

- New shim pack at [starter-pack/harness-shims/claude/](starter-pack/harness-shims/claude/) — copy-and-substitute templates for `AGENTS.md`, `CLAUDE.md`, `.claude/settings.json`, and three path-scoped `.claude/rules/` files.
- New guide at [docs/guides/setting-up-harnesses.md](docs/guides/setting-up-harnesses.md) — five-step adoption walkthrough ending in the conformance test from [consumer-project-overlay §8](docs/contracts/consumer-project-overlay.md#8-conformance-test-minimum).
- Indexed from [docs/guides/README.md](docs/guides/README.md), [docs/index.md](docs/index.md), and [starter-pack/README.md](starter-pack/README.md).

## Plan alignment

Closes Épico 5 of `aletheia-plano-melhoria-estrutura.md` v1.0:

- ✅ `AGENTS.md.template` 58 lines (under contract §4.1's ≤150 cap)
- ✅ `CLAUDE.md.template` 9 own lines (under §4.2's ≤30 cap)
- ✅ `.claude/rules/` with three path-scoped examples (`src.md`, `tests.md`, `ops-ai.md`)
- ✅ `.claude/settings.json.template` included
- ✅ Variables `{{PROJECT_NAME}}`, `{{PRIMARY_STACK}}`, etc. marked consistently
- ✅ Setup guide ≤5 steps
- ✅ Only Claude is shimmed; Codex/Cursor wait for a real adopter (per [ADR-004](docs/adr/ADR-004-aletheia-as-operating-overlay.md) §4 "no premature shims")

## Test plan

- [ ] Walk the setup guide on a scratch repo end-to-end; confirm a copy-rename-sed sequence produces functional files
- [ ] Confirm `grep -rh '{{' AGENTS.md .claude/settings.json` returns exactly the variables listed in step 3
- [ ] Verify governance check passes
- [ ] Open a Claude Code session in the example consumer project and confirm the §8 conformance test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)