### PR TITLE
docs(getting-started): four-doc adoption entry point (Epic 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,18 @@ AletheIA decides the flow. Skills shape capability. Runtimes execute. Tools info
 
 ## Where to start
 
-### Fastest understanding path
+### New to AletheIA? Start here
 
-1. `docs/getting-started.md`
+Four documents for adopters with no prior context:
+
+1. [`docs/getting-started/overview.md`](docs/getting-started/overview.md) — what AletheIA is, who it's for, when to use it
+2. [`docs/getting-started/installation-guide.md`](docs/getting-started/installation-guide.md) — step-by-step install via APM
+3. [`docs/getting-started/catalog.md`](docs/getting-started/catalog.md) — what the overlay provides and how to activate each element
+4. [`docs/getting-started/faq.md`](docs/getting-started/faq.md) — common questions about setup, security, and teamwork
+
+### Fastest understanding path (deep dive)
+
+1. `docs/getting-started/overview.md`
 2. `docs/core-operating-path.md`
 3. `docs/00-overview.md`
 4. `docs/governance.md`

--- a/docs/getting-started/catalog.md
+++ b/docs/getting-started/catalog.md
@@ -1,0 +1,183 @@
+# AletheIA — Capability Catalog
+
+This catalog describes what the AletheIA operating overlay provides, how to activate each element, and recommended flows for common adoption scenarios.
+
+For installation, see [`installation-guide.md`](installation-guide.md). For the normative contract these elements satisfy, see [`docs/contracts/consumer-project-overlay.md`](../contracts/consumer-project-overlay.md).
+
+---
+
+## What the overlay provides
+
+After installation, your project has two kinds of overlay elements:
+
+1. **Entry points** — files that agents read on startup to understand scope and rules.
+2. **Working folders** — directories where operating artifacts accumulate as work happens.
+
+### Entry points
+
+| File | Conformance | What it does |
+|---|---|---|
+| `AGENTS.md` | MUST | Cross-agent dispatcher. The first file any conformant agent reads. Points to the overlay location, declares which harnesses are in use, and sets the top-level reading order. |
+| `CLAUDE.md` | MUST (if using Claude Code) | Claude Code–specific shim. Keeps harness-specific config out of the portable overlay. |
+| `.claude/settings.json` | MUST (if using Claude Code) | Claude Code runtime configuration: permissions, tool allowlists, model selection. |
+| `.claude/rules/*.md` | SHOULD | Path-scoped rules that apply per directory. `src.md` for product code, `tests.md` for tests, `ops-ai.md` for the overlay folder. |
+| `ops/ai/constitution/` | MUST | The project's anchor. Mission, scope, stack, and non-negotiable principles. Agents read this before acting. |
+
+### Working folders
+
+| Folder | Conformance | What accumulates here |
+|---|---|---|
+| `ops/ai/handoffs/` | MUST | Session and boundary transitions. One file per handoff, named `YYYY-MM-DD-<slug>.md`. |
+| `ops/ai/reports/` | MUST | Closeouts and progress reports. One file per work slice or sprint, named `YYYY-MM-DD-<slug>-closeout.md`. |
+| `ops/ai/policies/` | SHOULD | Project-local constraints beyond canonical AletheIA (PR conventions, branching rules, security gates). |
+| `ops/ai/schemas/` | MAY | Project-specific data structures used by overlay operations. |
+| `ops/ai/skills/` | MAY | Reusable operating procedures local to this project. Not the same as Adaptive Skills — these are project-specific operating recipes. |
+| `ops/ai/learnings/` | SHOULD | Durable lessons extracted from real work. One file per learning, named `YYYY-MM-DD-<slug>.md`. |
+
+---
+
+## How to activate each element
+
+### Constitution
+
+The constitution is passive — agents read it automatically if `AGENTS.md` is correctly configured. Your job is to keep it current.
+
+- Replace `ops/ai/constitution/README.md` with four files: `mission.md`, `scope.md`, `stack.md`, `principles.md`.
+- Start minimal. One paragraph each is enough.
+- Trigger a re-read when scope or principles change: open a new session and tell the agent "re-read the constitution before we start."
+
+### Work Slices
+
+A Work Slice is not a file you create — it is a bounded unit of work you declare at the start of a session. Activating it means framing the task explicitly:
+
+```
+Task: migrate the orders table to the new schema
+Scope: only ops/db/migrations/ — no application code changes
+Risk: High (production data)
+Stop line: if migration plan requires touching more than 3 files, surface and pause
+```
+
+The agent records the slice framing in a decision record (see below). You can also use the Work Slice spec bundle for high-risk tasks:
+- [`docs/work-slice-spec-bundle.md`](../work-slice-spec-bundle.md)
+
+### Handoffs
+
+A handoff is created at the end of a session or at a meaningful boundary. To trigger one, tell the agent:
+
+```
+Create a handoff for this session.
+```
+
+The handoff captures: what was worked on, what is done, what is in progress, what is blocked, and what the next operator needs to know. It lands in `ops/ai/handoffs/YYYY-MM-DD-<slug>.md`.
+
+For the full handoff pattern: [`docs/concepts/handoff-capture-pattern.md`](../concepts/handoff-capture-pattern.md).
+
+### Reports and closeouts
+
+A closeout is created when a work slice is done. To trigger one:
+
+```
+Create a closeout report for this slice.
+```
+
+Reports land in `ops/ai/reports/YYYY-MM-DD-<slug>-closeout.md`. They contain: what was done, proof of validation, decisions made, and open questions.
+
+### Learnings
+
+A learning is created when you want to capture a durable lesson from a session:
+
+```
+Capture a learning: we found that X consistently happens when Y. Adjust Z going forward.
+```
+
+Learnings land in `ops/ai/learnings/YYYY-MM-DD-<slug>.md` and are read by future agents to inform behavior without repeating the same friction.
+
+### Policies
+
+Policies are project-local rules you write manually. Create one file per concern in `ops/ai/policies/`:
+
+- `pr-policy.md` — branch naming, required reviewers, commit conventions.
+- `security-gates.md` — what requires a human review gate.
+- `data-access.md` — what data the agent may and may not read.
+
+Agents read the policies folder on startup if `AGENTS.md` points to it (the default shim does).
+
+---
+
+## Recommended flows
+
+### New project from scratch
+
+1. Install AletheIA (see [`installation-guide.md`](installation-guide.md)).
+2. Fill the constitution with at least `mission.md` and `scope.md`.
+3. Open the first Claude Code session.
+4. Run a low-risk Work Slice to validate the overlay is working (e.g., scaffold a README or write a spec).
+5. At session end, create the first handoff.
+6. Expand the constitution and policies as you learn what constraints matter.
+
+### Existing project (legacy adoption)
+
+You do not need to stop work to adopt AletheIA. The minimum viable path:
+
+1. Install the overlay into the project root (step 2 of installation-guide.md).
+2. Write a minimal constitution that captures the current reality — even if the project is already running.
+3. For in-flight work, create a handoff that captures current state as if starting fresh.
+4. Add policies for the constraints you already enforce informally.
+5. Start using Work Slices for new work; retrofit existing tasks gradually.
+
+For the full guidance: [`docs/apply-to-existing-project.md`](../apply-to-existing-project.md).
+
+### Squad with BMAD or SDD
+
+AletheIA is complementary, not competing. If your squad already uses BMAD or SDD:
+
+- Keep your existing squad method — do not replace it.
+- AletheIA adds the operating loop your method does not provide: scope boundaries, governance gates, handoffs, and learnings.
+- Point BMAD/SDD agents at the constitution so they operate within declared scope.
+- Use handoffs to pass work between BMAD/SDD agents and AletheIA-governed sessions.
+
+For the positionining: [`docs/adr/ADR-005-positioning-in-agentic-ecosystem.md`](../adr/ADR-005-positioning-in-agentic-ecosystem.md).
+
+### Using Adaptive Skills alongside AletheIA
+
+[Adaptive Skills](https://github.com/nevitonsantana/adaptive-skills) is a compatible capability library. To use both:
+
+1. Install Adaptive Skills separately: `apm install nevitonsantana/adaptive-skills`.
+2. Skills live in the project's `ops/ai/skills/` folder (project-local) or in the Adaptive Skills library (shared).
+3. AletheIA governs when and how skills are invoked — skills execute, AletheIA decides the flow.
+
+For the full relationship: [`docs/adr/ADR-005-positioning-in-agentic-ecosystem.md`](../adr/ADR-005-positioning-in-agentic-ecosystem.md).
+
+---
+
+## Checklist for first adoption
+
+Use this checklist after installation and before the first real session.
+
+```
+[ ] apm_modules/AletheIA/ exists and is non-empty
+[ ] ops/ai/ exists with all required subfolders
+[ ] AGENTS.md exists at project root (no {{...}} placeholders)
+[ ] CLAUDE.md exists at project root (no {{...}} placeholders)
+[ ] .claude/settings.json exists (no {{...}} placeholders)
+[ ] ops/ai/constitution/ has at least mission.md and scope.md (non-empty)
+[ ] First Claude Code session read AGENTS.md on startup (check session output)
+[ ] Agent acknowledged the overlay under ops/ai/ without prompting
+[ ] Agent surfaced a conflict or asked for clarification when given an out-of-scope task
+```
+
+If any box is unchecked, the overlay is not fully active. See [`installation-guide.md#troubleshooting`](installation-guide.md#troubleshooting) or the technical reference at [`docs/guides/install-via-apm.md`](../guides/install-via-apm.md).
+
+---
+
+## Further reference
+
+| Need | Where to look |
+|---|---|
+| Full contract for all overlay elements | [`docs/contracts/consumer-project-overlay.md`](../contracts/consumer-project-overlay.md) |
+| Work Slice pattern in depth | [`docs/concepts/work-slice-pattern.md`](../concepts/work-slice-pattern.md) |
+| Handoff pattern in depth | [`docs/concepts/handoff-capture-pattern.md`](../concepts/handoff-capture-pattern.md) |
+| Governance gates and decision records | [`docs/governance.md`](../governance.md) |
+| Daily operations workflow | [`starter-pack/guides/daily-operations.md`](../../starter-pack/guides/daily-operations.md) |
+| Harness-specific setup (Claude Code, Codex, etc.) | [`docs/guides/setting-up-harnesses.md`](../guides/setting-up-harnesses.md) |
+| Manual adoption (no APM) | [`packs/operating-overlay/README.md`](../../packs/operating-overlay/README.md) |

--- a/docs/getting-started/catalog.md
+++ b/docs/getting-started/catalog.md
@@ -58,7 +58,7 @@ Stop line: if migration plan requires touching more than 3 files, surface and pa
 ```
 
 The agent records the slice framing in a decision record (see below). You can also use the Work Slice spec bundle for high-risk tasks:
-- [`docs/work-slice-spec-bundle.md`](../work-slice-spec-bundle.md)
+- [`docs/contracts/work-slice-spec-bundle.md`](../contracts/work-slice-spec-bundle.md)
 
 ### Handoffs
 
@@ -125,7 +125,7 @@ You do not need to stop work to adopt AletheIA. The minimum viable path:
 4. Add policies for the constraints you already enforce informally.
 5. Start using Work Slices for new work; retrofit existing tasks gradually.
 
-For the full guidance: [`docs/apply-to-existing-project.md`](../apply-to-existing-project.md).
+For the full guidance: [`docs/guides/apply-to-existing-project.md`](../guides/apply-to-existing-project.md).
 
 ### Squad with BMAD or SDD
 
@@ -177,7 +177,7 @@ If any box is unchecked, the overlay is not fully active. See [`installation-gui
 | Full contract for all overlay elements | [`docs/contracts/consumer-project-overlay.md`](../contracts/consumer-project-overlay.md) |
 | Work Slice pattern in depth | [`docs/concepts/work-slice-pattern.md`](../concepts/work-slice-pattern.md) |
 | Handoff pattern in depth | [`docs/concepts/handoff-capture-pattern.md`](../concepts/handoff-capture-pattern.md) |
-| Governance gates and decision records | [`docs/governance.md`](../governance.md) |
+| Governance gates and decision records | [`docs/concepts/governance.md`](../concepts/governance.md) |
 | Daily operations workflow | [`starter-pack/guides/daily-operations.md`](../../starter-pack/guides/daily-operations.md) |
 | Harness-specific setup (Claude Code, Codex, etc.) | [`docs/guides/setting-up-harnesses.md`](../guides/setting-up-harnesses.md) |
 | Manual adoption (no APM) | [`packs/operating-overlay/README.md`](../../packs/operating-overlay/README.md) |

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -1,0 +1,135 @@
+# AletheIA — FAQ
+
+Answers to common questions from teams adopting AletheIA for the first time.
+
+---
+
+## General
+
+**What exactly is AletheIA?**  
+AletheIA is an operating overlay — a governance layer you add to a project that shapes how AI-assisted work is scoped, decided, validated, handed off, and learned from. It is not an agent runtime, not a bundle of specialist agents, and not a product framework. See [`overview.md`](overview.md) for the full description.
+
+**Does AletheIA replace BMAD, SDD, or my current method?**  
+No. AletheIA is complementary to squad methods like BMAD or SDD. It adds the operating loop those methods do not provide: explicit scope, governance gates, handoffs between sessions, and durable learnings. Use AletheIA alongside your existing method, not instead of it. See [ADR-005](../adr/ADR-005-positioning-in-agentic-ecosystem.md) for the full positioning.
+
+**Does AletheIA require a specific agent or runtime?**  
+No. AletheIA is runtime-agnostic. The core overlay (`ops/ai/`, `AGENTS.md`, constitution) works with any agent that reads `AGENTS.md`. Harness-specific shims (`.claude/`, `CLAUDE.md`) are optional adapters for specific runtimes. Currently Claude Code is the primary supported harness; others are planned.
+
+**How is AletheIA different from Adaptive Skills?**  
+AletheIA governs the work — it decides scope, gates, handoffs, and validation. Adaptive Skills provides specialist capabilities that execute within that governance. They are designed to be used together: AletheIA decides the flow, skills shape what gets done. See [ADR-005](../adr/ADR-005-positioning-in-agentic-ecosystem.md) for the layer model.
+
+**The README mentions Crisis Monitor. Is AletheIA only for that domain?**  
+No. Crisis Monitor was the first project that validated AletheIA, preserved under `docs/pilots/` as a case study. AletheIA is domain-agnostic — it has been applied to software engineering, design work, and data analysis. See [ADR-006](../adr/ADR-006-domain-agnosticism.md).
+
+**What does "v0.1.0-alpha" mean?**  
+The APM package is in alpha. The core framework (AletheIA 1.0) is stable — the vocabulary, operating loop, and governance patterns are production-ready. The alpha tag applies to the APM packaging layer specifically, which may change as APM evolves. Do not use `--force` updates in production without reviewing the diff first.
+
+---
+
+## Installation
+
+**Why does installation require two commands?**  
+APM does not support install-time hooks for materializing project scaffolds. `apm install` downloads the package; `apm run scaffold-overlay` copies it into your project. This is a known limitation of the current APM spec, documented in [ADR-007](../adr/ADR-007-apm-packaging-strategy.md).
+
+**Can I install AletheIA without APM?**  
+Yes. The manual adoption path copies the pack directly without APM. See [`packs/operating-overlay/README.md`](../../packs/operating-overlay/README.md) for the manual steps.
+
+**I ran `apm install` but `apm_modules/AletheIA/` is empty. What happened?**  
+This is usually a network or auth issue. Run `apm install --verbose` for details. If you are behind a corporate proxy or require GitHub auth, configure APM credentials first: `apm config set github.token <your-pat>`.
+
+**`apm run scaffold-overlay` says the script is unknown.**  
+Your APM version may not surface package-defined scripts. Use the direct path instead:
+
+```bash
+bash apm_modules/AletheIA/packs/operating-overlay/scripts/scaffold-overlay.sh
+```
+
+**I already have `.claude/` and `AGENTS.md` in my project. Will the scaffold overwrite them?**  
+No. `scaffold-overlay` refuses to overwrite existing overlay artifacts. If you want to replace your current setup with the AletheIA scaffold, remove those files first, then run the command. Always commit your current state before doing so.
+
+**Do I need to re-run the install on every machine?**  
+Yes. `apm install` is per-machine. However, you should commit `apm.lock.yaml` to the repository so teammates and CI get the exact same package version. Teammates run `apm install` (without the tag) to restore from the lockfile.
+
+---
+
+## Security and credentials
+
+**Does AletheIA read my credentials, tokens, or environment variables?**  
+No. The overlay reads `AGENTS.md`, the constitution, and working folders. It does not read environment files, `.env`, or anything outside `ops/ai/` unless you explicitly point the constitution at those locations (which you should not do — credentials do not belong in the overlay).
+
+**Is it safe to commit `AGENTS.md` and `CLAUDE.md` to a public repository?**  
+Yes, as long as you do not put credentials or sensitive internal information in them. The shim files contain project metadata (name, description, stack) and overlay configuration — nothing sensitive by design.
+
+**What if an agent reads `ops/ai/policies/` and that folder contains internal rules?**  
+Policies are instructions for the agent, not secrets. They describe constraints (e.g., "require a human review gate before production deploys") — similar to a CONTRIBUTING.md. Treat them as you would any project documentation.
+
+**Can the overlay be used to give agents broad access to my system?**  
+AletheIA shapes behavior through instructions, not enforcement. The overlay cannot grant permissions the harness does not already have. Permission management is done in `.claude/settings.json` and the harness's own configuration.
+
+---
+
+## Environment
+
+**Does AletheIA work on Windows?**  
+Yes. The core overlay (markdown files and directory structure) is platform-agnostic. The variable substitution step uses `sed` on macOS/Linux; use PowerShell on Windows (see [`installation-guide.md`](installation-guide.md#step-3--substitute-variables)). APM itself supports Windows.
+
+**Does it work in CI/CD pipelines?**  
+The overlay files are part of your repository and are available in CI. Running a Claude Code session in CI is a separate question — AletheIA does not add or remove CI constraints. If your pipeline uses a Claude Code step, the overlay will be loaded automatically if the repository includes it.
+
+**What Node.js version does APM require?**  
+Node.js ≥ 18. Run `node --version` to check. AletheIA itself has no Node.js dependency — this is an APM requirement.
+
+**Can I use AletheIA without Claude Code?**  
+Yes. `AGENTS.md` and `ops/ai/` work with any conformant harness. The `.claude/` shim is only needed for Claude Code. If you use a different harness, you may need a harness-specific adapter — see [`docs/concepts/adapter-taxonomy.md`](../concepts/adapter-taxonomy.md).
+
+---
+
+## Common errors
+
+**The agent ignores the constitution and acts outside scope.**  
+First, confirm the constitution is non-empty and variables are substituted (no `{{...}}`). Then check that `AGENTS.md` correctly references the constitution path. If both look correct, the harness may not be reading `AGENTS.md` on startup — see the harness debugging guide at [`docs/guides/setting-up-harnesses.md`](../guides/setting-up-harnesses.md).
+
+**The agent refuses to do almost anything, citing scope conflicts.**  
+Your `scope.md` is probably too narrow. A scope declaration that lists only one specific task will block everything else. Broaden `scope.md` to reflect the project's actual domain, then list explicit exclusions for what you genuinely do not want agents touching.
+
+**The session ended without a handoff and I lost context.**  
+This is a discipline gap, not a bug. To recover, reconstruct context from the last report in `ops/ai/reports/` and the last handoff in `ops/ai/handoffs/`. Going forward, always ask for a handoff before ending a long session.
+
+**The agent creates handoffs and reports but does not use learnings.**  
+Learnings are passive — the agent reads them if `AGENTS.md` includes the learnings folder in the reading order, but using them requires referencing them explicitly in new sessions. Add a line to `CLAUDE.md` or `AGENTS.md` instructing agents to read learnings before starting work.
+
+**`grep -r '{{' ...` still shows placeholders after substitution.**  
+The substitution command may have missed some files or you may have used the wrong variable list. Run `grep -r '{{' AGENTS.md CLAUDE.md .claude/settings.json` to find remaining placeholders. The full variable list is in `apm_modules/AletheIA/packs/operating-overlay/manifest.yaml`.
+
+---
+
+## Working as a team
+
+**How do multiple people use the same AletheIA overlay?**  
+The overlay files are part of the repository. Everyone on the team works from the same constitution, policies, and accumulated handoffs and learnings. Each person runs their own agent sessions; handoffs in `ops/ai/handoffs/` connect sessions across people.
+
+**Should handoffs be committed to the repository?**  
+Yes. Handoffs and learnings are shared operational context. Commit them as you would any other project document. Reports should be committed on closeout.
+
+**Who owns the constitution?**  
+The constitution is a team document. The tech lead or project owner typically authors it, but anyone can propose changes. Treat changes to the constitution with the same weight as changes to a team charter — they affect how all agents on the project behave.
+
+**Can two people run agent sessions simultaneously?**  
+Yes, but with caution. Two parallel sessions that touch the same files will produce merge conflicts in the normal way. The overlay does not prevent this — coordination is a team responsibility. For high-risk parallel work, assign separate scopes to each session and use policies to separate the domains.
+
+**What happens when a new team member joins?**  
+They clone the repository, run `apm install` (which restores from `apm.lock.yaml`), read the constitution and the most recent handoff, and they are ready. The accumulated handoffs and learnings serve as an operational history.
+
+---
+
+## OS-specific notes
+
+| Topic | macOS | Linux | Windows |
+|---|---|---|---|
+| Variable substitution | `sed -i '' -e ...` (empty string after `-i`) | `sed -i -e ...` (no empty string) | PowerShell `(Get-Content ...) -replace ... \| Set-Content` |
+| APM installation | Homebrew or npm: `npm install -g @microsoft/apm` | npm: `npm install -g @microsoft/apm` | npm or winget |
+| Shell | zsh (default in macOS 10.15+) | bash | PowerShell or Command Prompt |
+| Line endings | LF | LF | CRLF by default — configure `git config core.autocrlf input` to avoid diff noise in markdown |
+| Path separator | `/` | `/` | `\` in native Windows paths; use `/` in APM commands and scripts |
+
+For harness-specific OS differences (Claude Code installation, permissions, etc.), see [`docs/guides/setting-up-harnesses.md`](../guides/setting-up-harnesses.md).

--- a/docs/getting-started/installation-guide.md
+++ b/docs/getting-started/installation-guide.md
@@ -1,0 +1,265 @@
+# AletheIA — Installation Guide
+
+> **Two-step installation.** AletheIA requires two commands to install: `apm install` downloads the package, and `apm run scaffold-overlay` materializes the overlay in your project. Do not skip the second step — the overlay will not be present after the first command alone. See [ADR-007](../adr/ADR-007-apm-packaging-strategy.md) for the reason.
+
+This guide walks you through installing AletheIA into a new or existing project from scratch. Estimated time: 15–30 minutes.
+
+---
+
+## Prerequisites
+
+Before you start, confirm:
+
+1. **APM is installed.** Run `apm --version`. If the command is not found, install APM first:
+   - Instructions: [microsoft.github.io/apm/installation](https://microsoft.github.io/apm/installation)
+   - APM requires Node.js ≥ 18. Run `node --version` to confirm.
+
+2. **You have a project directory.** AletheIA installs into a project root. You can use an existing project or create an empty one:
+   ```bash
+   mkdir my-project && cd my-project
+   git init
+   ```
+
+3. **You are in the project root.** Run `pwd` (macOS/Linux) or `cd` (Windows) and confirm you are at the top level of the project, not inside a subdirectory.
+
+4. **GitHub access.** The AletheIA package resolves from `github.com/nevitonsantana/AletheIA`. The repository is public. If your network requires auth for GitHub, configure APM credentials before proceeding (`apm config set github.token <your-pat>`).
+
+---
+
+## Step 1 — Install the AletheIA package
+
+From the project root:
+
+```bash
+apm install nevitonsantana/AletheIA#v0.1.0-alpha
+```
+
+What happens:
+
+- APM resolves the package at the pinned tag `v0.1.0-alpha`.
+- The package is downloaded into `apm_modules/AletheIA/`.
+- A lockfile `apm.lock.yaml` is written at the project root.
+
+**Commit the lockfile.** The lockfile pins the exact version and content hash so teammates and CI get the same bytes:
+
+```bash
+git add apm.lock.yaml
+git commit -m "chore: add AletheIA apm.lock.yaml"
+```
+
+The overlay is **not yet present** in your project after this step. Proceed to step 2.
+
+### Verify step 1
+
+```bash
+ls apm_modules/AletheIA/
+```
+
+You should see `apm.yml`, `packs/`, `docs/`, and `README.md`. If the directory is missing, the install failed — see [Troubleshooting](#troubleshooting).
+
+---
+
+## Step 2 — Materialize the overlay
+
+```bash
+apm run scaffold-overlay
+```
+
+What happens:
+
+- Copies the overlay structure from `apm_modules/AletheIA/packs/operating-overlay/` into your project root.
+- Skips source-only artifacts (`README.md`, `manifest.yaml`, `scripts/`).
+- Refuses to overwrite existing overlay files. If you already have `AGENTS.md`, `.claude/`, or `ops/ai/`, the command will list the conflicts and stop. See [Troubleshooting](#troubleshooting).
+
+After this step your project root contains:
+
+```
+my-project/
+├── AGENTS.md                      ← cross-agent dispatcher (needs variable substitution)
+├── CLAUDE.md                      ← Claude Code shim (needs variable substitution)
+├── .claude/
+│   ├── settings.json              ← Claude Code configuration (needs variable substitution)
+│   └── rules/
+│       ├── src.md
+│       ├── tests.md
+│       └── ops-ai.md
+└── ops/ai/
+    ├── constitution/README.md     ← placeholder — you will replace this in step 4
+    ├── handoffs/README.md
+    ├── reports/README.md
+    ├── policies/README.md
+    ├── schemas/README.md
+    ├── skills/README.md
+    └── learnings/README.md
+```
+
+### Verify step 2
+
+```bash
+ls ops/ai/
+```
+
+You should see `constitution/`, `handoffs/`, `reports/`, `policies/`, `schemas/`, `skills/`, `learnings/`. If any are missing, check the command output for error messages.
+
+---
+
+## Step 3 — Substitute variables
+
+The shim files ship with `{{PLACEHOLDER}}` variables. Substitute them before opening your first session.
+
+**macOS:**
+
+```bash
+PROJECT_NAME="My Project"
+ONE_LINER="Short description of what this project does"
+STACK="TypeScript, Node 20"
+
+sed -i '' \
+  -e "s|{{PROJECT_NAME}}|${PROJECT_NAME}|g" \
+  -e "s|{{PROJECT_ONE_LINER}}|${ONE_LINER}|g" \
+  -e "s|{{PRIMARY_STACK}}|${STACK}|g" \
+  -e 's|{{INSTALL_CMD}}|pnpm install|g' \
+  -e 's|{{TEST_CMD}}|pnpm test|g' \
+  -e 's|{{LINT_CMD}}|pnpm lint|g' \
+  -e 's|{{BUILD_CMD}}|pnpm build|g' \
+  -e 's|{{DEV_CMD}}|pnpm dev|g' \
+  AGENTS.md CLAUDE.md .claude/settings.json
+```
+
+**Linux:** drop the empty string after `-i`:
+
+```bash
+sed -i \
+  -e "s|{{PROJECT_NAME}}|${PROJECT_NAME}|g" \
+  ...
+  AGENTS.md CLAUDE.md .claude/settings.json
+```
+
+**Windows (PowerShell):**
+
+```powershell
+$files = @("AGENTS.md", "CLAUDE.md", ".claude\settings.json")
+foreach ($f in $files) {
+  (Get-Content $f) `
+    -replace '\{\{PROJECT_NAME\}\}', 'My Project' `
+    -replace '\{\{PROJECT_ONE_LINER\}\}', 'Short description' `
+    -replace '\{\{PRIMARY_STACK\}\}', 'TypeScript, Node 20' `
+    | Set-Content $f
+}
+```
+
+Adjust the values for your project. The full variable list with descriptions is in `apm_modules/AletheIA/packs/operating-overlay/manifest.yaml` under `variables:`.
+
+### Verify step 3
+
+```bash
+grep -r '{{' AGENTS.md CLAUDE.md .claude/settings.json && echo "STILL HAS PLACEHOLDERS" || echo "OK"
+```
+
+All output should be `OK` before proceeding.
+
+---
+
+## Step 4 — Fill the constitution
+
+The constitution is the document agents read first to understand what game they are playing. Without it, the overlay is installed but governance is not anchored.
+
+Replace `ops/ai/constitution/README.md` with four files:
+
+```
+ops/ai/constitution/
+├── mission.md    ← what the project exists to do, for whom (one paragraph)
+├── scope.md      ← what is and is not in scope; explicit "we do not do X"
+├── stack.md      ← languages, frameworks, infrastructure — one line each
+└── principles.md ← 5–10 non-negotiable rules and the values they protect
+```
+
+Start minimal. A single sentence per file is better than a placeholder paragraph. You will expand these as the project evolves.
+
+Example `mission.md`:
+
+```markdown
+This project builds an internal incident-triage dashboard for the platform team.
+The primary user is the on-call engineer who needs to understand alert scope in under 2 minutes.
+```
+
+Example `principles.md`:
+
+```markdown
+1. Never silently discard an alert. Surface failures visibly.
+2. Prefer an explicit stop over silent scope expansion.
+3. All agent actions in production require a human review gate.
+```
+
+---
+
+## Step 5 — Verify the installation
+
+Open a fresh Claude Code session from the project root:
+
+```bash
+claude
+```
+
+The session should:
+
+1. Read `AGENTS.md` on startup.
+2. Acknowledge the overlay under `ops/ai/`.
+3. Read the constitution before acting on any task.
+4. Surface a conflict if you ask it to do something outside the declared scope.
+
+If any of the four behaviors are missing, the overlay is not correctly installed. See the [technical reference](../guides/install-via-apm.md#step-5--verify) for the full conformance checklist.
+
+---
+
+## Updating AletheIA
+
+When a new version is published:
+
+```bash
+apm update nevitonsantana/AletheIA
+apm run scaffold-overlay --force
+```
+
+Before running `--force`, commit your current overlay state so you can compare and rescue any local customizations. The pack does not track adopter-side edits.
+
+---
+
+## Troubleshooting
+
+**`apm: command not found`**  
+APM is not installed or not on `$PATH`. Follow the APM installation guide at [microsoft.github.io/apm/installation](https://microsoft.github.io/apm/installation). Restart your shell after installation.
+
+**`apm install` completes but `apm_modules/AletheIA/` is empty**  
+Network or auth issue. If the repo requires GitHub auth, run `apm config set github.token <your-pat>` first. Run `apm install --verbose` for details.
+
+**`apm run scaffold-overlay` says "unknown script"**  
+Your APM version may not surface package-defined scripts. Invoke the script directly:
+
+```bash
+bash apm_modules/AletheIA/packs/operating-overlay/scripts/scaffold-overlay.sh
+```
+
+**`scaffold-overlay: target already contains overlay artifacts`**  
+The project already has `AGENTS.md`, `.claude/`, or `ops/ai/`. Either remove those paths or pass `--force`. Always commit your current state first so nothing is lost.
+
+**`scaffold-overlay: refusing to scaffold into the pack itself`**  
+You ran the command from inside `apm_modules/AletheIA/` instead of the project root. `cd` back to the project root and retry.
+
+**`sed: command not found` on Windows**  
+PowerShell is the recommended approach on Windows (see step 3). Alternatively, use Git Bash which ships `sed`.
+
+**Claude ignores `AGENTS.md`**  
+Confirm `AGENTS.md` is at the project root (not in a subdirectory), variables are substituted (no `{{...}}` remaining), and you started the Claude Code session from the project root. See [`docs/guides/setting-up-harnesses.md`](../guides/setting-up-harnesses.md) for harness-specific debugging.
+
+**The session reads the constitution but refuses to act on anything**  
+Check `scope.md`. An overly narrow scope can cause the agent to surface a conflict for nearly every task. Start with a broader declaration and tighten it as you learn which constraints matter.
+
+---
+
+## What to do next
+
+1. Run your first Work Slice: [`docs/core-operating-path.md`](../core-operating-path.md)
+2. Browse what the overlay provides: [`catalog.md`](catalog.md)
+3. Review the daily operations workflow: [`starter-pack/guides/daily-operations.md`](../../starter-pack/guides/daily-operations.md)
+4. Read the technical reference for this install flow: [`docs/guides/install-via-apm.md`](../guides/install-via-apm.md)

--- a/docs/getting-started/installation-guide.md
+++ b/docs/getting-started/installation-guide.md
@@ -259,7 +259,7 @@ Check `scope.md`. An overly narrow scope can cause the agent to surface a confli
 
 ## What to do next
 
-1. Run your first Work Slice: [`docs/core-operating-path.md`](../core-operating-path.md)
+1. Run your first Work Slice: [`docs/guides/core-operating-path.md`](../guides/core-operating-path.md)
 2. Browse what the overlay provides: [`catalog.md`](catalog.md)
 3. Review the daily operations workflow: [`starter-pack/guides/daily-operations.md`](../../starter-pack/guides/daily-operations.md)
 4. Read the technical reference for this install flow: [`docs/guides/install-via-apm.md`](../guides/install-via-apm.md)

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -1,0 +1,99 @@
+# AletheIA — Overview
+
+AletheIA is a portable **operating overlay** — a thin governance layer you place over your project that turns raw model or agent output into bounded, reviewable, validated action. It does not replace your agent runtime, your task tracker, or your team's method. It adds the operating loop those tools leave out: explicit scope, governance gates, validation proof, and restartable continuity.
+
+---
+
+## The problem it solves
+
+When you work with AI models or agents on real project tasks, two things tend to go wrong:
+
+1. **Loss of boundaries.** The session drifts. The model acts on assumptions you did not share. Work happens outside the agreed scope without anyone noticing until something breaks.
+2. **Loss of continuity.** The transcript grows until it overflows, or the session ends, and the next agent or human has to re-derive everything from scratch — wasting time and introducing errors.
+
+AletheIA solves both by making the operating loop explicit:
+
+```
+signal → framing → context → governance → bounded execution → validation → handoff / learning
+```
+
+Every meaningful task becomes a **Work Slice**: a bounded unit with a defined goal, scope, risk level, assumptions, and a stop line. The agent works within that boundary. Decisions are recorded. Validation is required before closure. Handoffs carry the state forward so the next session does not start blind.
+
+---
+
+## Practical daily benefits
+
+| Before AletheIA | With AletheIA |
+|---|---|
+| Agent scope unclear; drifts into adjacent work | Slice defines scope and stop line upfront |
+| No record of why a decision was made | Decision Record captures reasoning |
+| Session ends, next session re-derives everything | Handoff carries state, decisions, open questions |
+| Validation is informal ("does it look right?") | Conformance test specifies minimum proof |
+| Governance rules live in someone's head | Constitution externalizes rules for every agent |
+
+---
+
+## Who it is for
+
+AletheIA is useful for:
+
+- **Teams using agents on multi-session work** — where continuity and scope discipline matter.
+- **Tech leads governing hybrid squads** — where some tasks go to agents and some stay with humans; the overlay makes that boundary explicit.
+- **Individual developers using Claude Code or similar** — who want their sessions to be restartable, auditable, and scope-bound without building a custom system.
+- **Anyone rolling out AI-assisted work to a team** — who needs a lightweight governance layer that does not require everyone to become a prompt engineer.
+
+AletheIA is **not** a good fit if:
+
+- You need a ready-made squad of specialized agents (look at BMAD or SDD).
+- You need a portable agent runtime with memory and tool orchestration (look at Agentic Stack or Hermes).
+- You are running a one-shot automation where continuity and governance do not matter.
+
+---
+
+## When to use it
+
+Use AletheIA when:
+
+- A project will span multiple sessions, agents, or people.
+- You need a human-reviewable record of what agents decided and why.
+- The work carries risk: data migration, production changes, spec-driven development, compliance-sensitive tasks.
+- You want the same operating rules to apply regardless of which model or harness you use tomorrow.
+
+You do not need AletheIA for quick explorations, throwaway scripts, or tasks where the full context fits in a single session with no downstream consequence.
+
+---
+
+## How it relates to other tools
+
+AletheIA governs the work. It does not replace your tools — it adds a layer above them.
+
+| Tool category | Example | How it relates to AletheIA |
+|---|---|---|
+| Agent bundles / squad methods | BMAD, SDD | Complementary. AletheIA governs the loop; BMAD/SDD define the squad. Use together. |
+| Capability library | Adaptive Skills | Complementary. AletheIA governs when and how skills are invoked. |
+| Package manager | APM (Microsoft) | AletheIA is distributed as an APM package. |
+| Harness | Claude Code, Cursor, Codex | AletheIA is harness-agnostic. Each harness gets a lightweight adapter shim. |
+| Agent runtime | Agentic Stack, Hermes | Separate layer. AletheIA governs the flow; runtimes execute it. |
+
+For the full ecosystem map, see [`docs/concepts/ecosystem-map.md`](../concepts/ecosystem-map.md).
+
+---
+
+## Risks and cautions
+
+**AletheIA adds structure, not autonomy.** If you want agents to operate without human review gates, AletheIA will slow you down — that friction is intentional.
+
+**The constitution must reflect reality.** The overlay works because agents read the constitution before acting. If the constitution is stale or vague, the governance layer breaks silently. Keep it current.
+
+**Handoffs are only as good as what you put in them.** If the session closes without a handoff, the next operator starts blind. This is not AletheIA's failure — it is a discipline gap.
+
+**The overlay is not a security boundary.** AletheIA shapes behavior through instructions, not enforcement. A model that ignores instructions will ignore the overlay too. Treat AletheIA as a governance aid, not a sandbox wall.
+
+---
+
+## Next steps
+
+- Install AletheIA: [`installation-guide.md`](installation-guide.md)
+- Browse what the overlay provides: [`catalog.md`](catalog.md)
+- Questions? [`faq.md`](faq.md)
+- Deep dive: [`docs/00-overview.md`](../00-overview.md), [`docs/governance.md`](../governance.md)

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -96,4 +96,4 @@ For the full ecosystem map, see [`docs/concepts/ecosystem-map.md`](../concepts/e
 - Install AletheIA: [`installation-guide.md`](installation-guide.md)
 - Browse what the overlay provides: [`catalog.md`](catalog.md)
 - Questions? [`faq.md`](faq.md)
-- Deep dive: [`docs/00-overview.md`](../00-overview.md), [`docs/governance.md`](../governance.md)
+- Deep dive: [`docs/concepts/overview.md`](../concepts/overview.md), [`docs/concepts/governance.md`](../concepts/governance.md)


### PR DESCRIPTION
## Summary

- Creates \`docs/getting-started/\` with four documents for adopters with no prior context: \`overview.md\`, \`installation-guide.md\`, \`catalog.md\`, \`faq.md\`
- Updates \`README.md\` to surface these docs as the primary entry point under a new "New to AletheIA? Start here" block
- Covers the two-step APM install flow (ADR-007), overlay capabilities and activation, recommended adoption flows (new project, legacy, BMAD/SDD, Adaptive Skills), and common questions

## Acceptance criteria verified

- [x] Four documents in \`docs/getting-started/\`
- [x] Installation guide explicit about two-step flow (ADR-007) from the first line
- [x] README updated to point to the four docs as entry point
- [x] No substitution of technical depth in \`docs/concepts/\`, \`docs/contracts/\` — getting-started links to those as "further reference"
- [x] \`docs/guides/install-via-apm.md\` (Epic 4) preserved — coexists with distinct scope (technical reference vs. beginner guide)

## Decisions taken beyond the plan

- **Language: English** — repo convention applied per rule #3 (repo conventions over plan)
- **Coexistence with \`guides/install-via-apm.md\`** — scopes are distinct; the two files cross-reference each other
- **README: additive change** — new block above existing "Fastest understanding path" rather than replacing it
- **Adaptive Skills flow in \`catalog.md\`** — added as a recommended flow because the README already references it as a system component

## Part of

Epic 6 of the AletheIA + Adaptive Skills cross-repo plan. Epics 1–5 previously merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)