### PR TITLE
docs: despoluir Crisis Monitor de conteúdo canônico (Epic 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,15 @@ The repository is organized around four practical blocks:
 2. **Starter pack**
    - reusable guides, templates, checklists and playbooks for applying AletheIA in a project
 3. **Pilot and adoption materials**
-   - self-application, Crisis Monitor grounding, constrained adoption, project extension and pilot conversion
+   - self-application, first-validation grounding (Crisis Monitor — see `docs/pilots/`), constrained adoption, project extension and pilot conversion
 4. **1.x evolution tracks**
    - trust-boundary hardening, resource-aware operations, runtime-adapter guidance and future domain governance work
 
-Crisis Monitor remains an important pilot source, but its product-specific runtime, UI, assistant behavior and project-management rules are not the portable AletheIA core.
+### First validation case
 
-For the current ownership and re-entry boundary, see `docs/migration-from-crisis-monitor.md`.
+AletheIA is **domain-agnostic** (see [`docs/adr/ADR-006-domain-agnosticism.md`](docs/adr/ADR-006-domain-agnosticism.md)). The framework was first validated against the **Crisis Monitor** project — that case is preserved as labeled field evidence under `docs/pilots/` and `examples/`, but it is not the canonical reference. Additional consumer projects across other domains are expected and prioritized.
+
+For the current ownership and re-entry boundary on the first case specifically, see [`docs/pilots/migration-from-crisis-monitor.md`](docs/pilots/migration-from-crisis-monitor.md).
 
 ---
 

--- a/docs/_meta/crisis-monitor-references.md
+++ b/docs/_meta/crisis-monitor-references.md
@@ -1,0 +1,107 @@
+# Crisis Monitor references — inventory and reclassification
+
+> **Purpose.** Track every reference to the first validation case (Crisis Monitor) across the AletheIA repo, classify each by layer (canonical / example / meta), and record the action taken in Epic 2 of the 2026-05-21 cross-repo plan.
+>
+> **Date.** Created 2026-05-21.
+>
+> **Scope.** Markdown content in `docs/`, `examples/`, `starter-pack/`, plus root files. Excludes auto-generated artifacts and `engine/` / `policies/` / `schemas/` / `scripts/` / `tests/` (out of scope per plan §4.2).
+>
+> **Related ADR.** [ADR-006 — Domain agnosticism](../adr/ADR-006-domain-agnosticism.md).
+
+## Method
+
+```
+grep -rln -iE "crisis[- _]?monitor" --include="*.md" --include="*.ts" \
+  --include="*.json" --include="*.yaml" --include="*.yml" --include="*.sh" .
+```
+
+Each match was classified as:
+
+- **A — narrative dependency** (canonical doc tells the story *through* Crisis Monitor): refactor required.
+- **B — concrete reference** (placeholder / data / example slot): cirurgical fix.
+- **C — by design / already in example layer**: log only; no action.
+
+## Type A — refactored in this PR
+
+Canonical docs whose narrative was anchored on Crisis Monitor. Refactored to generic phrasing + explicit link to `docs/pilots/`.
+
+| File | Action |
+|---|---|
+| `docs/concepts/overview.md` | "Alpha 2 bridge" section rewritten: Crisis Monitor named as *first validation case*, link to pilot, paths corrected to actual locations. |
+| `docs/concepts/operating-overlay.md` | Two table rows generalized from "in Crisis Monitor" → "in a consumer project". One "looks like X but is Y" example generalized from `crisis-monitor-runbook` → `deployment-runbook`. |
+| `docs/concepts/self-application.md` | "What recent real-world validation added" narrative now opens with "first validation case" framing + link to pilot. "See also" paths corrected. |
+| `docs/concepts/project-extension-pattern.md` | "Crisis Monitor example" section rewritten as "Worked example pattern" — generic, with first-validation-case callout pointing to pilot. |
+| `docs/concepts/iterative-maintenance-governance.md` | "What recent real-world evidence changed" opens with "first validation case" framing + link to pilot. |
+| `docs/concepts/ai-agent-security-prompt-injection.md` | "Monitoring Content as Untrusted Input" generalized from "agentic products such as Crisis Monitor" → "agentic products that ingest external monitored content". "Crisis Monitor motivation without lock-in" renamed to "First-validation motivation without lock-in" with pilot link. |
+| `docs/guides/pilot-conversion.md` | "Crisis Monitor example" section rewritten as "Worked example: first validation case" with pilot link and explicit generic framing. |
+| `README.md` (root) | Block 3 of "What is in this repository" generalized. New subsection "First validation case" added with ADR-006 link and pilot/examples reference. |
+
+## Type B — cirurgical generalization in this PR
+
+Concrete placeholder/data references. Fixed without rewriting surrounding narrative.
+
+| File | Action |
+|---|---|
+| `docs/contracts/consumer-project-overlay.md` | Mission example placeholder changed to `<consumer-product>` with link to pilot. Skill example "triage a Crisis Monitor incident" → "triage an operational incident in the consumer product". |
+| `docs/contracts/runtime-adapter-contract.md` | YAML `project_id: crisis-monitor` → `project_id: example-consumer`. |
+| `docs/contracts/slice-telemetry-model.md` | YAML `slice_id: cris-routing-approval-round-2` → `routing-approval-round-2`; `project_id: crisis-monitor` → `example-consumer`. |
+| `docs/guides/setting-up-harnesses.md` | `sed` template substitution example changed from `Crisis Monitor` to `Acme Operations` (neutral fictional placeholder). |
+| `docs/concepts/context-graph-integration.md` | "Controlled tests on the Crisis Monitor confirmed" → "Controlled tests in the first validation case (Crisis Monitor pilot — see `pilots/context-graph-decision.md`)". Data (F1=0.041, 73–97% false positives) preserved with explicit source labeling, per the user's gate decision on 2026-05-21. |
+| `docs/index.md` | "I want to see real adoption evidence" section gains an explicit framing block citing ADR-006: pilots are labeled field evidence, not canonical content. Crisis Monitor pilot entries kept; description text adjusted to "first validation case". |
+| `docs/pilots/README.md` | Top-of-file callout added stating pilots are labeled field evidence, not canonical content, with link to ADR-006. |
+
+## Type C — by design or already in example layer (no action; logged)
+
+These files were left untouched in this PR. They are either:
+- Decision records that need to mention Crisis Monitor by their nature (ADRs).
+- Documents already in pilots / examples / reference / roadmap layers, where Crisis Monitor naturally belongs.
+- Meta tracking documents.
+
+| File | Layer | Why no action |
+|---|---|---|
+| `docs/adr/ADR-001-hermes-role.md` | adr | Historical decision; mentions Crisis Monitor as context of the time. |
+| `docs/adr/ADR-004-aletheia-as-operating-overlay.md` | adr | Decision uses Crisis Monitor as one of several example artifacts. |
+| `docs/adr/ADR-006-domain-agnosticism.md` | adr | Topic *is* Crisis Monitor's reclassification. Mentions are by design. |
+| `docs/_meta/MIGRATION.md` | meta | Documents the history of file moves; references are historical. |
+| `docs/_meta/docs-inventory.md` | meta | Inventory document; will be regenerated by docs maintenance. |
+| `docs/pilots/*` (7 files) | pilots | Pilots layer is the labeled-example layer. By construction. |
+| `docs/reference/learnings.md` | reference | Operational reference / historical record. |
+| `docs/reference/hermes-phase-minus-1-index.md` | reference | Operational reference / Hermes-specific historical record. |
+| `docs/reference/hermes-phase-minus-1-operational-matrix.md` | reference | Same as above. |
+| `docs/roadmaps/roadmap-alpha.md` | roadmaps | Historical roadmap entries referencing the first validation case. |
+| `docs/roadmaps/evolution-plan.md` | roadmaps | Same. |
+| `docs/roadmaps/resource-aware-operations-roadmap.md` | roadmaps | Same. |
+| `examples/*` (multiple) | examples | Examples layer. By construction. |
+| `examples/consumer-overlay-minimal/*` | examples | Minimal-overlay starter example which uses Crisis Monitor as instance. Acceptable in examples layer. |
+| `examples/pilot-conversion/crisis-monitor-real-world-validation.md` | examples | Filename declares the example. By construction. |
+| `examples/resource-aware-operations/*` | examples | Same. |
+| `starter-pack/*` (multiple) | starter-pack | Starter-pack is delivery / template layer — references are illustrative. |
+| `CHANGELOG.md` | meta | Historical change log entries are not rewritten. |
+
+## Validation against acceptance criteria
+
+The plan (§5, Epic 2) requires:
+
+| Criterion | Status |
+|---|---|
+| No canonical doc (concepts/, contracts/, guides/) has narrative dependency on Crisis Monitor | ✅ All 8 Type-A files refactored; 6 Type-B placeholders generalized. |
+| Crisis Monitor appears exclusively in pilots/, examples/, or case-studies/ | ⚠️ Crisis Monitor name still appears in canonical docs *as labeled first-validation reference with link to pilots/*. This is intentional per ADR-006 and the user's 2026-05-21 gate: preserve transparency about the first case, not erase it. |
+| Each repo has a README that explains "first validation case was Crisis Monitor; others are expected" | ✅ `README.md` root has new "First validation case" subsection. |
+
+## Anti-criteria respected
+
+- ❌ No Crisis Monitor content was deleted — only reframed/generalized.
+- ❌ No fictional second case was created to balance.
+- ❌ `engine/`, `policies/`, `schemas/`, `scripts/`, `tests/` were not touched.
+
+## Out-of-scope follow-ups
+
+- The companion repo (Adaptive Skills) carries the parallel inventory at `docs/_meta/crisis-monitor-references.md`. Its execution is a separate PR.
+- `docs/_meta/docs-inventory.md` is stale (lists paths from an earlier reorganization); regenerating it is out of scope for this PR.
+- Some files in `pilots/` reference each other with `docs/foo.md` paths that may have shifted during the earlier reorganization — out of scope; will be caught by future docs-link audits.
+
+## Revision
+
+Reopen this inventory when:
+- A new Crisis Monitor reference is added in a non-example layer (regression).
+- A second consumer project produces canonical evidence that should be cited alongside Crisis Monitor in the canonical layer (positive evolution toward observable agnosticism).

--- a/docs/concepts/ai-agent-security-prompt-injection.md
+++ b/docs/concepts/ai-agent-security-prompt-injection.md
@@ -92,7 +92,7 @@ The goal is explicit defensive posture.
 
 ### D. Monitoring Content as Untrusted Input
 
-For agentic products such as Crisis Monitor, this future pack should make explicit that:
+For agentic products that ingest external monitored content (news feeds, web mentions, document streams, monitoring pipelines), this future pack should make explicit that:
 
 - monitored content is untrusted by default
 - mentions, documents, news, snippets, and captured text enter as evidence or context
@@ -183,19 +183,19 @@ not replace them.
 
 ---
 
-## Crisis Monitor motivation without lock-in
+## First-validation motivation without lock-in
 
-Crisis Monitor and the Cris Assistente are strong motivating examples for this pack.
+The first validation case (Crisis Monitor and its assistant — see [`pilots/pilot-crisis-monitor.md`](../pilots/pilot-crisis-monitor.md)) is a strong motivating example for this pack.
 
-They make concrete problems visible, such as:
+It makes concrete problems visible, such as:
 
 - monitored content that should not become instruction
 - sensitive assistant-mediated workflows
 - tool and context boundaries that matter operationally
 
-Those examples are useful.
+That labeled example is useful.
 
-But this future pack should still remain reusable beyond one assistant or one product.
+But this future pack should still remain reusable beyond one assistant or one product. The principles below are written to apply to any agentic product with similar trust-boundary shape.
 
 ---
 

--- a/docs/concepts/context-graph-integration.md
+++ b/docs/concepts/context-graph-integration.md
@@ -91,10 +91,11 @@ Record graph use as exploration events. Record the delta between files suggested
 ## Known limitation: Next.js and design systems
 
 The `code-review-graph` evaluation benchmark reports **F1 = 0.041** for Next.js projects —
-nearly zero impact accuracy. Controlled tests on the Crisis Monitor confirmed: for UI
-components and CSS tokens, the 2-hop graph reaches virtually the entire project (73–97%
-false positives) because connection density in a shared design system makes any node
-reach the whole project within 2 hops.
+nearly zero impact accuracy. Controlled tests in the first validation case (Crisis Monitor
+pilot — see [`pilots/context-graph-decision.md`](../pilots/context-graph-decision.md))
+confirmed this empirically: for UI components and CSS tokens, the 2-hop graph reaches
+virtually the entire project (73–97% false positives) because connection density in a
+shared design system makes any node reach the whole project within 2 hops.
 
 For Next.js projects, the only operations with demonstrated value are:
 - `detect-changes` to identify test gaps in large PR reviews

--- a/docs/concepts/iterative-maintenance-governance.md
+++ b/docs/concepts/iterative-maintenance-governance.md
@@ -148,7 +148,7 @@ That sequence preserves clarity and keeps the experiment reversible.
 
 ## What recent real-world evidence changed
 
-The Crisis Monitor pilot did not turn AletheIA into an observability framework.
+The first validation case (Crisis Monitor — see [`pilots/pilot-crisis-monitor.md`](../pilots/pilot-crisis-monitor.md)) did not turn AletheIA into an observability framework.
 
 What it did was make one important point more concrete:
 

--- a/docs/concepts/operating-overlay.md
+++ b/docs/concepts/operating-overlay.md
@@ -50,8 +50,8 @@ The hard part is not the obvious cases — it's the ambiguous ones. These are th
 
 | Example | Layer | Why |
 |---|---|---|
-| `src/services/orders.ts` in Crisis Monitor | **product** | Code that implements the domain. AletheIA has no opinion on it. |
-| `ops/ai/constitution/mission.md` in Crisis Monitor | **overlay (local)** | Local instance of an overlay pattern, inside the consumer project. |
+| `src/services/orders.ts` in a consumer project | **product** | Code that implements the domain. AletheIA has no opinion on it. |
+| `ops/ai/constitution/mission.md` in a consumer project | **overlay (local)** | Local instance of an overlay pattern, inside the consumer project. |
 | `docs/contracts/delivery-output-contract.md` in AletheIA repo | **overlay (canonical)** | A normative spec for how AI-assisted deliveries must be shaped. |
 | Hermes session DB schema | **harness** | Runtime state — where the agent stored its session, not how the work was decided. |
 | Hermes logging plugin | **harness** | A vendor capability for the runtime, not a portable governance pattern. |
@@ -70,7 +70,7 @@ These are the calls that recur in PR review. Get them right and most ambiguity d
 
 2. **A `closeout-template.md` saved inside `~/.claude/`** — *looks like harness* (it's in the harness home directory). **Is overlay.** The location is incidental — the artifact governs how work is delivered, regardless of which agent ran. Move it to the canonical overlay (or the project's local overlay) and reference it from the harness.
 
-3. **A `crisis-monitor-runbook.md` describing how to deploy the Crisis Monitor app** — *looks like overlay* (it's a runbook). **Is product.** Operating the product ≠ operating the AI-assisted work. The deploy runbook is part of the consumer project's own docs, not its `ops/ai/` overlay.
+3. **A `deployment-runbook.md` describing how to deploy the consumer product** — *looks like overlay* (it's a runbook). **Is product.** Operating the product ≠ operating the AI-assisted work. The deploy runbook is part of the consumer project's own docs, not its `ops/ai/` overlay.
 
 4. **A `risk-inference-skill.md` invoked by Claude during planning** — *looks like harness* (skills feel like a Claude Code feature). **Is overlay.** The skill encodes how a decision is made; the harness merely executes it. Belongs in the canonical overlay; the harness shim points at it.
 

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -23,7 +23,7 @@ The public repository is organized around four blocks:
 
 3. **pilot materials**
    - why the framework emerged
-   - how it was extracted from Crisis Monitor
+   - how it was extracted from a first validation case (Crisis Monitor — see `pilots/`)
    - what was learned in the real test field
    - how pilot learnings return into framework evolution
    - how self-application, pilot conversion, and project extension stay connected
@@ -85,21 +85,19 @@ The roadmap and release gate are now read together through:
 
 ## Alpha 2 bridge and pilot grounding
 
-The Crisis Monitor pilot is the first concrete example of this bridge, and it now includes real-world validation beyond the first explicability slice.
+AletheIA's first validation case is the Crisis Monitor pilot — labeled field evidence preserved in `docs/pilots/`, not a canonical reference. See [ADR-006](../adr/ADR-006-domain-agnosticism.md) for the domain-agnosticism boundary.
 
 The key idea is simple:
 
-AletheIA should be reusable outside the original pilot while still preserving the lessons learned from that pilot.
+AletheIA should be reusable across consumer projects while still preserving the lessons surfaced by the first validation. That reuse depends on an explicit boundary between the framework core and each project's local extension layer.
 
-That reuse depends on an explicit boundary between the framework core and each project's local extension layer.
+At this point, Alpha 2 is organized around five explicit bridge artifacts:
 
-At this point, Alpha 2 is organized around five explicit bridge artifacts and is supported by stronger real-world validation from the Crisis Monitor pilot:
-
-- `docs/self-application.md`
-- `docs/pilot-crisis-monitor.md`
-- `docs/pilot-conversion.md`
-- `docs/project-extension-pattern.md`
-- `docs/migration-from-crisis-monitor.md`
+- `docs/concepts/self-application.md`
+- `docs/concepts/project-extension-pattern.md`
+- `docs/guides/pilot-conversion.md`
+- `docs/pilots/pilot-crisis-monitor.md` *(first concrete instance — labeled example, not canonical content)*
+- `docs/pilots/migration-from-crisis-monitor.md` *(first concrete instance of the migration boundary)*
 
 ---
 

--- a/docs/concepts/project-extension-pattern.md
+++ b/docs/concepts/project-extension-pattern.md
@@ -186,29 +186,19 @@ That distinction should remain reviewable.
 
 ---
 
-## Crisis Monitor example
+## Worked example pattern
 
-The Crisis Monitor work is a good example of a project extension.
+A consumer project will typically contain local patterns such as:
 
-It contains local patterns such as:
-
-- Cris-specific operating behavior
-- thread labels tied to crisis management work
-- ownership boundaries between Codex and Claude Code
+- product-specific operating behavior (assistant personas, internal labels)
+- ownership boundaries between different runtimes or agent roles
 - domain-specific routing, audit, and approval semantics
 
-Those details are useful and real.
-
-But AletheIA should not pretend they are universally required.
-
-Instead, the framework should extract only the reusable logic from them.
-
-For example:
-
-- decision explicability as a principle may generalize
-- one product's exact routing fields probably do not
+Those details are useful and real, but AletheIA does not pretend they are universally required. The framework extracts only the reusable logic from them. For example, decision explicability as a principle may generalize across projects; one product's exact routing fields probably do not.
 
 This is the discipline the extension pattern is meant to support.
+
+> **First validation case.** The Crisis Monitor pilot is the concrete first instance of this pattern. See [`pilots/pilot-crisis-monitor.md`](../pilots/pilot-crisis-monitor.md) — labeled example, not canonical content.
 
 ---
 
@@ -216,9 +206,9 @@ This is the discipline the extension pattern is meant to support.
 
 The project extension pattern connects directly to the other Alpha 2 artifacts.
 
-- `docs/pilot-crisis-monitor.md` shows a real project context
-- `docs/self-application.md` shows how the framework evolves itself
-- `docs/pilot-conversion.md` shows how pilot evidence becomes framework change
+- [`pilots/pilot-crisis-monitor.md`](../pilots/pilot-crisis-monitor.md) shows a real project context *(first validation case)*
+- [`concepts/self-application.md`](self-application.md) shows how the framework evolves itself
+- [`guides/pilot-conversion.md`](../guides/pilot-conversion.md) shows how pilot evidence becomes framework change
 
 The extension pattern adds the missing boundary:
 

--- a/docs/concepts/self-application.md
+++ b/docs/concepts/self-application.md
@@ -111,7 +111,7 @@ This is the practical bridge between:
 
 ## What recent real-world validation added
 
-The Crisis Monitor pilot made the self-application loop more concrete because it did not stop at an initial product proof.
+The first validation case — the Crisis Monitor pilot (see [`pilots/pilot-crisis-monitor.md`](../pilots/pilot-crisis-monitor.md)) — made the self-application loop more concrete because it did not stop at an initial product proof.
 
 The recent sequence moved through:
 
@@ -191,6 +191,6 @@ Together, they make the Alpha 2 loop concrete:
 
 See also:
 
-- `docs/pilot-crisis-monitor.md`
-- `docs/pilot-conversion.md`
-- `docs/project-extension-pattern.md`
+- [`pilots/pilot-crisis-monitor.md`](../pilots/pilot-crisis-monitor.md) *(first validation case — labeled example, not canonical content)*
+- [`guides/pilot-conversion.md`](../guides/pilot-conversion.md)
+- [`concepts/project-extension-pattern.md`](project-extension-pattern.md)

--- a/docs/contracts/consumer-project-overlay.md
+++ b/docs/contracts/consumer-project-overlay.md
@@ -56,8 +56,8 @@ Each subsection states: **purpose**, **minimum content**, **examples**, **what N
 - `stack.md` — primary languages, frameworks, infra; one line each.
 - `principles.md` — 5–10 non-negotiable principles; no platitudes.
 
-**Examples of good entries.**
-- mission: *"Crisis Monitor surfaces emerging operational incidents across our regions in under 5 minutes, for the incident-response team."*
+**Examples of good entries** *(drawn from the first validation case — see [`pilots/pilot-crisis-monitor.md`](../pilots/pilot-crisis-monitor.md))*:
+- mission: *"`<consumer-product>` surfaces emerging operational incidents across our regions in under 5 minutes, for the incident-response team."*
 - principle: *"Never silently drop an alert. If a sink fails, surface the failure as a higher-priority alert."*
 
 **What NOT to put.**
@@ -144,7 +144,7 @@ Each subsection states: **purpose**, **minimum content**, **examples**, **what N
 **Minimum content.** One folder per skill, each with a `SKILL.md` describing trigger, inputs, outputs, and steps.
 
 **Examples.**
-- `incident-triage/SKILL.md` — how to triage a Crisis Monitor incident.
+- `incident-triage/SKILL.md` — how to triage an operational incident in the consumer product.
 - `migration-checklist/SKILL.md` — pre-deploy checklist for schema migrations.
 
 **What NOT to put.**

--- a/docs/contracts/runtime-adapter-contract.md
+++ b/docs/contracts/runtime-adapter-contract.md
@@ -151,7 +151,7 @@ What matters is preserving the meaning of the fields, not forcing one storage fo
 
 ```txt
 slice_id: example-slice-001
-project_id: crisis-monitor
+project_id: example-consumer
 round_id: 2
 task_shape: bounded-execution
 cold_boot_budget: minimal

--- a/docs/contracts/slice-telemetry-model.md
+++ b/docs/contracts/slice-telemetry-model.md
@@ -114,8 +114,8 @@ A small vocabulary is enough for the first version.
 ## Minimal example
 
 ```txt
-slice_id: cris-routing-approval-round-2
-project_id: crisis-monitor
+slice_id: routing-approval-round-2
+project_id: example-consumer
 round_id: 2
 task_shape: bounded-execution
 cold_boot_budget: minimal

--- a/docs/guides/pilot-conversion.md
+++ b/docs/guides/pilot-conversion.md
@@ -178,26 +178,26 @@ Alpha 2 is going well when:
 
 ---
 
-## Crisis Monitor example
+## Worked example: first validation case
 
-The Crisis Monitor pilot now provides a stronger conversion example than an early explicability slice alone.
+The first validation case (Crisis Monitor — see [`pilots/pilot-crisis-monitor.md`](../pilots/pilot-crisis-monitor.md) for the full record) provides a stronger conversion example than an early explicability slice alone.
 
-The recent chain was:
+The chain a pilot conversion typically follows, instantiated against the first case:
 
-1. real authenticated smoke proved the lane under real conditions
-2. explainability contract hardening made the lane more coherent
-3. a health metric and alert exposed explainability degradation risk
-4. an investigable decision feed made the gap reviewable by occurrence
-5. a lane scorecard summarized the operational picture
-6. the framework absorbed the reusable part as stronger Alpha 2 and iterative-maintenance guidance
+1. real authenticated smoke proves the lane under real conditions
+2. explainability contract hardening makes the lane more coherent
+3. a health metric and alert exposes degradation risk
+4. an investigable decision feed makes the gap reviewable by occurrence
+5. a lane scorecard summarizes the operational picture
+6. the framework absorbs the reusable part as stronger Alpha 2 and iterative-maintenance guidance
 
-What remained product-specific:
+What remained product-specific (and stayed in the consumer project):
 
-- Cris naming
+- product-specific naming
 - exact event names
 - the local observability route shape
 
-What became reusable:
+What became reusable (and was promoted into AletheIA):
 
 - prove the lane before broadening claims
 - harden the contract before widening the surface

--- a/docs/guides/setting-up-harnesses.md
+++ b/docs/guides/setting-up-harnesses.md
@@ -74,8 +74,8 @@ Substitute with `sed` (one pass per variable). On macOS use `sed -i ''`; on GNU/
 ```bash
 # macOS
 sed -i '' \
-  -e 's|{{PROJECT_NAME}}|Crisis Monitor|g' \
-  -e 's|{{PROJECT_ONE_LINER}}|Crisis Monitor surfaces emerging operational incidents in under 5 minutes|g' \
+  -e 's|{{PROJECT_NAME}}|Acme Operations|g' \
+  -e 's|{{PROJECT_ONE_LINER}}|Acme Operations surfaces emerging operational incidents in under 5 minutes|g' \
   -e 's|{{PRIMARY_STACK}}|TypeScript, Node 20, Postgres|g' \
   -e 's|{{INSTALL_CMD}}|pnpm install|g' \
   -e 's|{{TEST_CMD}}|pnpm test|g' \

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,8 +59,10 @@ Reading map organized by intent. Each entry links to the most useful starting po
 
 ## I want to see real adoption evidence
 
-1. [Crisis Monitor pilot](pilots/pilot-crisis-monitor.md) — first real project adoption
-2. [Migration from Crisis Monitor](pilots/migration-from-crisis-monitor.md) — how AletheIA became standalone
+> AletheIA is domain-agnostic (see [ADR-006](adr/ADR-006-domain-agnosticism.md)). The pilots below are labeled field evidence — first validation case, not canonical content.
+
+1. [Crisis Monitor pilot](pilots/pilot-crisis-monitor.md) — first validation case
+2. [Migration from Crisis Monitor](pilots/migration-from-crisis-monitor.md) — how AletheIA became standalone after the first case
 3. [Context graph decision](pilots/context-graph-decision.md) — decision record with real test data
 4. [Hermes closeouts →](pilots/closeouts/) — operation records from Hermes pre-pilot
 5. [All pilots →](pilots/README.md)

--- a/docs/pilots/README.md
+++ b/docs/pilots/README.md
@@ -2,6 +2,8 @@
 
 Real adoption evidence, operation records, and case reports. These answer "what actually happened when X was tried?"
 
+> **Pilots are labeled field evidence — not canonical content.** AletheIA is domain-agnostic (see [ADR-006](../adr/ADR-006-domain-agnosticism.md)). The pilots below were the first concrete instances of the patterns the framework codifies; they document *what happened*, not *what must happen*. Crisis Monitor is the first validation case, not the canonical reference — other consumer projects across other domains are expected.
+
 Operation closeouts (session/task records from Hermes and other runtimes) live in [`closeouts/`](closeouts/).
 
 **What NOT to put here:** prescriptive guides on how to run a pilot (those go in `guides/`). A pilot document reports what happened; it does not instruct.


### PR DESCRIPTION
## Summary

Cross-repo plan Epic 2 — implements [ADR-006 (domain agnosticism)](https://github.com/nevitonsantana/AletheIA/blob/main/docs/adr/ADR-006-domain-agnosticism.md) by despoluindo Crisis Monitor references from canonical content (\`docs/concepts/\`, \`docs/contracts/\`, \`docs/guides/\`, \`README.md\`, \`docs/index.md\`).

Crisis Monitor is now consistently positioned as **first validation case** with explicit links to \`docs/pilots/\`, never as implicit canon.

## What changed

**Type A — narrative dependency refactored (8 files):**
- \`docs/concepts/overview.md\`, \`operating-overlay.md\`, \`self-application.md\`, \`project-extension-pattern.md\`, \`iterative-maintenance-governance.md\`, \`ai-agent-security-prompt-injection.md\`
- \`docs/guides/pilot-conversion.md\`
- \`README.md\` (root) — new "First validation case" subsection citing ADR-006

**Type B — placeholder/data generalized (6 files):**
- \`docs/contracts/consumer-project-overlay.md\`, \`runtime-adapter-contract.md\`, \`slice-telemetry-model.md\`
- \`docs/guides/setting-up-harnesses.md\` (\`sed\` template: Crisis Monitor → Acme Operations)
- \`docs/concepts/context-graph-integration.md\` (F1=0.041 data preserved with explicit source label, per user gate decision 2026-05-21)
- \`docs/index.md\` (pilots section gains explicit "first validation case" framing)

**New artifacts:**
- \`docs/_meta/crisis-monitor-references.md\` — full inventory with A/B/C classification and action per file
- \`docs/pilots/README.md\` — top-of-file callout: "Pilots are labeled field evidence — not canonical content"

## Context

Companion PR in Adaptive Skills: [adaptive-skills#docs/despoluicao-crisis-monitor](https://github.com/nevitonsantana/adaptive-skills/tree/docs/despoluicao-crisis-monitor). Order-independent.

## Decisions that extrapolated the plan (justified)

1. **Reused \`docs/pilots/\`, did not create \`docs/examples/\`.** Plan offered both options; reused existing structure per user approval.
2. **Crisis Monitor name still appears in canonical docs, labeled.** The acceptance criterion "appears exclusively in pilots/examples" was interpreted functionally: narrative status is in pilots; the name remains in canonical as labeled first-validation reference + link. This preserves transparency per ADR-006. Logged in inventory with Status: ⚠️ and justification.
3. **\`engine/\`, \`policies/\`, \`schemas/\`, \`scripts/\`, \`tests/\` not touched** per plan §4.2.

## Test plan

- [ ] Read \`docs/_meta/crisis-monitor-references.md\` — does the classification A/B/C match the actual changes?
- [ ] Read 2-3 Type-A refactored files cold — does Crisis Monitor read as labeled example, not as implicit canon?
- [ ] Confirm \`docs/pilots/README.md\` callout makes the framing explicit at entry.
- [ ] Confirm CI passes (docs-only change; should be uncontroversial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)