### PR TITLE
docs: ADR-005, ADR-006 and ecosystem-map (Epic 1)

### DIFF
--- a/docs/adr/ADR-005-positioning-in-agentic-ecosystem.md
+++ b/docs/adr/ADR-005-positioning-in-agentic-ecosystem.md
@@ -1,0 +1,82 @@
+# ADR 005 — AletheIA: positioning in the agentic ecosystem
+
+| Field | Value |
+|---|---|
+| Status | Accepted |
+| Date | 2026-05-21 |
+| Author | Neviton Santana |
+| Deciders | Neviton Santana |
+| Related | ADR-004 (AletheIA as operating overlay), ADR-006 (Domain agnosticism) |
+| Supersedes | — |
+
+## 1. Context
+
+ADR-004 fixed AletheIA's internal boundary (overlay vs. product vs. harness). It did not place AletheIA inside the **external** ecosystem of agentic tooling that consolidated through Q1–Q2 2026.
+
+By mid-2026 the ecosystem has visible, distinct layers:
+
+- **Open standards** for interop: [`AGENTS.md`](https://agents.md/), [`agentskills.io`](https://agentskills.io/), [MCP](https://modelcontextprotocol.io/).
+- **Package distribution**: [APM](https://microsoft.github.io/apm/) (Microsoft).
+- **Squad-ready bundles**: BMAD, SDD-style internal frameworks.
+- **Brain / runtime**: Agentic Stack, Hermes.
+- **Capability libraries**: Anthropic skills, awesome-copilot, agentskills.io packs, [Adaptive Skills](https://github.com/nevitonsantana/adaptive-skills).
+- **Harnesses**: Claude Code, Cursor, Codex, OpenCode, Gemini, Windsurf, etc.
+
+Without an explicit position statement, AletheIA gets confused with each adjacent layer ("is this another BMAD?", "is this a runtime?", "is this a package?"). The cost of re-explaining the boundary in every conversation already exceeds the cost of fixing it.
+
+## 2. Decision
+
+**AletheIA is an operating overlay in the ecosystem sense as well: a portable layer that governs *how* agent-assisted work happens, agnostic to which framework, runtime, harness, or domain is below.**
+
+### 2.1 Ecosystem map
+
+| Layer | Question it answers | Ecosystem solution | AletheIA's relationship |
+|---|---|---|---|
+| Open standards | How to interoperate? | `AGENTS.md`, `agentskills.io`, MCP | **Conforms** (consumer of standards) |
+| Package distribution | How to install and version? | APM | **Consumed by** (AletheIA is published as an APM package) |
+| Operating overlay | How to decide, validate, hand off, report? | — (under-occupied niche) | **This is AletheIA** |
+| Capability library | Reusable portable skills? | Anthropic skills, awesome-copilot, [Adaptive Skills](https://github.com/nevitonsantana/adaptive-skills) | **References** (overlays can call skills; skills are independent) |
+| Squad bundles | Pre-built agents for a squad? | BMAD, SDD | **Complementary** — runs alongside, does not replace |
+| Brain / runtime | Memory, hooks, autonomy? | Agentic Stack, Hermes | **Different layer** — overlay sits above runtime concerns |
+| Harness | Where to execute? | Claude Code, Cursor, Codex, etc. | **Consumer of overlay output** — receives shims, not contracts |
+
+### 2.2 Non-competition statements (normative)
+
+- AletheIA **does not compete with** BMAD, SDD, or similar squad-ready bundles. Those bundles ship agents; AletheIA governs how the work those agents do is decided, validated, handed off, and reported. An adopter can keep BMAD/SDD and add AletheIA on top.
+- AletheIA **does not compete with** APM. AletheIA is published *via* APM; APM is the distribution mechanism, AletheIA is the content.
+- AletheIA **does not compete with** Hermes, Agentic Stack, or other runtime/brain layers. Those persist sessions, hooks, autonomy; AletheIA shapes the contract that crosses the runtime boundary, not the boundary itself.
+- AletheIA **does not compete with** Adaptive Skills. Skills are reusable capabilities; AletheIA can call them, an adopter can use either without the other. See ADR-003 in the Adaptive Skills repo for the mirror of this statement.
+
+### 2.3 Value proposition (positioning summary)
+
+AletheIA occupies the *operating overlay* layer — the layer the ecosystem under-serves today. Every other layer assumes governance happens "somewhere else": standards do not legislate it, package managers do not enforce it, runtimes do not own it, capability libraries do not embody it, and squad bundles concentrate it inside their own framework. AletheIA externalizes governance as a portable layer that travels with the consumer project, independent of which agent framework, runtime, or harness is in use.
+
+## 3. Consequences
+
+**Positive.** Pitch becomes one sentence: "governance overlay, framework-agnostic, runs alongside BMAD/SDD/anything." Adopters who already invested in a squad framework do not have to abandon it. APM publication path is unblocked. Risk of being read as "yet another framework" is bounded.
+
+**Negative.** "Overlay" is conceptually less immediate than "bundle of agents you install"; education cost on first conversation. Some adopters who want a turnkey squad framework will see AletheIA as too abstract for their need — that is the correct read and they should use a bundle instead.
+
+**Accepted tradeoff.** Smaller surface, sharper differentiation, lower risk of duplication.
+
+## 4. Alternatives considered
+
+- **A. Build a squad bundle (BMAD-style).** Rejected — duplicates existing solutions, no differentiated value, contradicts ADR-004's overlay boundary.
+- **B. Position as a BMAD/SDD competitor.** Rejected — unfavorable terrain (BMAD has community traction); also factually wrong, since the layer differs.
+- **C. Position as a runtime / brain.** Rejected — collapses overlay into runtime, contradicting ADR-004.
+- **D. Stay silent on positioning and let adopters infer.** Rejected — re-litigation cost across conversations already exceeds the cost of this ADR.
+
+## 5. Relationship
+
+ADR-004 fixed the *internal* layering (overlay vs. product vs. harness). This ADR fixes the *ecosystem* layering. ADR-006 fixes the orthogonal axis: domain agnosticism. The 2026-05-21 cross-repo plan (Epic 4) consumes this ADR as prerequisite for APM packaging. [`docs/concepts/ecosystem-map.md`](../concepts/ecosystem-map.md) is the public-facing mirror of section 2.1.
+
+## 6. Review
+
+Reopen when:
+
+- BMAD, SDD, or a comparable bundle starts shipping a native governance overlay layer with similar properties → re-evaluate whether the niche is still distinct.
+- Adopters report at volume that they read AletheIA as a competitor of BMAD/SDD despite the positioning text → revise the framing or the artifact, not the decision.
+- A consolidated open standard for "operating overlay" appears (does not exist as of 2026-05) → align or supersede.
+- The cited adjacent layers (APM, MCP, AGENTS.md) consolidate or fragment in ways that change the map → update section 2.1 first; reopen ADR only if the boundary itself moves.
+
+If a review confirms the decision unchanged, record the confirmation date here and continue.

--- a/docs/adr/ADR-006-domain-agnosticism.md
+++ b/docs/adr/ADR-006-domain-agnosticism.md
@@ -1,0 +1,69 @@
+# ADR 006 — AletheIA: domain agnosticism
+
+| Field | Value |
+|---|---|
+| Status | Accepted |
+| Date | 2026-05-21 |
+| Author | Neviton Santana |
+| Deciders | Neviton Santana |
+| Related | ADR-004 (AletheIA as operating overlay), ADR-005 (Positioning in agentic ecosystem) |
+| Supersedes | — |
+
+## 1. Context
+
+AletheIA was developed against a single consumer project — **Crisis Monitor** — used as sandbox throughout its formative phase. That project shaped the canonical vocabulary, the slice/handoff patterns, the closeout templates, and the pilots in [`docs/pilots/`](../pilots/). The shaping is real and useful, but it leaves a residue: Crisis Monitor appears as the implicit reference example in canonical content, and a new reader cannot always tell whether a given decision is general or Crisis-Monitor-specific.
+
+The 2026-05-21 cross-repo plan declares the soft-launch goal — adopting AletheIA inside the author's company alongside BMAD/SDD — which forces this question: *is AletheIA a Crisis-Monitor framework that pretends to be general, or a general framework that was first validated on Crisis Monitor?*
+
+Both readings are possible from the current state of `docs/`. The reading must be fixed.
+
+## 2. Decision
+
+**AletheIA is domain-agnostic. Crisis Monitor is the first validation case, not the canonical case.** Other consumer projects are expected and prioritized.
+
+### 2.1 Membership criterion (canonical vs. example)
+
+A piece of content belongs in **canonical layer** (`docs/concepts/`, `docs/contracts/`, `docs/guides/`, `docs/adr/`) only if it remains true after substituting Crisis Monitor for any other domain (software product, design system, data pipeline, operations runbook, regulatory program, etc.).
+
+A piece of content belongs in **example layer** (`docs/pilots/`, `docs/examples/`, case studies) when it depends on Crisis-Monitor-specific facts, vocabulary, stakeholders, or incidents.
+
+When an artifact mixes both, it is mis-factored: separate the canonical insight from the Crisis-Monitor illustration, place each in its layer, and link.
+
+### 2.2 Reading test (operational)
+
+For any canonical document, the test is: *if a new adopter from a different domain reads this, do they see general guidance and a labeled example, or do they see Crisis Monitor and have to translate?* The latter is a defect, tracked by Epic 2 of the 2026-05-21 cross-repo plan.
+
+### 2.3 What this is not
+
+- This is **not** a requirement to produce a fictional second case study for balance. Declared agnosticism plus first-validation transparency is sufficient until soft-launch produces real cases.
+- This is **not** a removal of Crisis Monitor content. The case study is preserved as labeled evidence in [`docs/pilots/`](../pilots/) and (after Epic 2) in `docs/examples/`.
+- This is **not** a claim that *any* domain is equally well-supported today. The claim is that nothing in the *framework* prevents another domain; the framework was *exercised* on one.
+
+## 3. Consequences
+
+**Positive.** Adoption pitch generalizes: a design squad or a data team can read the canonical docs and recognize themselves without translation. Risk that adopters cite "no case for my domain" as blocker is mitigated by transparency, not by faking coverage. The Crisis Monitor case study gains a clearer role: labeled field evidence, not implicit canon.
+
+**Negative.** Some canonical docs need rewriting to remove embedded Crisis-Monitor framing — that work is real (Epic 2). Until that work lands, the gap between declared agnosticism and observable agnosticism is visible.
+
+**Accepted tradeoff.** A short window of declared-but-not-yet-observable agnosticism is preferable to keeping Crisis Monitor entangled in canonical content. The window closes with Epic 2.
+
+## 4. Alternatives considered
+
+- **A. Declare AletheIA Crisis-Monitor-specific; ship a generic fork later.** Rejected — the framework was already general by intent; only the examples are specific. Forking would duplicate maintenance for no gain.
+- **B. Keep Crisis Monitor as the canonical reference and treat other domains as ports.** Rejected — institutionalizes the residue ADR-006 is trying to remove and contradicts the cross-repo plan's H1 (complementary positioning).
+- **C. Produce a synthetic second case for balance before declaring agnosticism.** Rejected — premature, expensive, and creates a fictional artifact whose existence reduces credibility.
+- **D. Leave agnosticism implicit and rely on each conversation to clarify.** Rejected — same re-litigation cost argument as ADR-005.
+
+## 5. Relationship
+
+ADR-004 fixed *what* AletheIA is (overlay). ADR-005 fixed *where* it sits in the ecosystem. This ADR fixes *what it applies to* (any domain). Epic 2 of the 2026-05-21 cross-repo plan implements section 2.1 by auditing and reclassifying Crisis Monitor references across the repo. The mirror ADR in the Adaptive Skills repo (ADR-002) carries the same principle for capability libraries.
+
+## 6. Review
+
+Reopen when:
+
+- A second consumer project adopts AletheIA and surfaces a structural assumption that *is* genuinely Crisis-Monitor-specific (i.e., the framework turned out to be less general than this ADR claims) → narrow the agnosticism scope.
+- Soft-launch feedback shows adopters consistently fail to map a canonical concept to their domain without translation → the canonical content needs further despoluição beyond Epic 2.
+- A domain emerges where AletheIA *should* take an opinionated stance (e.g., regulated environments with mandatory artifacts) → consider domain packs rather than reopening the core agnosticism claim.
+
+If a review confirms the decision unchanged, record the confirmation date here and continue.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -66,3 +66,5 @@ Do *not* write one for:
 | [ADR-002](ADR-002-memory-and-skill-promotion-policy.md) | Memory and skill promotion policy | Accepted |
 | [ADR-003](ADR-003-slice-record-closeout-relationship.md) | Slice record / closeout relationship | Accepted |
 | [ADR-004](ADR-004-aletheia-as-operating-overlay.md) | AletheIA as operating overlay | Accepted |
+| [ADR-005](ADR-005-positioning-in-agentic-ecosystem.md) | Positioning in the agentic ecosystem | Accepted |
+| [ADR-006](ADR-006-domain-agnosticism.md) | Domain agnosticism | Accepted |

--- a/docs/concepts/ecosystem-map.md
+++ b/docs/concepts/ecosystem-map.md
@@ -1,0 +1,62 @@
+# Agentic ecosystem map
+
+> **Synchronized document.** This file is maintained identically in two repositories:
+> [`AletheIA/docs/concepts/ecosystem-map.md`](https://github.com/nevitonsantana/AletheIA/blob/main/docs/concepts/ecosystem-map.md)
+> and [`adaptive-skills/docs/concepts/ecosystem-map.md`](https://github.com/nevitonsantana/adaptive-skills/blob/main/docs/concepts/ecosystem-map.md).
+> Edits in either repo must be mirrored to the other. The plan that introduced this document is the 2026-05-21 cross-repo plan (Epic 1).
+
+## Purpose
+
+Place AletheIA and Adaptive Skills inside the broader 2026 ecosystem of agent-assisted work tooling, so that adopters can answer three questions without re-litigation:
+
+1. *Does this duplicate something I already use?*
+2. *Does this replace something I already use?*
+3. *Where does this fit in my stack?*
+
+## Layers
+
+The ecosystem is organized by **what question each layer answers**, not by vendor or product family.
+
+| Layer | Question it answers | Ecosystem solutions | This ecosystem |
+|---|---|---|---|
+| Open standards | How do components interoperate? | `AGENTS.md`, `agentskills.io`, MCP | Conformance target |
+| Package distribution | How is content installed and versioned? | APM (Microsoft) | Both repos publish here |
+| Operating overlay | How do we decide, validate, hand off, report? | — (under-occupied) | **AletheIA** |
+| Capability library | What reusable, portable skills are available? | Anthropic skills, awesome-copilot, agentskills.io packs | **Adaptive Skills** |
+| Squad-ready bundle | What pre-built agents do I drop into a squad? | BMAD, SDD, similar internal frameworks | Not built here |
+| Brain / runtime | How is memory, hooks, autonomy managed? | Agentic Stack, Hermes | Not built here (deferred) |
+| Harness | Where does the code actually execute? | Claude Code, Cursor, Codex, OpenCode, Gemini, Windsurf, etc. | Consumer of the layers above |
+
+## Differentiated value
+
+**AletheIA** occupies the *operating overlay* layer — under-occupied today. The other layers either delegate governance elsewhere (standards, package managers, runtimes, capability libraries) or concentrate it inside a specific framework (squad bundles). AletheIA externalizes governance as a portable layer that travels with the consumer project, independent of which framework, runtime, or harness is in use.
+
+**Adaptive Skills** occupies the *capability library* layer — populated but fragmented. The differentiator is conformance with open standards (`agentskills.io`, AGENTS.md) plus a governed evolution discipline (no skill self-edits; protected surfaces; observation → proposal → review).
+
+**Together** they provide a *governance overlay + capability library* combination that plugs into any squad setup without replacing the squad's existing framework. The two are usable independently — neither is a hard dependency of the other.
+
+## Relationship to adjacent solutions
+
+| Adjacent solution | Layer | Relationship |
+|---|---|---|
+| BMAD | Squad-ready bundle | **Complementary.** Keep BMAD; add AletheIA on top for governance; reference Adaptive Skills for portable capabilities. |
+| SDD-style internal framework | Squad-ready bundle | Same as BMAD. |
+| APM | Package distribution | **Consumed by.** Both repos are published as APM packages. |
+| Hermes / Agentic Stack | Brain / runtime | **Different layer.** No competition; AletheIA shapes contracts that cross the runtime boundary. |
+| Anthropic skills, awesome-copilot | Capability library | **Adjacent.** Adaptive Skills aims for `agentskills.io` conformance so artifacts are interoperable. |
+| Claude Code, Cursor, Codex, etc. | Harness | **Consumer.** Receives shims and projected artifacts; does not negotiate the contract. |
+
+## What this map deliberately does not say
+
+- It does not rank the layers by importance — each answers a distinct question.
+- It does not claim AletheIA + Adaptive Skills is sufficient for every squad. A squad without BMAD/SDD/equivalent still has to decide *which agents* to run; this ecosystem governs *how the work the agents do* is operated.
+- It does not claim domain coverage. Domain agnosticism is declared (see ADR-006 in AletheIA, ADR-002 in Adaptive Skills); observable agnosticism is a work item (Epic 2 of the cross-repo plan).
+
+## Source ADRs
+
+- AletheIA: [ADR-004 — Operating overlay](../adr/ADR-004-aletheia-as-operating-overlay.md), [ADR-005 — Positioning in agentic ecosystem](../adr/ADR-005-positioning-in-agentic-ecosystem.md), [ADR-006 — Domain agnosticism](../adr/ADR-006-domain-agnosticism.md).
+- Adaptive Skills: [ADR-001 — Adaptive Skills as capability library](https://github.com/nevitonsantana/adaptive-skills/blob/main/docs/adr/ADR-001-adaptive-skills-as-capability-library.md), [ADR-002 — Domain agnosticism](https://github.com/nevitonsantana/adaptive-skills/blob/main/docs/adr/ADR-002-domain-agnosticism.md), [ADR-003 — Relationship with AletheIA](https://github.com/nevitonsantana/adaptive-skills/blob/main/docs/adr/ADR-003-relationship-with-aletheia.md).
+
+## Revision
+
+This map updates when the ecosystem itself shifts (new consolidated layer, layer collapse, new dominant standard). Routine updates to a single solution within a layer do not require a new revision — only the table cell.


### PR DESCRIPTION
## Summary
Cross-repo plan Epic 1 — fixes AletheIA's external positioning.

- **ADR-005**: positioning in the agentic ecosystem (overlay layer; non-competition statements vs. BMAD/SDD/APM/Hermes/Adaptive Skills).
- **ADR-006**: domain agnosticism (Crisis Monitor is first validation case, not canonical case; membership criterion for canonical vs. example).
- **docs/concepts/ecosystem-map.md**: synchronized cross-repo document (byte-identical mirror lives in [adaptive-skills#docs/adrs-positioning](https://github.com/nevitonsantana/adaptive-skills/tree/docs/adrs-positioning)).
- **docs/adr/README.md**: updated "Current ADRs" table with ADR-005 and ADR-006.

## Context

Part of the 2026-05-21 cross-repo plan for AletheIA + Adaptive Skills (8 epics, gates explícitos). Onda 0 fechada em 2026-05-21; this is Epic 1.

Companion PR in the Adaptive Skills repo introduces ADR-001/002/003 + the same ecosystem map. The two PRs are intended to land together (order-independent).

## Decisions that extrapolated the plan (justified)

1. **Folder is \`docs/adr/\` (singular)**, following existing repo convention — not \`docs/adrs/\` as the plan template said.
2. **Content in English**, matching existing ADRs 001-004 and recent doc convention.
3. **Format**: metadata table + 6 numbered sections (Context/Decision/Consequences/Alternatives/Relationship/Review), per existing ADR convention. Plan's Apêndice A used as content reference, not literal format.
4. **No CLAUDE.md / AGENTS.md** added in this PR — deferred to Epic 4 (APM packaging) where \`AGENTS.md.template\` already lives.

## Test plan
- [ ] Read ADR-005 — does it answer "does AletheIA compete with BMAD/SDD/APM/Hermes/Adaptive Skills?" without ambiguity?
- [ ] Read ADR-006 — does it answer "is AletheIA Crisis-Monitor-specific?" without ambiguity?
- [ ] Compare \`docs/concepts/ecosystem-map.md\` here vs. the adaptive-skills PR — verify byte-identical content.
- [ ] Confirm \`docs/adr/README.md\` table lists ADR-005 and ADR-006 as Accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)