### PR TITLE
feat(engine): introduce Ajv schema validation at contracts boundary

### DIFF
--- a/engine/index.ts
+++ b/engine/index.ts
@@ -8,3 +8,4 @@ export * from "./learnings";
 export * from "./policy";
 export * from "./runtime";
 export * from "./types";
+export * from "./validation";

--- a/engine/validation.ts
+++ b/engine/validation.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+import Ajv2020, { type ErrorObject } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+
+export class SchemaValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly schemaId: string,
+    public readonly errors: ErrorObject[],
+  ) {
+    super(message);
+    this.name = "SchemaValidationError";
+  }
+}
+
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+addFormats(ajv);
+
+const validatorCache = new Map<string, ReturnType<typeof ajv.compile>>();
+
+export function validateAgainstSchema<T>(data: unknown, schemaPath: string): T {
+  let validate = validatorCache.get(schemaPath);
+  let schemaId = schemaPath;
+  if (!validate) {
+    const schema = JSON.parse(fs.readFileSync(schemaPath, "utf-8")) as object;
+    schemaId = (schema as { $id?: string }).$id ?? schemaPath;
+    validate = ajv.compile(schema);
+    validatorCache.set(schemaPath, validate);
+  } else {
+    schemaId = (validate.schema as { $id?: string })?.$id ?? schemaPath;
+  }
+
+  if (!validate(data)) {
+    const errors = validate.errors ?? [];
+    const summary = errors
+      .slice(0, 5)
+      .map((e) => `${e.instancePath || "(root)"} ${e.message ?? "invalid"}`)
+      .join("; ");
+    throw new SchemaValidationError(
+      `Schema validation failed for ${schemaId}: ${summary}`,
+      schemaId,
+      errors,
+    );
+  }
+
+  return data as T;
+}

--- a/package.json
+++ b/package.json
@@ -31,5 +31,9 @@
     "@types/node": "^20.14.0",
     "tsx": "^4.19.0",
     "typescript": "^5.5.0"
+  },
+  "dependencies": {
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 importers:
 
   .:
+    dependencies:
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
     devDependencies:
       '@types/node':
         specifier: ^20.14.0
@@ -179,10 +186,27 @@ packages:
   '@types/node@20.19.41':
     resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -191,6 +215,13 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -292,6 +323,17 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -321,12 +363,20 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.2: {}
+
   fsevents@2.3.3:
     optional: true
 
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  json-schema-traverse@1.0.0: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
 

--- a/tests/contracts/test-contracts.ts
+++ b/tests/contracts/test-contracts.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { validateAgainstSchema, SchemaValidationError } from "../../engine";
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -11,27 +12,53 @@ function readJsonFile<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, "utf-8")) as T;
 }
 
+const schemasDir = path.resolve(process.cwd(), "schemas");
+
+const fixtures = [
+  {
+    name: "Task Brief",
+    fixture: "examples/hello-world/task-brief.json",
+    schema: "aletheia-task-brief.schema.json",
+  },
+  {
+    name: "Context Pack",
+    fixture: "examples/hello-world/context-pack.json",
+    schema: "aletheia-context-pack.schema.json",
+  },
+  {
+    name: "Execution Scope",
+    fixture: "examples/governance/execution-scope.json",
+    schema: "aletheia-execution-scope.schema.json",
+  },
+  {
+    name: "Learning Record",
+    fixture: "examples/learning-from-failed-validation/learning-record.json",
+    schema: "aletheia-learning-record.schema.json",
+  },
+];
+
+for (const { name, fixture, schema } of fixtures) {
+  const data = readJsonFile<unknown>(path.resolve(process.cwd(), fixture));
+  validateAgainstSchema(data, path.join(schemasDir, schema));
+  console.log(`PASS: ${name} validates against ${schema}`);
+}
+
 const taskBrief = readJsonFile<Record<string, unknown>>(
   path.resolve(process.cwd(), "examples/hello-world/task-brief.json"),
 );
