### PR TITLE
docs(guides): Epic 7 pilot brief for Crisis Monitor team

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -28,3 +28,4 @@ If you need conceptual background, see [`concepts/`](../concepts/README.md). If 
 | [pilot-conversion.md](pilot-conversion.md) | How pilot learnings become framework improvements |
 | [github-project-operations.md](github-project-operations.md) | Using GitHub Projects for repo coordination |
 | [setting-up-harnesses.md](setting-up-harnesses.md) | Wiring a consumer project to Claude Code via the shim pack |
+| [pilot-crisis-monitor-overlay-handoff.md](pilot-crisis-monitor-overlay-handoff.md) | Brief for the Crisis Monitor team — Epic 7 overlay-adoption pilot |

--- a/docs/guides/pilot-crisis-monitor-overlay-handoff.md
+++ b/docs/guides/pilot-crisis-monitor-overlay-handoff.md
@@ -1,0 +1,154 @@
+# Pilot handoff — Crisis Monitor overlay adoption
+
+> **Audience:** Crisis Monitor team. This is the brief for adopting the AletheIA operating overlay in the Crisis Monitor repo and reporting back. It is a *prescriptive guide* — what to do, in what order, with what gates. The *result* will be recorded separately in [`docs/pilots/pilot-crisis-monitor-overlay-adoption.md`](../pilots/) (created by the team or by AletheIA maintainers once the pilot reports back).
+
+## Why this pilot
+
+Closes Epic 7 of the AletheIA documentation-improvement plan. Epics 0–6 produced the artifacts being validated:
+
+- The boundary decision: [ADR-004](../adr/ADR-004-aletheia-as-operating-overlay.md).
+- The concept: [`concepts/operating-overlay.md`](../concepts/operating-overlay.md).
+- The contract: [`contracts/consumer-project-overlay.md`](../contracts/consumer-project-overlay.md).
+- The shim pack: [`starter-pack/harness-shims/claude/`](../../starter-pack/harness-shims/claude/).
+- The preset bundle: [`starter-pack/presets/minimal-overlay/`](../../starter-pack/presets/minimal-overlay/).
+- The reference example: [`examples/consumer-overlay-minimal/`](../../examples/consumer-overlay-minimal/).
+
+This pilot is the first real-world validation. **Frictions are the expected output, not failures** — the goal is to falsify hypotheses (especially H2 from the plan: "the taxonomy covers ≥90% of docs without forcing").
+
+## What to do (six steps)
+
+### 1. Adopt the preset
+
+Copy the bundle into the Crisis Monitor repo root and follow the README:
+
+```bash
+cp -R /path/to/aletheia/starter-pack/presets/minimal-overlay/. /path/to/crisis-monitor/
+cd /path/to/crisis-monitor
+rm README.md manifest.yaml   # source artifacts, not runtime
+```
+
+Use [`starter-pack/presets/minimal-overlay/README.md`](../../starter-pack/presets/minimal-overlay/README.md) for the substitution steps and variable list.
+
+### 2. Fill the constitution
+
+Replace `ops/ai/constitution/README.md` with four files:
+
+- `mission.md`
+- `scope.md`
+- `stack.md`
+- `principles.md`
+
+Crisis Monitor already has implicit answers to all four in scattered places (wiki, Slack pins, tribal knowledge). The pilot value is partially in *forcing those answers into one place*. If writing one of them surfaces a question the team has been avoiding, **stop and answer it** — that's the constitution doing its job (see [`learnings/2026-05-20-overlay-adoption-cost.md`](../../examples/consumer-overlay-minimal/ops/ai/learnings/2026-05-20-overlay-adoption-cost.md) for the pattern).
+
+### 3. Run the conformance test
+
+From [contract §8](../contracts/consumer-project-overlay.md#8-conformance-test-minimum). Open a fresh Claude Code session in the Crisis Monitor repo root and check:
+
+1. The agent locates `AGENTS.md` without being told.
+2. The agent locates `ops/ai/constitution/` from `AGENTS.md` in ≤2 hops.
+3. The agent can describe mission, scope, and stack from the constitution in its first response.
+4. The agent finds the most recent handoff (or notes none exists yet) and proceeds without asking for context that should be in the constitution.
+
+Any failure is data — record it in the log (step 6).
+
+### 4. Test at least one handoff
+
+Per the contract: "MUST contain at least one handoff after the first non-trivial session." Pick one real piece of work in Crisis Monitor — a bug fix, a small feature, a refactor — and do it across two sessions or two agents, with a handoff in between. The point is to stress the handoff structure with real content, not to invent ceremony.
+
+### 5. Operate normally for ≥3 sessions
+
+Resist the urge to over-document. The pilot tests whether the overlay *helps under normal load*. After three sessions, you should be able to answer:
+
+- Did the constitution change what got built? How?
+- Did handoffs reduce session-warmup turns? (Baseline pre-overlay: 5–10 turns. Hypothesis: ≤2.)
+- Did any folder feel unused or in the way?
+
+### 6. Write the friction log
+
+Create `docs/pilots/pilot-crisis-monitor-overlay-adoption.md` (in the AletheIA repo, not the Crisis Monitor repo) with the structure below. Don't polish — raw observations are more useful than tidy ones.
+
+## Friction log template
+
+Copy this skeleton into `docs/pilots/pilot-crisis-monitor-overlay-adoption.md` when ready to write.
+
+```markdown
+# Pilot — Crisis Monitor overlay adoption
+
+**Date range:** YYYY-MM-DD to YYYY-MM-DD
+**Preset version:** minimal-overlay v1.0.0
+**Sessions covered:** N
+**Adopted by:** <names>
+
+## What encaixou direto
+
+What worked without adaptation. Be specific — name the folder, file, or rule.
+
+- Example: "`AGENTS.md` template was usable with only variable substitution; no structural edits needed."
+
+## What precisou de adaptação local
+
+What needed local change, and why. The "why" matters more than the "what" — it tells us whether the change generalizes.
+
+- Example: "`.claude/rules/tests.md` mentions hitting real Postgres in integration tests; our CI uses testcontainers. Adapted locally. *Generalizable?* No — runner choice is project-specific."
+
+## What ficou ambíguo
+
+Where the contract or guide left a real question unanswered. These are the most valuable entries.
+
+- Example: "Constitution `scope.md` — unclear whether to list out-of-scope items we *might* do in the future versus only those we've explicitly rejected. Defaulted to the latter."
+
+## Métricas observadas
+
+| Signal | Pre-overlay baseline | Post-overlay observation |
+|---|---|---|
+| Session warmup (turns until productive work) | 5–10 | ? |
+| "Where does X live?" questions per session | N | ? |
+| Time to write the first closeout | — | ? |
+
+Add other signals the team actually noticed, even if not on this list.
+
+## Promotion candidates
+
+Frictions or patterns that look like they would appear in *other* consumer projects, not just Crisis Monitor. These are candidates for promotion to canonical AletheIA — but per the [promotion gate](../concepts/operating-overlay.md#antifragile-patterns-how-to-avoid-drift), they wait for a second consumer project to confirm.
+
+- Example: "If a project uses pnpm workspaces, the `INSTALL_CMD` variable doesn't capture per-workspace install nuance. Worth a learning if a second monorepo hits this."
+
+## Verdict on the framework hypotheses
+
+The plan defined four falsifiable hypotheses. Comment on each:
+
+- **H1** — Three-layer boundary sustainable: *did anything force-fit into two layers?*
+- **H2** — Taxonomy covers ≥90%: *did `ops/ai/` need a folder the contract doesn't define?*
+- **H3** — `AGENTS.md` + `CLAUDE.md` as dispatchers work: *did the harness ignore them or demand duplication?*
+- **H4** — Bootstrap stays in AletheIA: *did this adoption produce diffs <20% from the canonical preset?*
+```
+
+## Escalation rules
+
+While the pilot is running, two things are worth interrupting for:
+
+1. **A friction that contradicts the contract.** If the contract says X and the project genuinely needs not-X, stop and write it up immediately — don't wait for the closeout. File an issue against AletheIA tagged `epic-7-pilot`.
+2. **A security or correctness gap.** The preset doesn't enforce secrets handling beyond a rule comment. If real PII or credentials end up in `ops/ai/`, treat it as a P1 — fix in Crisis Monitor first, then surface the gap to AletheIA.
+
+Everything else can wait for the friction log.
+
+## What not to do
+
+- **Don't backfill history.** No fake handoffs, closeouts, or learnings dated before the adoption day. The overlay starts on adoption date (see [contract §6](../contracts/consumer-project-overlay.md#6-adopting-in-a-legacy-project-minimum-viable-path)).
+- **Don't refactor the constitution mid-pilot.** Treat the first version as a baseline; revisions are evidence, not noise.
+- **Don't push local Crisis Monitor adaptations upstream to AletheIA.** Promotion waits for a second consumer project (per the promotion gate).
+- **Don't aim for perfection.** A 70%-done friction log written now is worth more than a 100% log written never.
+
+## Time budget
+
+| Phase | Estimate |
+|---|---|
+| Adopt preset + fill constitution | ~2 hours (one focused sitting) |
+| 3 sessions of normal operation | ~2 weeks of regular work |
+| Write the friction log | ~1 hour |
+
+The pilot can run alongside other Crisis Monitor work — it does not need a dedicated sprint.
+
+## Reporting back
+
+The friction log lives at `docs/pilots/pilot-crisis-monitor-overlay-adoption.md` in the AletheIA repo. Once the log is committed, Epic 7 closes and the structural-improvement plan is complete. Promotion candidates from the log become input for subsequent canonical-AletheIA changes (under their own slices, not retroactive edits to the plan).

--- a/docs/pilots/README.md
+++ b/docs/pilots/README.md
@@ -20,6 +20,14 @@ Operation closeouts (session/task records from Hermes and other runtimes) live i
 | [report-core-operating-path-friction-test.md](report-core-operating-path-friction-test.md) | Friction test: is `core-operating-path.md` sufficient for first use? |
 | [dev-handoff-2026-05.md](dev-handoff-2026-05.md) | Cycle record — May 2026 |
 
+## In flight
+
+| Pilot | Status | Brief |
+|---|---|---|
+| Crisis Monitor overlay adoption (Epic 7) | Handed off to Crisis Monitor team; friction log pending | [`guides/pilot-crisis-monitor-overlay-handoff.md`](../guides/pilot-crisis-monitor-overlay-handoff.md) |
+
+The friction log will land here as `pilot-crisis-monitor-overlay-adoption.md` once the pilot reports back. Until then, see the brief in `guides/` for the test plan and log template.
+
 ## Closeouts
 
 [`closeouts/`](closeouts/) contains individual operation records from the Hermes pre-pilot and other bounded execution sessions. Each file follows the closeout template.


### PR DESCRIPTION
## Summary

- New brief at [docs/guides/pilot-crisis-monitor-overlay-handoff.md](docs/guides/pilot-crisis-monitor-overlay-handoff.md) — six steps for the Crisis Monitor team to run the overlay-adoption pilot and report back. Includes the conformance test, escalation rules, time budget, anti-patterns, and a copy-paste friction-log skeleton with the four plan-specified sections (encaixou direto / adaptação local / ambíguo / métricas) and a per-hypothesis verdict prompt for H1–H4.
- [docs/guides/README.md](docs/guides/README.md) indexes the brief.
- [docs/pilots/README.md](docs/pilots/README.md) gets a new "In flight" section pointing back to the brief; the friction log itself will land as `docs/pilots/pilot-crisis-monitor-overlay-adoption.md` once the team reports back.

## Plan alignment

This is the documented handoff for Épico 7 of `aletheia-plano-melhoria-estrutura.md`. Pilot execution is deferred to the Crisis Monitor team alongside their existing work, not run by AletheIA maintainers directly. Epic 7 closes when the friction log is committed.

- ✅ Brief is *prescriptive* — placed in `guides/` per `pilots/README.md` convention
- ✅ Friction log structure matches plan §4-Épico-7 ("o que encaixou direto / adaptação local / ambíguo / métricas observadas")
- ✅ Promotion-candidate gating preserved (per [operating-overlay §Antifragile patterns](docs/concepts/operating-overlay.md#antifragile-patterns-how-to-avoid-drift))
- ✅ Per-hypothesis verdict prompt for H1–H4

## Test plan

- [ ] Walk the brief end-to-end as if you were a Crisis Monitor engineer; confirm steps are actionable without further context
- [ ] Verify links resolve (preset README, contract §8, operating-overlay promotion gate, examples)
- [ ] Verify governance check passes (green locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)