### PR TITLE
docs(pilots): separate cycle records from pilot reports in index

### DIFF
--- a/docs/pilots/README.md
+++ b/docs/pilots/README.md
@@ -18,7 +18,14 @@ Operation closeouts (session/task records from Hermes and other runtimes) live i
 | [resource-aware-crisis-monitor-reference.md](resource-aware-crisis-monitor-reference.md) | Bounded 1.2-track reference using Crisis Monitor evidence |
 | [resource-aware-operations-review.md](resource-aware-operations-review.md) | Consolidation of what the 1.2 track proves |
 | [report-core-operating-path-friction-test.md](report-core-operating-path-friction-test.md) | Friction test: is `core-operating-path.md` sufficient for first use? |
-| [dev-handoff-2026-05.md](dev-handoff-2026-05.md) | Cycle record — May 2026 |
+
+## Cycle records
+
+Periodic development logs — what shipped in a given cycle, open backlog references in upstream repos, parallel workstreams. Distinct from pilot reports (which test a hypothesis) and closeouts (which conclude a bounded operation).
+
+| Document | What it records |
+|---|---|
+| [dev-handoff-2026-05.md](dev-handoff-2026-05.md) | Cycle record — May 2026 (delivered: AletheIA PRs #120, #123 / Adaptive Skills PRs #21, #23; backlog tracked in upstream issues) |
 
 ## In flight
 


### PR DESCRIPTION
## Summary

- `dev-handoff-2026-05.md` was listed in `docs/pilots/README.md` alongside actual pilot reports (`pilot-crisis-monitor.md`, `report-core-operating-path-friction-test.md`, etc.), but it's a periodic **cycle record** — not a hypothesis test, not an operation closeout.
- Adds a dedicated **Cycle records** section to the index with an explicit definition distinguishing it from pilot reports (test a hypothesis) and closeouts (conclude a bounded operation).
- No file moves (would break inbound links); no edits to the handoff itself.

## Context

Surfaced during a lightweight pilot of the Adaptive Skills Capability Graph as advisory metadata. Disposition question: "does this handoff need a closeout after Epic 7 (PR #152)?" Cross-check against PR #152 showed it touched a different scope (Crisis Monitor overlay handoff) — no items in the May cycle record were closed by it. The real issue was index categorization, not lifecycle.

The Capability Graph's `traceability-check` module was what prompted the PR-#152 cross-check before assuming continuation — that step prevented an incorrect move into `closeouts/`.

## Test plan

- [ ] `pnpm check:governance` passes (verified locally — green)
- [ ] Links in the new section resolve
- [ ] No other docs reference the old single-list position of `dev-handoff-2026-05.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)