-const contextPack = readJsonFile<Record<string, unknown>>(
-  path.resolve(process.cwd(), "examples/hello-world/context-pack.json"),
+const brokenBrief: Record<string, unknown> = { ...taskBrief };
+delete brokenBrief.id;
+let caught: unknown;
+try {
+  validateAgainstSchema(brokenBrief, path.join(schemasDir, "aletheia-task-brief.schema.json"));
+} catch (error) {
+  caught = error;
+}
+assert(caught !== undefined, "Invalid Task Brief must throw.");
+assert(
+  caught instanceof Error && caught.name === "SchemaValidationError",
+  `Expected SchemaValidationError, got ${caught instanceof Error ? caught.name : typeof caught}: ${caught instanceof Error ? caught.message : String(caught)}`,
 );
-const executionScope = readJsonFile<Record<string, unknown>>(
-  path.resolve(process.cwd(), "examples/governance/execution-scope.json"),
-);
-const learningRecord = readJsonFile<Record<string, unknown>>(
-  path.resolve(process.cwd(), "examples/learning-from-failed-validation/learning-record.json"),
-);
-
-assert(typeof taskBrief.id === "string", "Task Brief must expose an id.");
-assert(typeof taskBrief.title === "string", "Task Brief must expose a title.");
-assert(typeof contextPack.summary === "string", "Context Pack must expose a summary.");
-assert(Array.isArray(contextPack.sources), "Context Pack must expose sources.");
-assert(typeof executionScope.id === "string", "Execution Scope must expose an id.");
-assert(Array.isArray(executionScope.allowed_files), "Execution Scope must expose allowed_files.");
-assert(Array.isArray(executionScope.forbidden_files), "Execution Scope must expose forbidden_files.");
-assert(typeof learningRecord.learning_type === "string", "Learning Record must expose a learning_type.");
-assert(typeof learningRecord.summary === "string", "Learning Record must expose a summary.");
+console.log("PASS: invalid Task Brief throws SchemaValidationError");
 
 console.log("AletheIA contract tests passed.");


### PR DESCRIPTION
## Summary

Adds runtime JSON Schema validation via **Ajv (Draft 2020-12)** at the contracts test boundary — replaces the hand-written shallow assertions in `tests/contracts/test-contracts.ts` with real schema-driven validation against the four existing schema/fixture pairs.

This is the **first concrete consumer of Ajv** on the path toward #125.

## Why this scope, not #125's full scope

Issue #125 targets validating *governance packs* at the `engine/` load path. Ground-truth check during planning:

- `engine/governance.ts` consumes `GovernancePack` as a typed object — there is no JSON load path inside `engine/` today; 4+ call sites in `tests/` and `examples/` do `JSON.parse(...) as GovernancePack`.
- **No `schemas/aletheia-governance-pack.schema.json` exists.** Validating a governance pack requires authoring that schema first.

Rather than bundle schema authoring + Ajv introduction + loader API into one PR, this PR ships Ajv with a proven first consumer and leaves the governance-pack work as a clean follow-up issue.

## Planning decisions (from Capability Graph pilot)

| Decision | Resolution |
|---|---|
| Where to validate | `tests/contracts/test-contracts.ts` — closest to existing schemas, zero engine runtime impact, immediate value |
| What schema first | All four schemas already loaded in this test (`task-brief`, `context-pack`, `execution-scope`, `learning-record`) |
| Fail vs warn | **Fail-fast** in the contracts test — it's a test suite; warnings would be noise |

## Changes

- **`engine/validation.ts`** (new) — `Ajv2020` + `ajv-formats`, cached compile per schema path, typed `SchemaValidationError` carrying `schemaId` and raw `errors[]`
- **`engine/index.ts`** — re-exports the validation surface
- **`tests/contracts/test-contracts.ts`** — validates the 4 fixtures against their schemas; new negative test asserts an invalid Task Brief throws `SchemaValidationError`
- **`package.json` / `pnpm-lock.yaml`** — adds `ajv ^8.20`, `ajv-formats ^3.0` as runtime dependencies

## Follow-up (not in this PR)

1. Author `schemas/aletheia-governance-pack.schema.json`
2. Introduce `loadGovernancePack(path): GovernancePack` in `engine/` using `validateAgainstSchema`
3. Migrate the 4+ unsafe `JSON.parse(...) as GovernancePack` call sites in `tests/` and `examples/`

That sequence completes #125.

## Test plan

- [x] `pnpm test:contracts` — 4 fixtures validate + invalid Task Brief throws
- [x] `pnpm test:all` — full suite green locally
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm check:governance` — green

Refs #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)