### PR TITLE
docs(starter-pack): minimal-overlay preset bundle — Epic 6

### DIFF
--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -45,6 +45,13 @@ If you are wiring a consumer project to a harness (currently: Claude Code), use:
 - `docs/guides/setting-up-harnesses.md` — five-step adoption walkthrough
 
 
+## Presets
+
+For a single-bundle adoption that combines the overlay skeleton with the harness shim, use:
+
+- `starter-pack/presets/minimal-overlay/` — day-one overlay + Claude shims + `manifest.yaml` provenance record
+
+
 ## Alpha 4 baseline
 
 The current practical Alpha 4 handoff baseline now includes:

--- a/starter-pack/presets/minimal-overlay/.claude/rules/ops-ai.md
+++ b/starter-pack/presets/minimal-overlay/.claude/rules/ops-ai.md
@@ -1,0 +1,11 @@
+# Rules — `ops/ai/`
+
+Applies when editing files under `ops/ai/` (the operating overlay folder).
+
+- **Never invent historical artifacts.** Don't backfill handoffs, closeouts, or learnings dated before the project adopted the overlay.
+- **Naming is `YYYY-MM-DD-<kebab-slug>.md`** for handoffs, learnings, and reports (`-closeout.md` suffix on closeouts). The date is when the event happened, not when the file was written.
+- **Constitution edits are decisions, not refactors.** Treat changes to `mission.md`, `scope.md`, or `principles.md` as durable decisions: capture the why in the commit message (or a `reports/` closeout) so the change survives.
+- **Promotion gate.** If a pattern in this project looks generalizable to other projects, do not silently move it to canonical AletheIA. Wait for a second project to need it; record the candidacy in `ops/ai/learnings/`.
+- **No secrets, credentials, or PII**, even in examples or "this used to fail" anecdotes inside learnings.
+
+See the [consumer-project-overlay contract](https://github.com/nevitonsantana/AletheIA/blob/main/docs/contracts/consumer-project-overlay.md) for the normative rules these enforce.

--- a/starter-pack/presets/minimal-overlay/.claude/rules/src.md
+++ b/starter-pack/presets/minimal-overlay/.claude/rules/src.md
@@ -1,0 +1,10 @@
+# Rules — `src/`
+
+Applies when editing files under `src/` (or this project's primary source path).
+
+- All new modules MUST have at least one unit test in the matching `tests/` path.
+- Never introduce a new third-party dependency without recording the choice in `ops/ai/learnings/` — the justification must be durable, not chat-thread.
+- Public APIs MUST have a docstring or JSDoc comment with parameters and return value documented.
+- If a change touches a module that has historically broken (per `ops/ai/learnings/`), re-read the relevant learning before editing.
+
+> Adapt the path and language-specific bits (JSDoc vs docstring vs Javadoc, etc.) to this project's stack on first use, then delete this note.

--- a/starter-pack/presets/minimal-overlay/.claude/rules/tests.md
+++ b/starter-pack/presets/minimal-overlay/.claude/rules/tests.md
@@ -1,0 +1,10 @@
+# Rules — `tests/`
+
+Applies when editing files under `tests/`.
+
+- Honor the project's chosen test runner. Don't introduce a second one without an entry in `ops/ai/learnings/`.
+- Integration tests SHOULD hit real dependencies (DB, queues) rather than mocks, unless the project's policy says otherwise. Mocks at the boundary have masked real regressions before.
+- Each test file SHOULD have a single top-level `describe` (or equivalent) matching the module under test.
+- Snapshot tests are permitted only when the asserted value is intentionally opaque (e.g., a large rendered payload). Prefer explicit assertions elsewhere.
+
+> Adapt to this project's runner conventions on first use, then delete this note.

--- a/starter-pack/presets/minimal-overlay/.claude/settings.json
+++ b/starter-pack/presets/minimal-overlay/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash({{INSTALL_CMD}})",
+      "Bash({{TEST_CMD}}*)",
+      "Bash({{LINT_CMD}}*)",
+      "Bash({{BUILD_CMD}})",
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)"
+    ],
+    "deny": [
+      "Bash(rm -rf*)",
+      "Bash(git push --force*)"
+    ]
+  }
+}

