### PR TITLE
chore: add .gitignore and untrack node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+coverage/
+.env*
+*.tsbuildinfo


### PR DESCRIPTION
## Summary
- Add root `.gitignore` covering `node_modules/`, `dist/`, `*.log`, `.DS_Store`, `coverage/`, `.env*`, `*.tsbuildinfo`.
- Prevents recurrence of the incident in #154 where pnpm-generated files were swept into a commit by `git add -A` and required a force-push cleanup.
- `node_modules` was already untracked on disk (prior cleanup), so no `git rm --cached` was needed — this PR just adds the ignore rules so the directory stops showing as untracked.

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds locally
- [x] `pnpm test:all` passes (contracts, goldens, e2e, learnings)
- [ ] CI Quality Gate passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)