### PR TITLE
feat(engine): GovernancePack JSON Schema + validated loader (closes #125)

### DIFF
--- a/engine/index.ts
+++ b/engine/index.ts
@@ -9,3 +9,4 @@ export * from "./policy";
 export * from "./runtime";
 export * from "./types";
 export * from "./validation";
+export * from "./loader";

--- a/engine/loader.ts
+++ b/engine/loader.ts
@@ -1,0 +1,25 @@
+import path from "node:path";
+import fs from "node:fs";
+import { validateAgainstSchema } from "./validation";
+import type { GovernancePack } from "./types";
+
+const GOVERNANCE_PACK_SCHEMA = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  "../schemas/aletheia-governance-pack.schema.json",
+);
+
+/**
+ * Load and validate a GovernancePack from a JSON file.
+ *
+ * Throws `SchemaValidationError` if the file does not conform to the
+ * governance-pack schema. Throws a standard `Error` if the file cannot
+ * be read.
+ */
+export function loadGovernancePack(filePath: string): GovernancePack {
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`Governance pack file not found: ${resolved}`);
+  }
+  const raw: unknown = JSON.parse(fs.readFileSync(resolved, "utf-8"));
+  return validateAgainstSchema<GovernancePack>(raw, GOVERNANCE_PACK_SCHEMA);
+}

--- a/examples/learning-from-failed-validation/run.ts
+++ b/examples/learning-from-failed-validation/run.ts
@@ -3,16 +3,17 @@ import path from "node:path";
 
 import {
   createLearningFromPolicyEvaluation,
+  loadGovernancePack,
   runBeforeFinalizeHook,
 } from "../../engine";
-import type { GovernanceFacts, GovernancePack, LearningRecord } from "../../engine";
+import type { GovernanceFacts, LearningRecord } from "../../engine";
 
 function readJsonFile<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, "utf-8")) as T;
 }
 
 const baseDir = path.resolve(process.cwd(), "examples/learning-from-failed-validation");
-const pack = readJsonFile<GovernancePack>(
+const pack = loadGovernancePack(
   path.resolve(process.cwd(), "policies/aletheia-development-governance.v1.json"),
 );
 const facts = readJsonFile<GovernanceFacts>(path.join(baseDir, "facts.json"));

--- a/schemas/aletheia-governance-pack.schema.json
+++ b/schemas/aletheia-governance-pack.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia.local/schemas/governance-pack.schema.json",
+  "title": "AletheIA Governance Pack",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["meta", "hooks", "facts_model", "rules"],
+  "properties": {
+    "meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "domain", "status", "default_mode"],
+      "properties": {
+        "name":         { "type": "string", "minLength": 1 },
+        "version":      { "type": "string", "minLength": 1 },
+        "domain":       { "type": "string", "minLength": 1 },
+        "status":       { "type": "string", "minLength": 1 },
+        "default_mode": { "type": "string", "enum": ["strict", "balanced", "relaxed"] }
+      }
+    },
+    "vocabulary": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "hooks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "description"],
+        "properties": {
+          "id":          { "type": "string", "enum": ["before_execute", "after_execute", "before_finalize"] },
+          "description": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "facts_model": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "stage", "description", "enabled", "action_by_mode"],
+        "properties": {
+          "id":          { "type": "string", "minLength": 1 },
+          "stage":       { "type": "string", "enum": ["before_execute", "after_execute", "before_finalize"] },
+          "description": { "type": "string", "minLength": 1 },
+          "enabled":     { "type": "boolean" },
+          "when_all": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/predicate" }
+          },
+          "when_any": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/predicate" }
+          },
+          "action_by_mode": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["strict", "balanced", "relaxed"],
+            "properties": {
+              "strict":   { "type": "string", "enum": ["allow", "review", "ask_human", "block"] },
+              "balanced": { "type": "string", "enum": ["allow", "review", "ask_human", "block"] },
+              "relaxed":  { "type": "string", "enum": ["allow", "review", "ask_human", "block"] }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "predicate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fact", "op", "value"],
+      "properties": {
+        "fact": { "type": "string", "minLength": 1 },
+        "op":   { "type": "string", "enum": ["eq", "neq", "gt", "gte", "lt", "lte", "contains", "in"] },
+        "value": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "number" },
+            { "type": "boolean" },
+            { "type": "null" },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  { "type": "string" },
+                  { "type": "number" },
+                  { "type": "boolean" },
+                  { "type": "null" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/contracts/test-contracts.test.ts
+++ b/tests/contracts/test-contracts.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, it, expect } from "vitest";
-import { validateAgainstSchema, SchemaValidationError } from "../../engine";
+import { validateAgainstSchema, SchemaValidationError, loadGovernancePack } from "../../engine";
 
 function readJsonFile<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, "utf-8")) as T;