--- a/starter-pack/presets/minimal-overlay/AGENTS.md
+++ b/starter-pack/presets/minimal-overlay/AGENTS.md
@@ -1,0 +1,58 @@
+# {{PROJECT_NAME}} — agent dispatcher
+
+{{PROJECT_ONE_LINER}}. This file is the first thing any AI agent should read when working on this repo.
+
+## Where the overlay lives
+
+All operating-overlay artifacts live under `ops/ai/`. Read in this order before acting:
+
+1. [`ops/ai/constitution/mission.md`](ops/ai/constitution/mission.md)
+2. [`ops/ai/constitution/scope.md`](ops/ai/constitution/scope.md)
+3. [`ops/ai/constitution/stack.md`](ops/ai/constitution/stack.md)
+4. [`ops/ai/constitution/principles.md`](ops/ai/constitution/principles.md)
+5. The most recent file in [`ops/ai/handoffs/`](ops/ai/handoffs/)
+
+If `ops/ai/` does not yet exist or is empty beyond the constitution, this project is fresh on the overlay — your job is to start populating it as work proceeds.
+
+## Stack at a glance
+
+{{PRIMARY_STACK}}
+
+## Essential commands
+
+```bash
+{{INSTALL_CMD}}            # install deps
+{{TEST_CMD}}               # run the test suite
+{{LINT_CMD}}               # lint and format check
+{{BUILD_CMD}}              # production build
+{{DEV_CMD}}                # local dev
+```
+
+## Validation gates
+
+Before merge, all of the following MUST be green:
+
+- `{{TEST_CMD}}` — full test suite
+- `{{LINT_CMD}}` — zero warnings
+- `{{BUILD_CMD}}` — clean build
+- At least one human reviewer approves
+- A closeout exists in `ops/ai/reports/` for the slice being merged
+
+## Non-negotiable rules
+
+The full list lives in [`ops/ai/constitution/principles.md`](ops/ai/constitution/principles.md). Keep these top-of-mind:
+
+1. **Honor the constitution.** If a request conflicts with `principles.md`, stop and surface the conflict.
+2. **Stay inside scope.** If a task drifts past `scope.md`, flag it before acting.
+3. **No credentials, secrets, or PII in code, logs, or prompts.**
+4. **End every non-trivial session with a handoff** in `ops/ai/handoffs/` (Context / State / Next / Open questions).
+
+If this section grows past 5–7 items, the extras belong in `principles.md`, not here.
+
+## Pointers
+
+- For closeouts and progress, see [`ops/ai/reports/`](ops/ai/reports/).
+- For local policies that constrain operation, see [`ops/ai/policies/`](ops/ai/policies/).
+- For durable lessons that should inform future work, see [`ops/ai/learnings/`](ops/ai/learnings/).
+- For path-scoped rules consumed by Claude Code, see [`.claude/rules/`](.claude/rules/).
+- For framework background, see the [AletheIA operating-overlay concept](https://github.com/nevitonsantana/AletheIA/blob/main/docs/concepts/operating-overlay.md) and [contract](https://github.com/nevitonsantana/AletheIA/blob/main/docs/contracts/consumer-project-overlay.md).

--- a/starter-pack/presets/minimal-overlay/CLAUDE.md
+++ b/starter-pack/presets/minimal-overlay/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md
+
+Read [`AGENTS.md`](AGENTS.md) first. It is the source of truth for project shape, commands, gates, and rules. This file adds only Claude-specific notes.
+
+## Claude-specific notes
+
+- Path-scoped rules live in [`.claude/rules/`](.claude/rules/). Honor them when editing files under the matching paths.
+- When in doubt about scope, prefer asking over inventing. The constitution is short on purpose.
+- End every non-trivial session with a handoff in [`ops/ai/handoffs/`](ops/ai/handoffs/) using the four-section structure (Context, State, Next, Open questions).

--- a/starter-pack/presets/minimal-overlay/README.md
+++ b/starter-pack/presets/minimal-overlay/README.md
@@ -1,0 +1,97 @@
+# Preset — minimal-overlay
+
+Day-one operating overlay for a consumer project using Claude Code. A single bundle that combines:
+
+- The required `ops/ai/` directory skeleton (per [consumer-project-overlay contract](../../../docs/contracts/consumer-project-overlay.md))
+- The Claude harness shim (per [Epic 5 shim pack](../../harness-shims/claude/))
+- A [`manifest.yaml`](manifest.yaml) recording the canonical source of every file
+
+Use this preset when starting a new consumer project, or when retrofitting overlay structure onto an existing one. The preset is static and reviewable on purpose — no CLI, no generator, no magic.
+
+For background, see:
+- [operating-overlay concept](../../../docs/concepts/operating-overlay.md) — the three-layer model
+- [consumer-project-overlay contract](../../../docs/contracts/consumer-project-overlay.md) — what the preset satisfies
+- [setting-up-harnesses guide](../../../docs/guides/setting-up-harnesses.md) — step-by-step adoption walkthrough
+- [`examples/consumer-overlay-minimal/`](../../../examples/consumer-overlay-minimal/) — a populated reference for what this preset becomes after adoption
+
+## What's in the bundle
+
+```
+minimal-overlay/
+├── README.md                       # this file (delete after adoption)
+├── manifest.yaml                   # provenance + variables + checklist
+├── AGENTS.md                       # harness dispatcher (≤150 lines)
+├── CLAUDE.md                       # Claude-specific shim (≤30 own lines)
+├── .claude/
+│   ├── settings.json               # Claude Code config
+│   └── rules/
+│       ├── src.md                  # path-scoped rule for product source
+│       ├── tests.md                # path-scoped rule for tests
+│       └── ops-ai.md               # path-scoped rule for the overlay folder
+└── ops/ai/
+    ├── constitution/README.md      # placeholder — replace with mission/scope/stack/principles
+    ├── handoffs/README.md          # placeholder — first handoff replaces it
+    ├── reports/README.md           # placeholder — first closeout replaces it
+    ├── policies/README.md          # placeholder — populate if non-default constraints exist
+    ├── schemas/README.md           # placeholder — populate only if needed
+    ├── skills/README.md            # placeholder — populate only if needed
+    └── learnings/README.md         # placeholder — first learning replaces it
+```
+
+The bundle has **no template suffixes** — files are already in their adopted names. Adoption is copy + variable substitution + fill the constitution.
+
+## Adoption (new project)
+
+1. **Copy** the preset into the new project root:
+   ```bash
+   cp -R starter-pack/presets/minimal-overlay/. /path/to/new-project/
+   cd /path/to/new-project
+   ```
+   The `.` after `minimal-overlay/` copies contents (including dotdirs) rather than the directory itself.
+
+2. **Remove the source artifacts** that don't belong in a runtime project:
+   ```bash
+   rm README.md manifest.yaml
+   ```
+   Keep these only if you want a record of the preset version inside the project.
+
+3. **Substitute variables.** See `manifest.yaml`'s `variables:` section for the full list. On macOS:
+   ```bash
+   sed -i '' \
+     -e 's|{{PROJECT_NAME}}|My Project|g' \
+     -e 's|{{PROJECT_ONE_LINER}}|<one sentence>|g' \
+     -e 's|{{PRIMARY_STACK}}|TypeScript, Node 20|g' \
+     -e 's|{{INSTALL_CMD}}|pnpm install|g' \
+     -e 's|{{TEST_CMD}}|pnpm test|g' \
+     -e 's|{{LINT_CMD}}|pnpm lint|g' \
+     -e 's|{{BUILD_CMD}}|pnpm build|g' \
+     -e 's|{{DEV_CMD}}|pnpm dev|g' \
+     AGENTS.md .claude/settings.json
+   ```
+   Verify: `grep -r '{{' .` should return nothing.
+
+4. **Fill the constitution.** Replace `ops/ai/constitution/README.md` with the four required files (mission, scope, stack, principles). The other placeholder READMEs can stay until real content lands.
+
+5. **Verify** with a fresh Claude Code session — see the [§8 conformance test](../../../docs/contracts/consumer-project-overlay.md#8-conformance-test-minimum) in the contract.
+
+Time budget: ~30 minutes of focused work for a new project, longer for legacy retrofits that need scope and principle decisions surfaced.
+
+## Adoption (legacy project)
+
+Same five steps, with two adjustments:
+
+- After step 3, **don't backfill history.** No fake handoffs, closeouts, or learnings from before adoption date (per contract §6 "anti-pattern: don't backfill").
+- Treat the constitution as a forcing function. If `scope.md` exposes a question the team has been avoiding, that's the constitution doing its job — answer it before opening sessions on the new overlay.
+
+## What this preset deliberately does NOT include
+
+- **Codex, Cursor, or other harness shims.** Only Claude. Other harnesses wait for a real adopter (ADR-004 §4 "no premature shims").
+- **Product-architecture opinions.** No `src/` layout, no framework preference, no build-tool stance.
+- **Pre-filled handoffs, closeouts, or learnings.** The overlay starts at adoption date.
+- **A generator or CLI.** Static bundle on purpose — easier to review, version, and roll back.
+
+## Versioning
+
+The preset version is in `manifest.yaml` (`version:` field). When the canonical contract changes in a way that requires preset updates, bump the version and update the `provenance:` entries to match.
+
+Consumer projects MAY pin to a specific preset version by copying `manifest.yaml` into the project and treating future updates as opt-in upgrades.

--- a/starter-pack/presets/minimal-overlay/manifest.yaml
+++ b/starter-pack/presets/minimal-overlay/manifest.yaml
@@ -1,0 +1,163 @@
+---
+# Preset manifest — minimal-overlay
+# Bundles the consumer-project-overlay contract (Epic 4) and the Claude
+# harness shim pack (Epic 5) into a single copy-and-fill bundle.
+#
+# This manifest is the authoritative provenance record: every file the
+# preset emits maps back to a canonical source in AletheIA. An agent that
+# reads this file can reconstruct the lineage of any preset file without
+# inspecting the AletheIA repo directly.
+
+preset: minimal-overlay
+version: 1.0.0
+schema: https://github.com/nevitonsantana/AletheIA/blob/main/starter-pack/presets/minimal-overlay/manifest.yaml
+description: >
+  Day-one operating overlay for a consumer project using Claude Code.
+  Provides the required ops/ai/ skeleton, harness shims, and three
+  path-scoped rules. Constitution and other content surfaces ship as
+  placeholders to be filled at adoption.
+
+aletheia_min_version: 1.0.0
+last_updated: 2026-05-21
+
+# --- Provenance ---------------------------------------------------------
+# Each entry: preset file → canonical source. "Canonical" means the
+# normative document or pattern in AletheIA from which this file derives.
+# If a preset file diverges from its canonical source, that divergence is
+# either (a) variable substitution, or (b) a bug.
+
+provenance:
+  - file: AGENTS.md
+    source: starter-pack/harness-shims/claude/AGENTS.md.template
+    contract: docs/contracts/consumer-project-overlay.md#41-agentsmd-—-must
+    notes: Renamed from .template; identical content modulo variable substitution.
+
+  - file: CLAUDE.md
+    source: starter-pack/harness-shims/claude/CLAUDE.md.template
+    contract: docs/contracts/consumer-project-overlay.md#42-claudemd-—-must-if-claude-code-is-used
+    notes: Renamed from .template; no substitution needed.
+
+  - file: .claude/settings.json
+    source: starter-pack/harness-shims/claude/.claude/settings.json.template
+    contract: docs/contracts/consumer-project-overlay.md#43-claude-—-should-if-claude-code-is-used
+
+  - file: .claude/rules/src.md
+    source: starter-pack/harness-shims/claude/.claude/rules/src.md
+    contract: docs/contracts/consumer-project-overlay.md#43-claude-—-should-if-claude-code-is-used
+
+  - file: .claude/rules/tests.md
+    source: starter-pack/harness-shims/claude/.claude/rules/tests.md
+    contract: docs/contracts/consumer-project-overlay.md#43-claude-—-should-if-claude-code-is-used
+
+  - file: .claude/rules/ops-ai.md
+    source: starter-pack/harness-shims/claude/.claude/rules/ops-ai.md
+    contract: docs/contracts/consumer-project-overlay.md#43-claude-—-should-if-claude-code-is-used
+
+  - file: ops/ai/constitution/README.md
+    source: docs/contracts/consumer-project-overlay.md#31-opsai-constitution-—-must
+    contract: docs/contracts/consumer-project-overlay.md#31-opsai-constitution-—-must
+    notes: Placeholder with fill-in instructions. MUST be replaced with mission/scope/stack/principles before first session.
+
+  - file: ops/ai/handoffs/README.md
+    source: docs/contracts/consumer-project-overlay.md#32-opsai-handoffs-—-must
+    contract: docs/contracts/consumer-project-overlay.md#32-opsai-handoffs-—-must
+    notes: Empty-state placeholder. First real handoff lands as YYYY-MM-DD-<slug>.md.
+
+  - file: ops/ai/reports/README.md
+    source: docs/contracts/consumer-project-overlay.md#33-opsai-reports-—-must
+    contract: docs/contracts/consumer-project-overlay.md#33-opsai-reports-—-must
+
+  - file: ops/ai/policies/README.md
+    source: docs/contracts/consumer-project-overlay.md#34-opsai-policies-—-should
+    contract: docs/contracts/consumer-project-overlay.md#34-opsai-policies-—-should
+
+  - file: ops/ai/schemas/README.md
+    source: docs/contracts/consumer-project-overlay.md#35-opsai-schemas-—-may
+    contract: docs/contracts/consumer-project-overlay.md#35-opsai-schemas-—-may
+
+  - file: ops/ai/skills/README.md
+    source: docs/contracts/consumer-project-overlay.md#36-opsai-skills-—-may
+    contract: docs/contracts/consumer-project-overlay.md#36-opsai-skills-—-may
+
+  - file: ops/ai/learnings/README.md
+    source: docs/contracts/consumer-project-overlay.md#37-opsai-learnings-—-should
+    contract: docs/contracts/consumer-project-overlay.md#37-opsai-learnings-—-should
+
+# --- Variables ----------------------------------------------------------
+# Substitute these before opening the first session. Adoption is not
+# complete until grep -r '{{' returns no matches.
+
+variables:
+  - name: PROJECT_NAME
+    description: Display name of the project (e.g., "Crisis Monitor")
+    appears_in:
+      - AGENTS.md
+    required: true
+
+  - name: PROJECT_ONE_LINER
+    description: One sentence — what the project does, for whom
+    appears_in:
+      - AGENTS.md
+    required: true
+
+  - name: PRIMARY_STACK
+    description: Comma-separated primary languages/frameworks
+    appears_in:
+      - AGENTS.md
+    required: true
+
+  - name: INSTALL_CMD
+    description: Dependency-install command (e.g., "pnpm install")
+    appears_in:
+      - AGENTS.md
+      - .claude/settings.json
+    required: true
+
+  - name: TEST_CMD
+    description: Test command (e.g., "pnpm test")
+    appears_in:
+      - AGENTS.md
+      - .claude/settings.json
+    required: true
+
+  - name: LINT_CMD
+    description: Lint command (e.g., "pnpm lint")
+    appears_in:
+      - AGENTS.md
+      - .claude/settings.json
+    required: true
+
+  - name: BUILD_CMD
+    description: Build command (e.g., "pnpm build")
+    appears_in:
+      - AGENTS.md
+      - .claude/settings.json
+    required: true
+
+  - name: DEV_CMD
+    description: Local dev command, or "n/a" if not applicable
+    appears_in:
+      - AGENTS.md
+    required: false
+
+# --- Adoption checklist -------------------------------------------------
+# An agent or human can use this list as the conformance gate for adoption.
+
+adoption_checklist:
+  - Copy the preset directory's contents into the consumer project root
+  - Remove this manifest file from the consumer project (it is a source artifact, not a runtime one)
+  - Rename .template files (none in this preset — already renamed)
+  - Substitute all variables; confirm with `grep -r '{{' .` returns nothing
+  - Replace ops/ai/constitution/README.md with mission.md, scope.md, stack.md, principles.md
+  - Delete the placeholder READMEs in handoffs/, reports/, policies/, learnings/ once real content lands
+  - Run the contract §8 conformance test in a fresh Claude Code session
+
+# --- Out of scope -------------------------------------------------------
+# What this preset deliberately does NOT include. Adding any of these
+# without a corresponding change to the canonical contract is a smell.
+
+out_of_scope:
+  - Codex, Cursor, or other harness shims (ADR-004 §4 "no premature shims")
+  - Product source layout opinions (operating-overlay.md "antifragile patterns")
+  - Generated CLI or bootstrap tooling (Epic 7 out of scope per plan §3.2)
+  - Pre-populated handoffs, closeouts, or learnings (contract §6 "anti-pattern: don't backfill")

--- a/starter-pack/presets/minimal-overlay/ops/ai/constitution/README.md
+++ b/starter-pack/presets/minimal-overlay/ops/ai/constitution/README.md
@@ -1,0 +1,12 @@
+# Constitution — fill before first session
+
+This directory MUST contain four files before the first Claude Code session against the new overlay. Replace this README with:
+
+- `mission.md` — one paragraph. What the project exists to do, for whom.
+- `scope.md` — bulleted in/out of scope. What the project does NOT do is often more important than what it does.
+- `stack.md` — primary languages, frameworks, infra. One line each.
+- `principles.md` — 5–10 non-negotiable rules. No platitudes — each rule must be one you'd reject a PR over.
+
+See [docs/contracts/consumer-project-overlay.md §3.1](https://github.com/nevitonsantana/AletheIA/blob/main/docs/contracts/consumer-project-overlay.md#31-opsai-constitution-—-must) for the normative spec and [examples/consumer-overlay-minimal/ops/ai/constitution/](https://github.com/nevitonsantana/AletheIA/tree/main/examples/consumer-overlay-minimal/ops/ai/constitution) for worked examples.
+
+Delete this file once the four constitution files exist.

--- a/starter-pack/presets/minimal-overlay/ops/ai/handoffs/README.md
+++ b/starter-pack/presets/minimal-overlay/ops/ai/handoffs/README.md
@@ -1,0 +1,9 @@
+# Handoffs — empty until first session
+
+This directory accumulates session-to-session handoffs. Each file is named `YYYY-MM-DD-<kebab-slug>.md` and contains four sections: **Context**, **State**, **Next**, **Open questions**.
+
+See [docs/contracts/consumer-project-overlay.md §3.2](https://github.com/nevitonsantana/AletheIA/blob/main/docs/contracts/consumer-project-overlay.md#32-opsai-handoffs-—-must) for the normative spec.
+
+**Anti-pattern**: do not backfill historical handoffs. The overlay starts at adoption date.
+
+Delete this README once the first real handoff is committed.

--- a/starter-pack/presets/minimal-overlay/ops/ai/learnings/README.md
+++ b/starter-pack/presets/minimal-overlay/ops/ai/learnings/README.md
@@ -1,0 +1,9 @@
+# Learnings — durable lessons go here
+
+A learning is the bridge between "we found this once" and "we now operate differently because of it." File naming: `YYYY-MM-DD-<kebab-slug>.md`. Each learning states **Context**, **Observation**, **Change**.
+
+**SHOULD** accumulate over time. Empty after several sprints is a smell — either the project isn't learning, or the lessons aren't being captured here.
+
+See [docs/contracts/consumer-project-overlay.md §3.7](https://github.com/nevitonsantana/AletheIA/blob/main/docs/contracts/consumer-project-overlay.md#37-opsai-learnings-—-should).
+
+Delete this README once the first real learning is committed.

--- a/starter-pack/presets/minimal-overlay/ops/ai/policies/README.md
+++ b/starter-pack/presets/minimal-overlay/ops/ai/policies/README.md
@@ -1,0 +1,9 @@
+# Policies — local operational rules
+
+Project-local rules that constrain how the agent operates here, beyond what canonical AletheIA already imposes. Typical files: `pr-policy.md`, `data-handling-policy.md`, `tool-use-policy.md`.
+
+**SHOULD** be populated if this project has non-default constraints (regulated data, restricted tools, custom review workflow). **MAY** stay empty for exploratory projects.
+
+See [docs/contracts/consumer-project-overlay.md §3.4](https://github.com/nevitonsantana/AletheIA/blob/main/docs/contracts/consumer-project-overlay.md#34-opsai-policies-—-should) for the normative spec.
+
+Delete this README once real policies exist, or keep it empty until a real constraint forces one.

--- a/starter-pack/presets/minimal-overlay/ops/ai/reports/README.md
+++ b/starter-pack/presets/minimal-overlay/ops/ai/reports/README.md
@@ -1,0 +1,7 @@
+# Reports — closeouts go here
+
+One closeout per shipped slice. File naming: `YYYY-MM-DD-<slug>-closeout.md`. Required three-section structure: **Done**, **Pending**, **Frictions**.
+
+See [docs/contracts/consumer-project-overlay.md §3.3](https://github.com/nevitonsantana/AletheIA/blob/main/docs/contracts/consumer-project-overlay.md#33-opsai-reports-—-must) for the normative spec.
+
+Delete this README once the first real closeout is committed.

--- a/starter-pack/presets/minimal-overlay/ops/ai/schemas/README.md
+++ b/starter-pack/presets/minimal-overlay/ops/ai/schemas/README.md
@@ -1,0 +1,9 @@
+# Schemas — MAY be empty
+
+Project-local data structures for overlay operations (custom telemetry shapes, project-specific closeout extensions). One file per schema, JSON Schema or YAML.
+
+**MAY** be omitted entirely. If present, every schema MUST validate and be linked from the artifact that consumes it.
+
+**Not for product domain schemas** — those belong in the product layer.
+
+See [docs/contracts/consumer-project-overlay.md §3.5](https://github.com/nevitonsantana/AletheIA/blob/main/docs/contracts/consumer-project-overlay.md#35-opsai-schemas-—-may).

--- a/starter-pack/presets/minimal-overlay/ops/ai/skills/README.md
+++ b/starter-pack/presets/minimal-overlay/ops/ai/skills/README.md
@@ -1,0 +1,9 @@
+# Skills — MAY be empty
+
+Reusable operating procedures specific to this project, packaged so the agent can invoke them by name. One folder per skill, each with a `SKILL.md` describing trigger, inputs, outputs, and steps.
+
+**MAY** be omitted. Add a skill only when an operating procedure stabilizes enough that re-explaining it each session becomes the bottleneck.
+
+**Generic skills** that would apply to any project belong in canonical AletheIA — see the promotion gate in [docs/concepts/operating-overlay.md](https://github.com/nevitonsantana/AletheIA/blob/main/docs/concepts/operating-overlay.md#antifragile-patterns-how-to-avoid-drift).
+
+See [docs/contracts/consumer-project-overlay.md §3.6](https://github.com/nevitonsantana/AletheIA/blob/main/docs/contracts/consumer-project-overlay.md#36-opsai-skills-—-may).


### PR DESCRIPTION
## Summary

- New preset at [starter-pack/presets/minimal-overlay/](starter-pack/presets/minimal-overlay/) — a static, copy-and-fill bundle combining the Epic 4 overlay skeleton with the Epic 5 Claude shim pack.
- [`manifest.yaml`](starter-pack/presets/minimal-overlay/manifest.yaml) is the authoritative provenance record: every preset file maps back to its canonical source via contract-section anchors, with the 8-variable catalog, adoption checklist, and out-of-scope list.
- [`README.md`](starter-pack/presets/minimal-overlay/README.md) walks adoption in five steps for both new and legacy projects.
- Indexed from [starter-pack/README.md](starter-pack/README.md).

## Plan alignment

Closes Épico 6 of `aletheia-plano-melhoria-estrutura.md` v1.0:

- ✅ Bundle layout matches the plan §4 spec (`AGENTS.md`, `CLAUDE.md`, `.claude/`, `ops/ai/` with placeholder READMEs)
- ✅ Manifest maps every preset file → canonical AletheIA source
- ✅ Manifest lists variables to fill at adoption
- ✅ README explains adoption for new and legacy projects
- ✅ Static bundle — no generator, no CLI (plan §3.2 out-of-scope respected)
- ✅ Only Claude shim included; Codex/Cursor wait for a real adopter

## Test plan

- [ ] Walk `README.md` step-by-step on a scratch directory; confirm `cp -R …/.` + `sed` produces a functional project
- [ ] Validate `manifest.yaml` with a YAML parser (already passing locally with `python3 yaml.safe_load`)
- [ ] Cross-check every `provenance:` entry resolves to a real file/anchor in the repo
- [ ] Confirm `grep -r '{{' starter-pack/presets/minimal-overlay/` lists exactly the variables documented in the manifest
- [ ] Verify governance check passes (already green locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)