### PR TITLE
chore: add .gitignore to prevent dependency files from being committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+coverage/
+.env*
+*.tsbuildinfo


### PR DESCRIPTION
## Summary

Adds a `.gitignore` covering `node_modules/`, `dist/`, logs, `.DS_Store`, `coverage/`, env files, and `*.tsbuildinfo`.

## Why

Without a `.gitignore`, `pnpm install` / `pnpm add` leaves the working tree with thousands of untracked files. `git add -A` then risks committing them. PR #154 required a manual cleanup after pnpm-generated files were accidentally staged.

**Scope note:** `node_modules/` was not tracked in `HEAD` — no `git rm --cached` needed. This PR is purely preventive.

## Test plan

- [x] `pnpm test:all` green locally
- [ ] CI Quality Gate green
- [ ] `pnpm install --frozen-lockfile` unaffected (no change to lockfile or package.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)