@@ -30,6 +30,11 @@ const fixtures = [
     fixture: "examples/learning-from-failed-validation/learning-record.json",
     schema: "aletheia-learning-record.schema.json",
   },
+  {
+    name: "Governance Pack",
+    fixture: "policies/aletheia-development-governance.v1.json",
+    schema: "aletheia-governance-pack.schema.json",
+  },
 ];
 
 describe("Contract validation", () => {
@@ -39,6 +44,20 @@ describe("Contract validation", () => {
       expect(() => validateAgainstSchema(data, path.join(schemasDir, schema))).not.toThrow();
     });
   }
+
+  it("loadGovernancePack validates and returns a valid pack", () => {
+    const pack = loadGovernancePack(
+      path.resolve(process.cwd(), "policies/aletheia-development-governance.v1.json"),
+    );
+    expect(pack.meta.name).toBeTruthy();
+    expect(Array.isArray(pack.rules)).toBe(true);
+  });
+
+  it("loadGovernancePack throws SchemaValidationError for a malformed pack", () => {
+    expect(() =>
+      loadGovernancePack(path.resolve(process.cwd(), "examples/hello-world/task-brief.json")),
+    ).toThrow(SchemaValidationError);
+  });
 
   it("throws SchemaValidationError for an invalid Task Brief (missing id)", () => {
     const taskBrief = readJsonFile<Record<string, unknown>>(

--- a/tests/e2e/test-e2e.test.ts
+++ b/tests/e2e/test-e2e.test.ts
@@ -4,11 +4,12 @@ import { describe, it, expect } from "vitest";
 
 import {
   createExecutionScope,
+  loadGovernancePack,
   runBeforeExecuteHook,
   runAfterExecuteHook,
   runBeforeFinalizeHook,
 } from "../../engine";
-import type { GovernanceFacts, GovernancePack } from "../../engine";
+import type { GovernanceFacts } from "../../engine";
 import { runExampleScenario } from "../run-example";
 
 function readJsonFile<T>(filePath: string): T {
@@ -16,7 +17,7 @@ function readJsonFile<T>(filePath: string): T {
 }
 
 describe("E2E — governance hooks + kernel path", () => {
-  const pack = readJsonFile<GovernancePack>(
+  const pack = loadGovernancePack(
     path.resolve(process.cwd(), "policies/aletheia-development-governance.v1.json"),
   );
   const beforeFacts = readJsonFile<{ facts: GovernanceFacts }>(


### PR DESCRIPTION
## Summary

- Adds `schemas/aletheia-governance-pack.schema.json` (Draft 2020-12) derived from the `GovernancePack` TypeScript interface — validates `meta`, `hooks`, `facts_model`, `rules`, predicates, and `action_by_mode`.
- Adds `engine/loader.ts`: `loadGovernancePack(path)` loads and validates a pack via `validateAgainstSchema`, throwing `SchemaValidationError` on malformed input **before any execution**.
- Migrates the two `JSON.parse(...) as GovernancePack` call sites (`tests/e2e`, `examples/learning-from-failed-validation`) to `loadGovernancePack`.
- Adds 3 new contract tests: governance pack fixture passes schema, valid pack loads correctly, malformed file throws `SchemaValidationError`.

## Acceptance criteria

- [x] Loading a governance pack with a missing required field throws a descriptive error before any execution.
- [x] Loading a valid governance pack proceeds normally.
- [x] All existing tests pass (18/18).
- [x] CI Quality Gate green.

## Test plan

- All 18 tests pass locally (`pnpm test`)
- TypeScript noEmit clean (`pnpm exec tsc --noEmit`)
- CI will run full suite on push