### PR TITLE
docs(knowledge-governance): introduce Knowledge Governance Layer (docs-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- introduce the Knowledge Governance Layer (docs-only): concepts, contracts, JSON Schemas, and generic project-extension examples for governing user-provided knowledge bases used by agents and skills (ADR-008)
+
 - clarify that `recommend-clean-restart` should explicitly signal a fresh thread / local clear-thread action before starting a new issue
 - add a project-local Constitution context guide clarifying how stronger governing-context bootstraps can support clean restart without becoming framework core
 

--- a/docs/adr/ADR-008-knowledge-governance-layer.md
+++ b/docs/adr/ADR-008-knowledge-governance-layer.md
@@ -1,0 +1,78 @@
+# ADR 008 — Knowledge Governance Layer
+
+| Field | Value |
+|---|---|
+| Status | Accepted |
+| Date | 2026-05-28 |
+| Author | Neviton Santana |
+| Deciders | Neviton Santana |
+| Related | ADR-004 (AletheIA as operating overlay), ADR-005 (Positioning in agentic ecosystem), ADR-006 (Domain agnosticism) |
+| Supersedes | — |
+
+## 1. Context
+
+AletheIA already treats context as a governed resource (context graph, context packs, project-extension pattern). What it did not yet have was a vocabulary for **user-provided knowledge bases** — proprietary frameworks, internal policies, personas, design systems, research findings — used by agents and skills.
+
+The recurring failure modes when this gap is left unaddressed:
+
+- Skills start carrying proprietary content directly, losing portability.
+- Users paste documents into prompts without scope, owner, version, sensitivity, or usage policy.
+- Restricted text leaks into responses, logs, traces, and handoffs.
+- Sources of very different authority (a persona vs. an accessibility guideline vs. a compliance policy) are treated as equivalent.
+- There is no audit trail for *which* source influenced a decision.
+
+A first concrete consumer (the Feature Value Governance Pack) made the gap unavoidable: it needs a strategic framework, personas, accessibility guidelines, and operating-model context — and none of those should be inlined into the skill.
+
+## 2. Decision
+
+Introduce a **Knowledge Governance Layer** as a structural extension of AletheIA, with the following non-negotiables:
+
+1. **Knowledge is not raw context.** Every source is a governed object with `id`, `owner`, `version`, `sensitivity`, `authority_level`, `scope`, `retrieval_mode`, and usage policy.
+2. **Skills declare types, not sources.** A skill says it needs a `proprietary_framework` or `accessibility_guideline`; the resolver picks the concrete pack under the active permissions and policy.
+3. **Capsule-first.** The default unit of consumption is an operational capsule of the source, not the full source. Full source is the exception, not the rule.
+4. **Sensitivity and authority are independent vocabularies.** A `regulated` persona is still a persona.
+5. **Source precedence is framework-stable.** Compliance / security / privacy / mandatory accessibility outrank policies, operating model, strategy, interpretive frameworks, personas, benchmarks, and stakeholder input — in that order.
+6. **Restricted use limits are policy, not preference.** Internal/confidential/restricted/regulated sources have explicit citation, exposure, export, and human-review rules.
+7. **Every relevant use is auditable.** Source, version, scope, agent, skill, task, restrictions, conflicts, and outcome are logged.
+8. **First phase is docs-only.** No vector DB, no runtime, no UI, no IAM/DLP. Schemas exist as conceptual contracts.
+
+The layer ships as concepts, contracts, schemas, and generic examples in this repository, with a companion skill-side surface in Adaptive Skills (boundaries doc, templates, three governance skills).
+
+## 3. Consequences
+
+**Positive**
+- Skills become portable: no proprietary residue inside reusable artifacts.
+- User-provided knowledge gets a single, vendor-agnostic envelope (`knowledge_pack`).
+- The resolver becomes the one place that adjudicates source eligibility and exposure — eliminating ad-hoc rules scattered across skills.
+- Audit and conflict-resolution are first-class, not afterthoughts.
+- Feature Value Governance — and any later consumer — can declare dependencies without coupling to one organization's framework.
+
+**Negative / accepted tradeoffs**
+- Onboarding a new knowledge source has overhead (manifest + capsule + classification). Mitigated by progressive maturity levels (`minimal | operational | governed`).
+- A skill that needs governed knowledge cannot run knowledge-aware until at least one matching pack is registered. We treat this as a feature: loud refusal over silent fallback.
+- The layer increases the conceptual surface area of AletheIA. Mitigated by keeping it strictly docs-only in phase one and by binding it to existing context discipline rather than replacing it.
+
+## 4. Alternatives considered
+
+- **Embed framework content directly into skills.** Rejected: destroys portability, makes auditing impossible, and forces every skill consumer to inherit one organization's content.
+- **Treat knowledge as raw prompt context.** Rejected: no scope, no authority, no audit, no exposure control. The exact failure mode the layer exists to prevent.
+- **Build a runtime registry + resolver implementation up front.** Rejected for phase one. The conceptual contracts must stabilize before code is committed; a premature implementation would foreclose vocabulary choices.
+- **Bind the layer to a specific vector store or retrieval stack.** Rejected: violates vendor-agnosticism and ADR-006 (Domain agnosticism).
+- **Put the Feature Value Governance Pack content inside the layer.** Rejected: the pack is a *consumer*, not the parent. The layer must not absorb one consumer's content.
+
+## 5. Relationship
+
+- Extends the context discipline introduced by the context-graph integration and the project-extension pattern.
+- Provides the substrate for the Feature Value Governance Pack and any future consumer that needs proprietary or restricted knowledge.
+- Pairs with the Adaptive Skills companion changes (skill-knowledge boundaries, templates, governance skills).
+- Does not modify any existing contract or schema; only adds.
+
+## 6. Review
+
+This ADR should be revisited when any of the following becomes true:
+
+- A runtime resolver implementation is proposed (would change "logical role" → contract).
+- A vector store or retrieval-stack integration is on the table.
+- Multiple consumers (beyond Feature Value Governance) exist and reveal gaps in the taxonomy or precedence policy.
+- IAM, DLP, or formal IP governance are integrated and reshape the restricted-use policy.
+- The `sensitivity` or `authority_level` vocabularies prove insufficient in practice.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,3 +69,4 @@ Do *not* write one for:
 | [ADR-005](ADR-005-positioning-in-agentic-ecosystem.md) | Positioning in the agentic ecosystem | Accepted |
 | [ADR-006](ADR-006-domain-agnosticism.md) | Domain agnosticism | Accepted |
 | [ADR-007](ADR-007-apm-packaging-strategy.md) | APM packaging strategy | Accepted |
+| [ADR-008](ADR-008-knowledge-governance-layer.md) | Knowledge Governance Layer | Accepted |

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -36,3 +36,7 @@ If you need a step-by-step guide, see [`guides/`](../guides/README.md). If you n
 | [domain-governance-packs.md](domain-governance-packs.md) | Future domain-specific governance packs |
 | [ai-agent-security-prompt-injection.md](ai-agent-security-prompt-injection.md) | Future domain pack for AI agent security |
 | [web-app-security-trust-boundaries.md](web-app-security-trust-boundaries.md) | Future domain pack for web security |
+| [knowledge-governance-layer.md](knowledge-governance-layer.md) | Layer that governs user-provided knowledge bases used by agents and skills |
+| [user-provided-knowledge.md](user-provided-knowledge.md) | How users register knowledge bases without dumping documents into prompts |
+| [framework-capsules.md](framework-capsules.md) | Operational summary of a framework or large source; the default unit a skill consumes |
+| [knowledge-resolver.md](knowledge-resolver.md) | Logical role that selects which knowledge sources enter task context |

--- a/docs/concepts/framework-capsules.md
+++ b/docs/concepts/framework-capsules.md
@@ -1,0 +1,80 @@
+# Framework Capsules
+
+## Goal
+
+Define the **capsule**: an operational summary of a knowledge source — typically a proprietary framework, a policy document, or any source large enough that loading it whole would be wasteful or risky.
+
+A capsule is the default unit a skill consumes. The full source is consulted only when the task and the source's retrieval mode allow it.
+
+---
+
+## What a capsule is
+
+A capsule is a structured, short document that answers, for one source:
+
+- what is this source for
+- when should it be used
+- when should it **not** be used
+- the small set of concepts an agent needs to reason with it
+- the key questions it prompts
+- the criteria for applying it
+- the limits of its applicability
+- signals that suggest the source is being misused or overreached
+- the expected output format when this source is in play
+
+A capsule is to a framework what a runbook is to a system: enough to operate it correctly, not enough to reconstruct it.
+
+---
+
+## What a capsule is not
+
+A capsule must not contain:
+
+- the integral text of the source
+- examples that include client, customer, or partner identifiers
+- excerpts from regulated, contractual, or confidential material
+- internal narrative ("we adopted this in Q2 because X") unless the narrative is part of the operational logic
+- enterprise-specific carve-outs that belong in a project extension
+
+If a capsule starts to read like the source itself, it is no longer a capsule.
+
+---
+
+## Capsule vs. playbook vs. full source vs. restricted source
+
+| Artifact | Purpose | Typical size | Who can consume |
+|---|---|---|---|
+| **Capsule** | operate the source correctly | 1–3 pages | any authorized agent or skill |
+| **Playbook** | step-by-step procedure for a specific task using the source | varies | task-bound agents |
+| **Full source** | the original document | as-is | only when retrieval mode permits |
+| **Restricted source** | full source with sensitivity controls | as-is | only with explicit authorization + audit |
+
+A skill in **knowledge-aware mode** asks the resolver for a capsule first. It escalates to a playbook, an excerpt, or the full source only when the task explicitly requires it and the [restricted-knowledge-usage-policy](../contracts/restricted-knowledge-usage-policy.md) allows it.
+
+---
+
+## Why capsule-first
+
+- **Lower context cost.** A capsule is small and cacheable.
+- **Lower leakage risk.** A capsule does not contain sensitive verbatim text.
+- **Lower interpretive noise.** A capsule is curated; the full source includes scaffolding the task does not need.
+- **Clearer authority.** The capsule states the source's intended scope, so an agent will not overreach.
+- **Versionable surface.** A capsule changes more slowly than the underlying source's edits.
+
+---
+
+## Capsule lifecycle
+
+- **Author** the capsule with the source's owner.
+- **Review** with at least one person not involved in authoring.
+- **Version** alongside the knowledge pack.
+- **Re-review** on the cycle declared in the manifest (`expiry.review_cycle`).
+- **Retire** when the source is deprecated or superseded.
+
+---
+
+## See also
+
+- [knowledge-governance-layer](knowledge-governance-layer.md)
+- [knowledge-resolver](knowledge-resolver.md)
+- [knowledge-pack-manifest](../contracts/knowledge-pack-manifest.md)

--- a/docs/concepts/knowledge-governance-layer.md
+++ b/docs/concepts/knowledge-governance-layer.md
@@ -1,0 +1,111 @@
+# Knowledge Governance Layer
+
+## Goal
+
+Define a layer that lets users and projects register knowledge bases (frameworks, policies, personas, research, design systems, guidelines) for use by agents and skills **without** coupling proprietary content to skills and **without** turning internal documents into raw prompt context.
+
+This layer is an extension of AletheIA's existing context discipline. It evolves the idea of *context packs* into *knowledge packs* governed by registry, manifest, precedence, and audit.
+
+---
+
+## Problem
+
+Without explicit governance over knowledge sources, four failure modes appear quickly:
+
+- skills start carrying proprietary content directly
+- internal sources are pulled wholesale into prompts
+- restricted documents leak into responses, logs, or handoffs
+- sources of very different authority are treated as equivalent
+
+The problem is not that users add knowledge. The problem is that they add it without scope, owner, version, sensitivity, authority, or usage policy.
+
+---
+
+## Principles
+
+1. **Knowledge is not raw context.** Every source is a governed object with metadata.
+2. **Skills declare dependencies; they do not carry content.** A skill states the *type* of knowledge it needs, not the document itself.
+3. **AletheIA resolves access and risk.** Decisions about which sources may be used in which task by which agent stay in the framework, not in the skill.
+4. **Capsule first.** Prefer an operational capsule of a source over the full source.
+5. **Minimum sufficient context.** Retrieve only the slice required for the task.
+6. **Sources differ in authority.** Compliance, normative guidelines, strategy, interpretive frameworks, personas, benchmarks, and stakeholder input do not weigh equally.
+7. **Restricted sources require exposure limits.** Internal, confidential, regulated, or proprietary content must not be reproduced or exported without authorization.
+8. **Every relevant use is auditable.** When a source influences a recommendation or decision, the system records source, version, scope, agent, skill, task, and outcome.
+
+---
+
+## Scope
+
+### In scope (this layer, docs-only)
+
+- a registry concept for knowledge sources
+- a manifest for knowledge packs
+- a contract for how skills declare knowledge dependencies
+- precedence policy between sources
+- usage policy for restricted sources
+- a conceptual knowledge resolver
+- audit log specification
+- examples that are generic and safe
+
+### Out of scope (for this phase)
+
+- a real vector database
+- a UI for uploads and management
+- IAM, SSO, or DLP integration
+- fine-tuning with internal content
+- formal IP governance
+- runtime enforcement code
+
+These remain future evolutions and must not block the documental groundwork.
+
+---
+
+## Relationship to context discipline
+
+AletheIA already treats context as a governed resource (see [context-graph-integration](context-graph-integration.md) and the *project-extension* pattern). The Knowledge Governance Layer is a continuation, not a replacement:
+
+| Concern | Existing layer | This layer adds |
+|---|---|---|
+| What to read | context graph, context packs | knowledge packs with manifest |
+| Why a source is allowed | task scope | source ownership, sensitivity, authority |
+| How much to read | minimum sufficient context | capsule-first, retrieval modes |
+| Where conflicts go | durable decisions | source precedence policy |
+| Trail of use | telemetry | knowledge audit log |
+
+A skill operating in *knowledge-aware mode* reuses the same minimum-sufficient-context posture; it just gets its candidate sources from a governed registry instead of an unbounded document pool.
+
+---
+
+## Relationship to the Feature Value Governance Pack
+
+The Feature Value Governance Pack is **the first consumer** of this layer, not its parent. The two have distinct responsibilities:
+
+| Concern | Owned by |
+|---|---|
+| Declaring which knowledge a feature analysis needs | Feature Value Governance (skill side) |
+| Resolving which sources fill those slots | Knowledge Governance Layer (AletheIA) |
+| Governing exposure, citation, audit, conflict | Knowledge Governance Layer (AletheIA) |
+| Executing the analysis | Adaptative Skills |
+
+The content of the Feature Value Governance Pack does **not** move into this layer. The pack continues to live where it lives; it gains a knowledge-dependency declaration and consumes whatever framework, persona, and policy packs the resolver authorizes for its tasks.
+
+---
+
+## Limits
+
+- This layer does not decide whether a source is *true*. It decides whether a source may be *used*, *cited*, *summarized*, or *exposed* in a given task.
+- This layer does not replace human judgment for high-impact decisions; it routes those to review.
+- This layer does not move enterprise-specific rules into framework core. Specific frameworks, policies, and personas live in project extensions.
+
+---
+
+## See also
+
+- [user-provided-knowledge](user-provided-knowledge.md)
+- [framework-capsules](framework-capsules.md)
+- [knowledge-resolver](knowledge-resolver.md)
+- [knowledge-source-contract](../contracts/knowledge-source-contract.md)
+- [knowledge-pack-manifest](../contracts/knowledge-pack-manifest.md)
+- [source-precedence-policy](../contracts/source-precedence-policy.md)
+- [restricted-knowledge-usage-policy](../contracts/restricted-knowledge-usage-policy.md)
+- [knowledge-audit-log-spec](../contracts/knowledge-audit-log-spec.md)

--- a/docs/concepts/knowledge-resolver.md
+++ b/docs/concepts/knowledge-resolver.md
@@ -1,0 +1,92 @@
+# Knowledge Resolver
+
+## Goal
+
+Define, conceptually, the mechanism that decides **which sources enter the context of a task**.
+
+The resolver is a logical role inside AletheIA. This document describes its inputs, decisions, outputs, and failure modes. It does not specify an implementation.
+
+---
+
+## Inputs
+
+For a given task, the resolver reads:
+
+- the **task contract** — purpose, risk, scope, audience, deliverable
+- the **skill's knowledge dependency manifest** — what types of knowledge are required, optional, or conditional
+- the **knowledge registry** — knowledge packs available to this project / agent / user
+- the **source precedence policy** — how to rank when sources conflict
+- the **restricted knowledge usage policy** — what may be retrieved and how
+- the **agent and user permissions** — scope, project, sensitivity clearance
+
+---
+
+## Decisions the resolver makes
+
+1. **Eligibility.** Which registered sources are in-scope for this task, agent, skill, and user?
+2. **Sufficiency.** Are all `required` knowledge dependencies satisfied?
+3. **Mode.** For each eligible source, which retrieval mode applies (capsule-first, excerpt-only, metadata-only, full, human-review-required, blocked)?
+4. **Selection.** Among eligible sources of the same type, which one to use? Tie-break by precedence, recency, and authority.
+5. **Composition.** How to assemble a *minimum sufficient* context pack from the selected sources.
+6. **Disclosure.** Which restrictions apply (citation required, no verbatim, no export, etc.).
+7. **Escalation.** Whether the task must pause for human review.
+
+---
+
+## Outputs
+
+The resolver returns a **knowledge-aware context pack**:
+
+- the set of selected sources with version pins
+- the retrieved scope (capsule, excerpts, metadata)
+- the active restrictions
+- the gaps (required dependencies not satisfied)
+- the conflicts detected and how precedence resolved them
+- the audit log entries to be written when the pack is used
+
+See [knowledge-aware-context-pack.json](../../examples/project-extension/knowledge-aware-context-pack.json) for a concrete shape.
+
+---
+
+## Selection logic, in order
+
+1. Filter the registry by `allowed_skills`, `allowed_agents`, project scope, and user permission.
+2. For each dependency declared by the skill, find candidates whose `type` is in `accepted_types`.
+3. Drop candidates whose `retrieval_mode` is `blocked` for this task.
+4. Drop candidates whose sensitivity exceeds the task's allowed sensitivity.
+5. Rank surviving candidates by source precedence.
+6. Apply `capsule_first` when the source allows it.
+7. Mark unsatisfied `required` dependencies as gaps; unsatisfied `optional` as assumptions.
+8. Detect conflicts between selected sources; resolve with precedence; log both the conflict and the resolution.
+
+---
+
+## When the resolver refuses
+
+The resolver must refuse — not silently fall back — when:
+
+- a `required` dependency has no eligible source
+- the only eligible source for a required type is `restricted` and not authorized for this task
+- the task crosses a sensitivity boundary not granted to the agent
+- a mandatory source (compliance, security, privacy, accessibility) conflicts with the task in a way the agent cannot resolve
+
+Refusal returns a structured reason, not a generic error. The skill then chooses between `stop_and_request_source`, `continue_with_assumption_marker`, or `request_authorized_context_pack` per its fallback behavior.
+
+---
+
+## What the resolver does not do
+
+- It does not write or evaluate the source content itself.
+- It does not adjudicate factual correctness.
+- It does not replace human review when the policy requires it.
+- It does not learn from past selections (no implicit memory beyond audit).
+
+---
+
+## See also
+
+- [knowledge-governance-layer](knowledge-governance-layer.md)
+- [framework-capsules](framework-capsules.md)
+- [skill-knowledge-dependency-contract](../contracts/skill-knowledge-dependency-contract.md)
+- [source-precedence-policy](../contracts/source-precedence-policy.md)
+- [knowledge-audit-log-spec](../contracts/knowledge-audit-log-spec.md)

--- a/docs/concepts/user-provided-knowledge.md
+++ b/docs/concepts/user-provided-knowledge.md
@@ -1,0 +1,98 @@
+# User-Provided Knowledge
+
+## Goal
+
+Describe how a user or project can add a knowledge base for use by agents and skills **without** that addition turning into a document dump in the prompt.
+
+This is the human-side surface of the [Knowledge Governance Layer](knowledge-governance-layer.md).
+
+---
+
+## What "adding knowledge" means
+
+When a user attaches a framework, policy, persona pack, research report, or design guideline to a project, they are doing four things at once — even if the UI hides it:
+
+1. **declaring a source** (file, link, internal doc)
+2. **claiming a purpose** (what tasks it should inform)
+3. **classifying it** (sensitivity, authority, owner)
+4. **constraining its use** (citation, exposure, export)
+
+If only step 1 happens, the system has a document. It does not have governed knowledge.
+
+---
+
+## What user-provided knowledge is not
+
+- It is not a system prompt extension.
+- It is not raw paste into agent context.
+- It is not a memory store.
+- It is not a fine-tuning dataset.
+- It is not an authority override for compliance, security, or accessibility sources.
+
+---
+
+## The minimum a user provides
+
+To register a base, the user supplies (or is asked for) at least:
+
+- a short name and id
+- a type (see source taxonomy in [knowledge-source-contract](../contracts/knowledge-source-contract.md))
+- an owner
+- a sensitivity level
+- an authority level
+- a scope (which task families this source is allowed to inform)
+- a retrieval mode preference (capsule-first, excerpt-only, etc.)
+- a usage policy (citation, exposure, export)
+
+This is captured in a [knowledge pack manifest](../contracts/knowledge-pack-manifest.md).
+
+---
+
+## Why not just paste the document
+
+Pasting bypasses every guardrail this layer exists for:
+
+- no version, no rollback when the document changes
+- no owner, no review cycle
+- no scope, so the document influences tasks it should not
+- no authority level, so a persona suggestion can outrank an accessibility rule
+- no audit, so no one can answer "what did this source change?"
+- no exposure limit, so restricted text can land in logs, traces, and handoffs
+
+A document without manifest is a leak waiting for a trigger.
+
+---
+
+## Progressive maturity
+
+A user does not need a full manifest on day one. The system should accept:
+
+| Level | What the user provides | What the system can do |
+|---|---|---|
+| **0 — Unregistered** | nothing | refuse to use as governed source |
+| **1 — Minimal** | id, owner, sensitivity, scope | use only in low-risk tasks, no citation, no export |
+| **2 — Operational** | + authority level, retrieval mode, capsule | use in declared scope with capsule-first |
+| **3 — Governed** | + usage policy, review cycle, audit fields | full participation under the resolver |
+
+A skill that requires governed knowledge should be unable to bind to a level-0 source. A skill that accepts minimal sources should mark its output with an *uncertainty / lower-authority* signal.
+
+---
+
+## Failure modes to make visible
+
+When user-provided knowledge cannot be used safely, the system must say so — not silently swap to a generic mode:
+
+- *"This source is not registered. Either register it or proceed in generic mode."*
+- *"This source has authority `interpretive` but the task requires a `mandatory` source. Cannot proceed without a higher-authority anchor."*
+- *"This source is `confidential`. It cannot be cited verbatim in an external-facing deliverable. Capsule-only mode applied."*
+
+Loud refusal is a feature.
+
+---
+
+## See also
+
+- [framework-capsules](framework-capsules.md)
+- [knowledge-resolver](knowledge-resolver.md)
+- [knowledge-pack-manifest](../contracts/knowledge-pack-manifest.md)
+- [restricted-knowledge-usage-policy](../contracts/restricted-knowledge-usage-policy.md)

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -20,6 +20,12 @@ If you need conceptual background, see [`concepts/`](../concepts/README.md). If 
 | [work-slice-spec-bundle.md](work-slice-spec-bundle.md) | Optional spec bundle for slices that need pre-execution clarity |
 | [durable-decision-finalization-context-prompt.md](durable-decision-finalization-context-prompt.md) | Accepted durable decision: require finalization context prompt at slice close |
 | [consumer-project-overlay.md](consumer-project-overlay.md) | How a consumer project instantiates the operating overlay (`ops/ai/` + harness shims). Reference example: [`examples/consumer-overlay-minimal/`](../../examples/consumer-overlay-minimal/) |
+| [knowledge-source-contract.md](knowledge-source-contract.md) | What every knowledge source must satisfy to be governed by the Knowledge Governance Layer |
+| [knowledge-pack-manifest.md](knowledge-pack-manifest.md) | YAML manifest schema for a knowledge pack on disk |
+| [skill-knowledge-dependency-contract.md](skill-knowledge-dependency-contract.md) | How a skill declares knowledge it needs without binding to a specific source |
+| [source-precedence-policy.md](source-precedence-policy.md) | How conflicts between knowledge sources are resolved |
+| [restricted-knowledge-usage-policy.md](restricted-knowledge-usage-policy.md) | Usage rules for confidential, restricted, and regulated sources |
+| [knowledge-audit-log-spec.md](knowledge-audit-log-spec.md) | Minimum audit fields when a knowledge source influences output |
 
 ### Bootstrap contracts — note on relationship
 

--- a/docs/contracts/knowledge-audit-log-spec.md
+++ b/docs/contracts/knowledge-audit-log-spec.md
@@ -1,0 +1,138 @@
+# Knowledge Audit Log — Specification
+
+## Goal
+
+Define the minimum information that must be recorded each time a knowledge source influences an agent or skill output.
+
+The audit log makes it possible to answer, after the fact: *which source, at what version, in what scope, under what restrictions, produced what outcome — by which agent and skill, for which task.*
+
+---
+
+## When to write an entry
+
+Write a log entry when:
+
+- a knowledge pack is **selected** by the resolver for a task
+- a knowledge pack is **consulted** during execution (capsule, excerpt, or full)
+- a **conflict** between sources is detected and resolved
+- a **fallback** is triggered (missing required, restricted, etc.)
+- a **human review** request is raised
+- a **refusal** is returned by the resolver or the skill
+
+Do not log restricted excerpts themselves. Log identifiers, versions, scopes, and decisions.
+
+---
+
+## Required fields
+
+| Field | Notes |
+|---|---|
+| `task_id` | the task under execution |
+| `agent_id` | the agent that ran the skill |
+| `skill_id` | the skill that consumed the source |
+| `skill_version` | semver |
+| `source_id` | knowledge pack id |
+| `source_version` | semver of the pack consumed |
+| `sensitivity` | snapshot at use time |
+| `authority_level` | snapshot at use time |
+| `retrieved_scope` | one of `capsule`, `excerpt`, `metadata`, `full` |
+| `retrieval_mode_applied` | which mode the resolver actually used |
+| `restrictions_applied` | list (e.g. `no_verbatim`, `no_export`, `citation_required`) |
+| `human_review_required` | boolean |
+| `human_review_reason` | required when the boolean is true |
+| `decision_output` | short structured summary of the effect on the deliverable |
+| `conflict_id` | optional; links to conflict resolution entries |
+| `prevailing_source` / `suppressed_sources` | optional; used in conflict entries |
+| `fallback_applied` | optional; values from skill `fallback_behavior` |
+| `refusal_reason` | optional; required when the entry records a refusal |
+| `timestamp` | ISO 8601 UTC |
+
+---
+
+## Optional but recommended
+
+- `user_id` — actor who initiated the task
+- `project_id` / `workspace_id` — scope boundary
+- `trust_boundary` — local label for the boundary this task ran inside
+- `pack_integrity_hash` — content hash of the consumed slice (capsule digest, not full source)
+- `resolver_version` — useful when policies evolve
+
+---
+
+## Example entry — normal use
+
+```json
+{
+  "task_id": "task_2026-05-28_feat-001",
+  "agent_id": "product-agent",
+  "skill_id": "feature-value-governance",
+  "skill_version": "0.1.0",
+  "source_id": "example-4-layers",
+  "source_version": "1.0.0",
+  "sensitivity": "internal",
+  "authority_level": "interpretive",
+  "retrieved_scope": "capsule",
+  "retrieval_mode_applied": "capsule_first",
+  "restrictions_applied": ["no_verbatim", "no_export", "citation_required"],
+  "human_review_required": false,
+  "decision_output": "Used 4-layers capsule to frame revenue-lever analysis.",
+  "timestamp": "2026-05-28T12:55:00Z"
+}
+```
+
+## Example entry — conflict
+
+```json
+{
+  "task_id": "task_2026-05-28_feat-001",
+  "agent_id": "design-agent",
+  "skill_id": "knowledge-conflict-resolution",
+  "skill_version": "0.1.0",
+  "conflict_id": "conflict_2026-05-28_001",
+  "prevailing_source": "wcag-internal@1.2.0",
+  "suppressed_sources": ["casual-shopper@0.4.0"],
+  "decision_output": "Kept explicit form labels per accessibility guideline.",
+  "human_review_required": false,
+  "timestamp": "2026-05-28T12:56:10Z"
+}
+```
+
+## Example entry — refusal
+
+```json
+{
+  "task_id": "task_2026-05-28_feat-001",
+  "agent_id": "product-agent",
+  "skill_id": "feature-value-governance",
+  "skill_version": "0.1.0",
+  "source_id": "internal-pricing-policy",
+  "source_version": "2.3.0",
+  "sensitivity": "confidential",
+  "authority_level": "mandatory",
+  "retrieved_scope": "metadata",
+  "retrieval_mode_applied": "blocked",
+  "refusal_reason": "External deliverable; full_text_exposure forbidden and no authorized excerpt available.",
+  "human_review_required": true,
+  "human_review_reason": "Client delivery flagged in human_review_required_for.",
+  "timestamp": "2026-05-28T12:57:42Z"
+}
+```
+
+---
+
+## Storage posture
+
+This spec does not mandate a storage technology. Any store is acceptable that:
+
+- preserves entries for the retention period required by the most sensitive source touched
+- supports filtering by `task_id`, `source_id`, `agent_id`, and `human_review_required`
+- does not retain restricted excerpts beyond their authorized lifetime
+- can be exported for review without exposing restricted text
+
+---
+
+## See also
+
+- [knowledge-source-contract](knowledge-source-contract.md)
+- [restricted-knowledge-usage-policy](restricted-knowledge-usage-policy.md)
+- [source-precedence-policy](source-precedence-policy.md)

--- a/docs/contracts/knowledge-pack-manifest.md
+++ b/docs/contracts/knowledge-pack-manifest.md
@@ -1,0 +1,153 @@
+# Knowledge Pack Manifest
+
+## Goal
+
+Specify the conceptual YAML manifest that represents a knowledge pack on disk. A pack is the unit registered in the [knowledge registry](../concepts/knowledge-governance-layer.md) and resolved by the [knowledge resolver](../concepts/knowledge-resolver.md).
+
+This is a documental contract. There is no runtime parser yet.
+
+---
+
+## Pack directory layout (recommended)
+
+```text
+knowledge-packs/
+  <pack-id>/
+    manifest.yaml
+    capsule.md
+    usage-policy.md
+    version-history.md
+    source-map.md
+    full-source.md          # OR source-link.md, depending on policy
+    examples/
+```
+
+Files beyond `manifest.yaml` and `capsule.md` are optional but recommended.
+
+---
+
+## Manifest schema (conceptual)
+
+```yaml
+knowledge_pack:
+  # Identity
+  id: <kebab-case-id>                 # required, unique within project/org
+  name: <human-readable>              # required
+  type: <source_type>                 # required; see knowledge-source-contract
+  owner: <person-or-team>             # required
+  version: <semver>                   # required
+
+  # Classification
+  sensitivity: public | internal | confidential | restricted | regulated   # required
+  authority_level: mandatory | normative | procedural | strategic | interpretive | evidence_proxy | evidential | comparative | contextual   # required
+
+  # Use
+  scope:                              # required; task families the source informs
+    - <scope-tag>
+  allowed_skills:                     # optional allowlist; empty = governed by scope only
+    - <skill-id>
+  allowed_agents:                     # optional allowlist
+    - <agent-id>
+
+  # Retrieval
+  retrieval_mode: capsule_first | excerpt_only | metadata_only | full_source_allowed | human_review_required | blocked   # required
+  citation_required: true | false     # required
+  full_text_exposure: allowed | forbidden | conditional   # required
+  export_allowed: true | false        # required
+
+  # Review
+  human_review_required_for:          # required list (may be empty)
+    - external_publication
+    - client_delivery
+    - policy_conflict
+  expiry:
+    review_cycle: weekly | monthly | quarterly | yearly   # required
+    expires_on: <ISO date or null>    # required
+
+  # Provenance
+  source_location: <link | path | registry-ref>   # required
+  source_integrity_notes: |           # required, free text
+    How authenticity and provenance are established for this source.
+
+  # Optional
+  prerequisite_sources: []
+  supersedes: []
+  tags: []
+```
+
+---
+
+## Worked example (generic)
+
+```yaml
+knowledge_pack:
+  id: example-4-layers
+  name: Example Strategic Framework
+  type: proprietary_framework
+  owner: example-owner
+  version: 1.0.0
+
+  sensitivity: private              # treat as "internal" in this taxonomy
+  authority_level: interpretive
+
+  scope:
+    - business_design
+    - product_strategy
+    - feature_governance
+
+  allowed_skills:
+    - strategic-value-analysis
+    - feature-value-governance
+    - opportunity-tree-alignment
+  allowed_agents:
+    - product-agent
+    - business-design-agent
+    - design-agent
+
+  retrieval_mode: capsule_first
+  citation_required: true
+  full_text_exposure: forbidden
+  export_allowed: false
+
+  human_review_required_for:
+    - external_publication
+    - client_delivery
+    - policy_conflict
+
+  expiry:
+    review_cycle: quarterly
+    expires_on: null
+
+  source_location: knowledge-packs/example-4-layers/full-source.md
+  source_integrity_notes: |
+    Maintained by the example-owner. Changes tracked in version-history.md.
+    Capsule reviewed alongside every minor version bump.
+```
+
+> Note: the sensitivity vocabulary in this manifest uses the framework taxonomy (`public | internal | confidential | restricted | regulated`). If a project uses local labels (e.g. `private`), it should map them explicitly in its project extension.
+
+---
+
+## Validation rules (documental)
+
+A manifest is *well-formed* when:
+
+- all required fields are present
+- `type` is a known source type
+- `sensitivity` and `authority_level` use the defined vocabularies
+- `retrieval_mode` is one of the six defined modes
+- if `retrieval_mode: capsule_first`, a `capsule.md` exists
+- if `full_text_exposure: forbidden`, no examples include verbatim source text
+- if `sensitivity` is `restricted` or `regulated`, `human_review_required_for` is not empty
+- `expiry.review_cycle` is set even when `expires_on` is null
+
+A manifest that fails validation is registered at *minimal* maturity only.
+
+---
+
+## See also
+
+- [knowledge-source-contract](knowledge-source-contract.md)
+- [skill-knowledge-dependency-contract](skill-knowledge-dependency-contract.md)
+- [restricted-knowledge-usage-policy](restricted-knowledge-usage-policy.md)
+- [knowledge-audit-log-spec](knowledge-audit-log-spec.md)

--- a/docs/contracts/knowledge-source-contract.md
+++ b/docs/contracts/knowledge-source-contract.md
@@ -1,0 +1,107 @@
+# Knowledge Source Contract
+
+## Goal
+
+Define the contract that every knowledge source must satisfy to be usable by agents and skills under the [Knowledge Governance Layer](../concepts/knowledge-governance-layer.md).
+
+This is a conceptual contract. The on-disk shape lives in [knowledge-pack-manifest](knowledge-pack-manifest.md).
+
+---
+
+## Required fields
+
+| Field | Meaning |
+|---|---|
+| `id` | stable, kebab-case identifier, unique inside the project / org |
+| `name` | human-readable name |
+| `type` | one value from the source taxonomy below |
+| `owner` | accountable person or team for accuracy, review, and retirement |
+| `version` | semver; bump on any content or scope change |
+| `sensitivity` | one of `public`, `internal`, `confidential`, `restricted`, `regulated` |
+| `authority_level` | one of `mandatory`, `normative`, `procedural`, `strategic`, `interpretive`, `evidence_proxy`, `evidential`, `comparative`, `contextual` |
+| `scope` | task families or domains the source is allowed to inform |
+| `retrieval_mode` | default mode: `capsule_first`, `excerpt_only`, `metadata_only`, `full_source_allowed`, `human_review_required`, `blocked` |
+| `citation_required` | boolean; whether outputs must cite the source |
+| `full_text_exposure` | `allowed`, `forbidden`, or `conditional` |
+| `export_allowed` | boolean; whether content may leave the workspace |
+| `human_review_required_for` | list of conditions that force human review |
+| `expiry.review_cycle` | how often the source must be re-validated |
+| `source_location` | how to reach the underlying source (link, path, registry ref) |
+| `source_integrity_notes` | how the source's authenticity / provenance is established |
+
+Optional:
+
+- `allowed_skills`, `allowed_agents` — explicit allowlists
+- `prerequisite_sources` — other packs that must be present
+- `supersedes` — packs this one replaces
+
+---
+
+## Source taxonomy
+
+```yaml
+source_types:
+  compliance_policy:        { authority: mandatory,             precedence: highest }
+  security_policy:          { authority: mandatory,             precedence: highest }
+  privacy_policy:           { authority: mandatory,             precedence: highest }
+  accessibility_guideline:  { authority: normative,             precedence: very_high }
+  operating_model:          { authority: procedural,            precedence: high }
+  product_strategy:         { authority: strategic,             precedence: high }
+  proprietary_framework:    { authority: interpretive,          precedence: medium_high }
+  design_system:            { authority: normative_or_guiding,  precedence: high }
+  persona:                  { authority: evidence_proxy,        precedence: medium }
+  research_finding:         { authority: evidential,            precedence: depends_on_quality }
+  benchmark:                { authority: comparative,           precedence: low_medium }
+  stakeholder_input:        { authority: contextual,            precedence: variable }
+```
+
+The taxonomy is intentionally small. Project extensions may *bind* their own concrete sources to these types but must not invent new top-level authority semantics in framework core.
+
+---
+
+## Sensitivity levels
+
+| Level | Citation | Exposure | Export | Logs / handoffs | Human review |
+|---|---|---|---|---|---|
+| **public** | free under general policy | allowed | allowed | unrestricted | not required |
+| **internal** | within project/org | summary only outside | discouraged | masked if cross-boundary | only if conflict |
+| **confidential** | only to authorized recipients | capsule-only by default | forbidden by default | masked | required for external delivery |
+| **restricted** | per explicit authorization | highly limited | forbidden | redacted | always required for use beyond reading |
+| **regulated** | per legal / regulatory rules | per regulation | typically forbidden | per regulation | always required |
+
+Higher sensitivity does **not** mean higher authority. A `regulated` persona is still a persona, not a policy.
+
+---
+
+## Authority semantics
+
+- **Mandatory** sources cannot be overridden by interpretation. Conflicts route to human review or refusal, never to silent compromise.
+- **Normative** sources set the default; deviations require explicit justification.
+- **Procedural** sources describe how work flows; they can be adapted but not ignored.
+- **Strategic** sources set direction; they constrain prioritization, not correctness.
+- **Interpretive** sources help reasoning; they do not constrain compliance.
+- **Evidence proxy / evidential** sources inform but do not bind.
+- **Comparative / contextual** sources support, never settle.
+
+---
+
+## Acceptance posture
+
+A source enters the registry only when:
+
+1. all required fields are present and consistent
+2. owner has acknowledged accountability
+3. sensitivity and authority have been reviewed by someone other than the author
+4. a capsule exists for any source whose default `retrieval_mode` is `capsule_first`
+5. `source_integrity_notes` make the provenance auditable
+
+A source that fails any of these is registered at *minimal* maturity (see [user-provided-knowledge](../concepts/user-provided-knowledge.md)) and is not eligible for tasks that require `governed` maturity.
+
+---
+
+## See also
+
+- [knowledge-pack-manifest](knowledge-pack-manifest.md)
+- [skill-knowledge-dependency-contract](skill-knowledge-dependency-contract.md)
+- [source-precedence-policy](source-precedence-policy.md)
+- [restricted-knowledge-usage-policy](restricted-knowledge-usage-policy.md)

--- a/docs/contracts/restricted-knowledge-usage-policy.md
+++ b/docs/contracts/restricted-knowledge-usage-policy.md
@@ -1,0 +1,89 @@
+# Restricted Knowledge Usage Policy
+
+## Goal
+
+Define usage rules for knowledge sources that are **internal**, **confidential**, **restricted**, **regulated**, or otherwise sensitive — including proprietary frameworks the organization does not want exposed verbatim.
+
+This policy applies in addition to the [knowledge-source-contract](knowledge-source-contract.md) and is enforced by the [knowledge-resolver](../concepts/knowledge-resolver.md).
+
+---
+
+## What restricted means here
+
+"Restricted" is shorthand for any source whose `sensitivity` is `internal`, `confidential`, `restricted`, or `regulated`. The exact controls depend on the level (see the sensitivity table in [knowledge-source-contract](knowledge-source-contract.md)).
+
+---
+
+## What may be done with a restricted source
+
+| Action | internal | confidential | restricted | regulated |
+|---|---|---|---|---|
+| Consult capsule | yes | yes | yes if authorized | yes if authorized |
+| Cite identifier (id + version) | yes | yes | yes if authorized | per regulation |
+| Quote verbatim excerpts | discouraged | only with authorization | no by default | per regulation |
+| Reproduce full source | no | no | no | no |
+| Include in external deliverables | summary only | no | no | no |
+| Include in logs / handoffs | yes if masked at boundary | masked | redacted | per regulation |
+| Export outside workspace | discouraged | no | no | no |
+
+When the table forbids an action, the resolver must surface the limit as a structured restriction in the context pack, not silently drop the action.
+
+---
+
+## When human review is required
+
+Human review is mandatory when at least one of the following is true:
+
+- the source is used in an **external publication** or **client delivery**
+- the use would create a **policy conflict** between mandatory sources
+- the source's `human_review_required_for` list matches the task
+- the resolver cannot determine sensitivity with confidence
+- the task crosses **trust boundaries** (project, client, organization)
+- the source is `regulated` and used in a decision with legal or financial impact
+
+A skill must pause and surface a review request. It must not produce a final deliverable while review is pending.
+
+---
+
+## Logs, handoffs, and traces
+
+Restricted content is easy to lose at the edges. The policy explicitly covers them:
+
+- **Logs.** Do not write restricted excerpts to logs. Log identifiers, versions, scope, and decisions instead.
+- **Handoffs.** Strip restricted excerpts when handing off across agents, threads, or boundaries. Replace with capsule + pack id + version.
+- **Traces / telemetry.** Same as logs. If a trace captures prompt and response, mask restricted segments.
+- **Long-term memory.** Do not persist restricted excerpts into agent or session memory.
+
+If a system cannot honor these rules, it must refuse to operate on the source rather than degrade silently.
+
+---
+
+## Refusal patterns
+
+When a use violates this policy, the resolver returns one of:
+
+- `request_authorized_context_pack` — the task is plausible but needs explicit authorization
+- `downgrade_to_capsule` — the task can continue with the capsule alone
+- `refuse` — the task cannot proceed under current permissions
+
+Refusals must include: source id, version, sensitivity, authority, scope, and the specific rule violated.
+
+---
+
+## What this policy is not
+
+- It is not a substitute for IAM, DLP, or encryption at rest / in transit.
+- It is not legal advice for any specific regulation.
+- It is not a license framework.
+- It is operational discipline for how an agent fleet handles sensitive sources.
+
+Integrations with IAM, DLP, secrets management, and review workflows are explicit future work and are out of scope for this docs-only phase.
+
+---
+
+## See also
+
+- [knowledge-source-contract](knowledge-source-contract.md)
+- [source-precedence-policy](source-precedence-policy.md)
+- [knowledge-audit-log-spec](knowledge-audit-log-spec.md)
+- [restricted-enterprise-context (example)](../../examples/project-extension/restricted-enterprise-context.md)

--- a/docs/contracts/skill-knowledge-dependency-contract.md
+++ b/docs/contracts/skill-knowledge-dependency-contract.md
@@ -1,0 +1,130 @@
+# Skill Knowledge Dependency Contract
+
+## Goal
+
+Define how a skill declares the knowledge it needs **without** pointing at a specific source.
+
+A skill declares *types* of knowledge. The [knowledge resolver](../concepts/knowledge-resolver.md) decides which concrete pack — if any — satisfies the dependency under the active permissions and policies.
+
+---
+
+## Principles
+
+1. A skill states **what kind** of knowledge it needs, not **which document**.
+2. A skill never embeds proprietary content. Procedure goes in the skill; content lives in a knowledge pack.
+3. A skill must declare what it does when a dependency cannot be satisfied (`fallback_behavior`).
+4. A skill must operate in **generic mode** when no governed source is available, unless the dependency is `required` and the skill has chosen `stop_and_request_source`.
+
+---
+
+## Schema (conceptual)
+
+```yaml
+skill: <skill-id>
+version: <semver>
+
+knowledge_dependencies:
+  <dependency-key>:
+    required: true | false                # default false
+    required_when:                         # optional; conditional requirement
+      - <task-trigger>
+    accepted_types:                        # source types that can satisfy this
+      - <source_type>
+    min_authority: <authority_level>       # optional floor
+    preferred_retrieval_mode: <mode>       # optional hint to resolver
+    notes: <free text>                     # optional
+
+fallback_behavior:
+  missing_required_source: stop_and_request_source | continue_in_generic_mode | abort
+  missing_optional_source: continue_with_assumption_marker | omit_silently
+  restricted_source: request_authorized_context_pack | downgrade_to_capsule | refuse
+  conflicting_sources: apply_source_precedence_policy | escalate_to_human_review
+```
+
+`dependency-key` is a skill-meaningful slot name (e.g. `strategic_framework`, `personas`, `accessibility_guidelines`). It is not a source id.
+
+---
+
+## Required vs. optional vs. conditional
+
+- **required: true** — the skill cannot produce its expected output without this knowledge type. The resolver must satisfy it or the fallback fires.
+- **required: false** — the skill produces useful output without it; if present, output improves.
+- **required_when** — required only when listed task triggers match. Useful for accessibility, privacy, or compliance dependencies that activate by task shape.
+
+---
+
+## Worked example
+
+```yaml
+skill: feature-value-governance
+version: 0.1.0
+
+knowledge_dependencies:
+  strategic_framework:
+    required: true
+    accepted_types:
+      - proprietary_framework
+      - product_strategy
+      - business_design_framework
+    min_authority: interpretive
+
+  personas:
+    required: false
+    accepted_types:
+      - persona
+      - research_finding
+
+  accessibility_guidelines:
+    required_when:
+      - interface_change
+      - content_decision
+      - navigation_decision
+      - customer_facing_experience
+    accepted_types:
+      - accessibility_guideline
+    min_authority: normative
+
+  operating_model:
+    required_when:
+      - roadmap_decision
+      - prioritization_decision
+      - governance_decision
+    accepted_types:
+      - operating_model
+
+fallback_behavior:
+  missing_required_source: stop_and_request_source
+  missing_optional_source: continue_with_assumption_marker
+  restricted_source: request_authorized_context_pack
+  conflicting_sources: apply_source_precedence_policy
+```
+
+---
+
+## Output expectations
+
+A knowledge-aware skill must surface, in its output:
+
+- which knowledge slots were satisfied and by which pack `id@version`
+- which slots were unsatisfied and how the fallback was applied
+- which restrictions were active (e.g. capsule-only, no verbatim, no export)
+- any conflicts detected and how precedence resolved them
+
+This makes the audit trail (see [knowledge-audit-log-spec](knowledge-audit-log-spec.md)) reconstructable from the skill output alone.
+
+---
+
+## What a skill must not do
+
+- declare a specific source `id` as a dependency (breaks portability and governance)
+- carry a copy of source content inside `skill.md` or its templates
+- bypass `fallback_behavior` by improvising context from the agent's prior memory
+- assume that a missing optional source is equivalent to "the source agrees with me"
+
+---
+
+## See also
+
+- [knowledge-pack-manifest](knowledge-pack-manifest.md)
+- [knowledge-resolver](../concepts/knowledge-resolver.md)
+- [source-precedence-policy](source-precedence-policy.md)

--- a/docs/contracts/source-precedence-policy.md
+++ b/docs/contracts/source-precedence-policy.md
@@ -1,0 +1,102 @@
+# Source Precedence Policy
+
+## Goal
+
+Define the policy that resolves conflict between knowledge sources used in the same task.
+
+Conflict resolution is part of the framework core. The list of concrete sources is not. Projects bind their packs to the types below; the precedence between types is stable.
+
+---
+
+## Default precedence
+
+From highest to lowest:
+
+1. **Legal, compliance, security, privacy, and mandatory accessibility sources.**
+2. **Formal corporate policies.**
+3. **Organizational operating model.**
+4. **Product or business strategy.**
+5. **Proprietary supporting frameworks.**
+6. **Personas, research findings, and user evidence.**
+7. **Benchmarks and external references.**
+8. **Stakeholder preferences and contextual input.**
+
+A source in a higher tier overrides a source in a lower tier *in the dimension of conflict*. It does not erase the lower source; it constrains it.
+
+---
+
+## How the resolver applies precedence
+
+1. Identify that two or more selected sources disagree on a decision-relevant point.
+2. Locate each source's tier (via `type` → tier mapping below).
+3. The higher-tier source's position is taken.
+4. The lower-tier source is preserved as **context**, not authority.
+5. The conflict, the chosen source, and the suppressed source are written to the audit log.
+6. If the higher source is `mandatory` and the lower source's removal materially changes the deliverable, escalate to human review per `human_review_required_for`.
+
+---
+
+## Type-to-tier mapping
+
+| Tier | Source types |
+|---|---|
+| 1 | `compliance_policy`, `security_policy`, `privacy_policy`, `accessibility_guideline` (when normative) |
+| 2 | corporate policies expressed as `operating_model` with `authority: mandatory` |
+| 3 | `operating_model` |
+| 4 | `product_strategy` |
+| 5 | `proprietary_framework`, `design_system` (when guiding) |
+| 6 | `persona`, `research_finding` |
+| 7 | `benchmark` |
+| 8 | `stakeholder_input` |
+
+Within a tier, break ties by, in order:
+
+1. higher `authority_level`
+2. narrower, more specific `scope`
+3. more recent `version` (only when both are still inside `expiry`)
+4. explicit `prerequisite_sources` / `supersedes` relationships
+
+---
+
+## Worked conflict
+
+```text
+Detected:
+  - persona "casual-shopper" suggests removing inline labels for visual minimalism.
+  - accessibility_guideline "wcag-2.1-aa-internal" requires explicit labels on every form field.
+
+Tiers:
+  - persona → tier 6
+  - accessibility_guideline → tier 1
+
+Resolution:
+  - accessibility_guideline prevails.
+  - persona preserved as design context, not as authority.
+  - Output must keep explicit labels; the simplification must be redesigned without removing them.
+
+Audit:
+  - conflict_id: <uuid>
+  - prevailing_source: wcag-2.1-aa-internal@<version>
+  - suppressed_sources: [casual-shopper@<version>]
+  - human_review_required: false
+```
+
+---
+
+## When precedence is not enough
+
+Precedence resolves *which source wins*. It does not resolve cases where:
+
+- two sources at the same tier disagree and tie-breakers do not settle it
+- a `mandatory` source conflicts with another `mandatory` source (e.g. privacy vs. accessibility)
+- the lower source's removal makes the deliverable infeasible
+
+In these cases the resolver must **escalate to human review** with a structured conflict record. Skills must not invent a compromise.
+
+---
+
+## See also
+
+- [restricted-knowledge-usage-policy](restricted-knowledge-usage-policy.md)
+- [knowledge-audit-log-spec](knowledge-audit-log-spec.md)
+- [knowledge-resolver](../concepts/knowledge-resolver.md)

--- a/examples/project-extension/README.md
+++ b/examples/project-extension/README.md
@@ -1,0 +1,23 @@
+# Project Extension — Examples
+
+Generic, safe examples that illustrate how a project can extend AletheIA locally without distorting the framework core.
+
+These examples are **not** real policies, frameworks, or personas. They are minimal demonstrations of shape and posture.
+
+## Contents
+
+| File | What it shows |
+|---|---|
+| [restricted-enterprise-context.md](restricted-enterprise-context.md) | How a constrained enterprise project layers local rules on top of the framework |
+| [local-trust-boundary-mapping.md](local-trust-boundary-mapping.md) | A small posture mapping for data class, model, and tool permission |
+| [proprietary-framework-pack-example.md](proprietary-framework-pack-example.md) | A proprietary framework registered as a knowledge pack (manifest + capsule) |
+| [internal-policy-pack-example.md](internal-policy-pack-example.md) | An internal policy registered as a knowledge pack with `excerpt_only` retrieval |
+| [persona-pack-example.md](persona-pack-example.md) | A persona registered as an `evidence_proxy` source |
+| [knowledge-aware-context-pack.json](knowledge-aware-context-pack.json) | Resolver output: which slots got filled, conflicts, restrictions, audit hints |
+
+## Related
+
+- [Knowledge Governance Layer](../../docs/concepts/knowledge-governance-layer.md)
+- [Knowledge Pack Manifest contract](../../docs/contracts/knowledge-pack-manifest.md)
+- [Source Precedence Policy](../../docs/contracts/source-precedence-policy.md)
+- [Restricted Knowledge Usage Policy](../../docs/contracts/restricted-knowledge-usage-policy.md)

--- a/examples/project-extension/internal-policy-pack-example.md
+++ b/examples/project-extension/internal-policy-pack-example.md
@@ -1,0 +1,102 @@
+# Internal Policy Pack — Example
+
+## Goal
+
+Show a generic example of an internal policy registered as a knowledge pack. The policy below is fictional. Do not reuse phrasings as if they were a real corporate document.
+
+---
+
+## manifest.yaml
+
+```yaml
+knowledge_pack:
+  id: example-internal-data-handling
+  name: Example Internal Data Handling Policy
+  type: operating_model            # corporate procedural authority
+  owner: example-policy-owner
+  version: 2.1.0
+
+  sensitivity: confidential
+  authority_level: procedural
+
+  scope:
+    - data_processing_decisions
+    - vendor_review
+    - product_features_touching_customer_data
+
+  allowed_skills:
+    - restricted-context-check
+    - knowledge-conflict-resolution
+    - feature-value-governance
+  allowed_agents:
+    - product-agent
+    - business-design-agent
+
+  retrieval_mode: excerpt_only
+  citation_required: true
+  full_text_exposure: conditional
+  export_allowed: false
+
+  human_review_required_for:
+    - external_publication
+    - client_delivery
+    - policy_conflict
+    - vendor_onboarding
+
+  expiry:
+    review_cycle: yearly
+    expires_on: 2027-05-28
+
+  source_location: internal-policy-repo://policies/data-handling
+  source_integrity_notes: |
+    Authoritative copy held in the internal policy repository. Pack mirrors
+    metadata and capsule only. Excerpts are pulled on demand under access control.
+```
+
+---
+
+## capsule.md (excerpt, generic)
+
+```markdown
+# Example Internal Data Handling — Capsule
+
+## Purpose
+Set procedural rules for how features handle, store, and share data classified as internal or confidential.
+
+## When this policy is in scope
+- A feature touches customer data, vendor data, or internal operational data.
+- A change alters retention, sharing, or export behavior.
+- A vendor is being evaluated for access to data in scope.
+
+## Operating rules (summarized)
+- Minimize data captured to what the feature demonstrably needs.
+- Default retention to the shortest period acceptable for the use case.
+- Sharing across trust boundaries requires named justification and review.
+
+## Limits
+- Procedural, not legal. Defers to compliance and privacy policy where they apply.
+- Does not authorize new categories of data collection.
+
+## Expected output when this policy is consulted
+- Which provisions of the policy apply.
+- Where the proposed change is aligned.
+- Where the proposed change requires escalation.
+```
+
+---
+
+## What this example demonstrates
+
+- An internal policy enters the layer as a **confidential, procedural** source.
+- It uses **`excerpt_only`** retrieval — agents may pull narrow excerpts under access control, never the full text.
+- `full_text_exposure: conditional` means exposure is decided per task by the resolver, not by the skill.
+- The pack is bound to a small set of governance skills, not to general production skills.
+- Any conflict with a `mandatory` source (compliance, security, privacy) escalates per the [source-precedence-policy](../../docs/contracts/source-precedence-policy.md).
+
+---
+
+## What this example is not
+
+- It is not a real corporate policy.
+- It is not a redistribution template.
+- It is not a substitute for the policy's authoritative copy in the internal policy repository.

--- a/examples/project-extension/knowledge-aware-context-pack.json
+++ b/examples/project-extension/knowledge-aware-context-pack.json
@@ -1,0 +1,106 @@
+{
+  "$comment": "Example output of the knowledge-resolver for a knowledge-aware skill. Generic and safe. Not a runtime artifact.",
+  "context_pack_version": "0.1.0",
+  "task": {
+    "id": "task_2026-05-28_feat-001",
+    "purpose": "Decide whether the proposed checkout simplification should ship as-is.",
+    "audience": "internal_review",
+    "risk_class": "medium",
+    "scope_tags": [
+      "feature_governance",
+      "customer_facing_experience",
+      "interface_change"
+    ]
+  },
+  "agent": {
+    "id": "product-agent",
+    "trust_boundary": "project-acme-internal"
+  },
+  "skill": {
+    "id": "feature-value-governance",
+    "version": "0.1.0",
+    "mode": "knowledge_aware"
+  },
+  "knowledge_dependencies_resolution": {
+    "strategic_framework": {
+      "required": true,
+      "satisfied_by": {
+        "source_id": "example-4-layers",
+        "source_version": "1.0.0",
+        "retrieved_scope": "capsule",
+        "retrieval_mode_applied": "capsule_first"
+      }
+    },
+    "personas": {
+      "required": false,
+      "satisfied_by": {
+        "source_id": "example-persona-casual-shopper",
+        "source_version": "0.4.0",
+        "retrieved_scope": "capsule",
+        "retrieval_mode_applied": "capsule_first"
+      }
+    },
+    "accessibility_guidelines": {
+      "required_when_matched": true,
+      "satisfied_by": {
+        "source_id": "wcag-internal",
+        "source_version": "1.2.0",
+        "retrieved_scope": "excerpt",
+        "retrieval_mode_applied": "excerpt_only"
+      }
+    },
+    "operating_model": {
+      "required_when_matched": false,
+      "satisfied_by": null,
+      "fallback_applied": "omit_silently"
+    }
+  },
+  "restrictions_active": [
+    "no_verbatim_for:example-4-layers",
+    "no_export_for:example-4-layers",
+    "citation_required_for:example-4-layers",
+    "citation_required_for:wcag-internal"
+  ],
+  "conflicts_detected": [
+    {
+      "conflict_id": "conflict_2026-05-28_001",
+      "between": [
+        "example-persona-casual-shopper@0.4.0",
+        "wcag-internal@1.2.0"
+      ],
+      "topic": "explicit form labels on checkout fields",
+      "resolved_by": "source_precedence_policy",
+      "prevailing_source": "wcag-internal@1.2.0",
+      "suppressed_sources": ["example-persona-casual-shopper@0.4.0"],
+      "human_review_required": false
+    }
+  ],
+  "gaps": [],
+  "human_review": {
+    "required": false,
+    "reasons": []
+  },
+  "audit_log_entries_to_write": [
+    {
+      "source_id": "example-4-layers",
+      "source_version": "1.0.0",
+      "retrieved_scope": "capsule",
+      "sensitivity": "internal",
+      "authority_level": "interpretive"
+    },
+    {
+      "source_id": "example-persona-casual-shopper",
+      "source_version": "0.4.0",
+      "retrieved_scope": "capsule",
+      "sensitivity": "internal",
+      "authority_level": "evidence_proxy"
+    },
+    {
+      "source_id": "wcag-internal",
+      "source_version": "1.2.0",
+      "retrieved_scope": "excerpt",
+      "sensitivity": "internal",
+      "authority_level": "normative"
+    }
+  ]
+}

--- a/examples/project-extension/persona-pack-example.md
+++ b/examples/project-extension/persona-pack-example.md
@@ -1,0 +1,97 @@
+# Persona Pack — Example
+
+## Goal
+
+Show a generic example of a persona registered as a knowledge pack. The persona below is fictional.
+
+---
+
+## manifest.yaml
+
+```yaml
+knowledge_pack:
+  id: example-persona-casual-shopper
+  name: Example Persona — Casual Shopper
+  type: persona
+  owner: example-research-owner
+  version: 0.4.0
+
+  sensitivity: internal
+  authority_level: evidence_proxy
+
+  scope:
+    - product_feature_decisions
+    - ux_research_referencing
+    - opportunity_framing
+
+  allowed_skills:
+    - feature-value-governance
+    - ux-strategy
+    - ux-provocation
+  allowed_agents:
+    - product-agent
+    - design-agent
+
+  retrieval_mode: capsule_first
+  citation_required: true
+  full_text_exposure: allowed
+  export_allowed: true
+
+  human_review_required_for:
+    - policy_conflict
+
+  expiry:
+    review_cycle: quarterly
+    expires_on: null
+
+  source_location: knowledge-packs/example-persona-casual-shopper/full-source.md
+  source_integrity_notes: |
+    Derived from anonymized aggregate research, no identifying customer data.
+    Underlying interviews are stored separately and not part of this pack.
+```
+
+---
+
+## capsule.md (excerpt, generic)
+
+```markdown
+# Example Persona — Casual Shopper
+
+## Who they are
+A non-expert buyer who shops infrequently and prefers minimal cognitive load.
+
+## What they value
+- Clear pricing.
+- Predictable steps.
+- Low effort to recover from mistakes.
+
+## What they avoid
+- Long forms.
+- Decisions with unclear consequences.
+- Unfamiliar terminology.
+
+## Useful framings
+- "Would this be obvious to someone who shops once a quarter?"
+- "What does the worst-case recovery look like?"
+
+## Limits
+- Evidence proxy only. Cannot override accessibility, privacy, or compliance sources.
+- Should not be cited as evidence of universal behavior.
+```
+
+---
+
+## What this example demonstrates
+
+- A persona enters the layer as an **`evidence_proxy`** with **medium precedence**.
+- It is allowed in design and product framing, not in compliance or security decisions.
+- Conflicts with higher-tier sources (e.g. accessibility) lose, as shown in [source-precedence-policy](../../docs/contracts/source-precedence-policy.md).
+- The pack mentions provenance explicitly so it cannot be confused with raw user data.
+
+---
+
+## What this example is not
+
+- Not a real persona.
+- Not derived from any real customer.
+- Not an authoritative source on user behavior.

--- a/examples/project-extension/proprietary-framework-pack-example.md
+++ b/examples/project-extension/proprietary-framework-pack-example.md
@@ -1,0 +1,137 @@
+# Proprietary Framework Pack — Example
+
+## Goal
+
+Show a generic, non-confidential example of a proprietary framework registered as a knowledge pack.
+
+The framework below is fictional. Do not treat it as a real method, and do not reuse the name in real engagements.
+
+---
+
+## Pack layout
+
+```text
+knowledge-packs/
+  example-4-layers/
+    manifest.yaml
+    capsule.md
+    usage-policy.md
+    version-history.md
+    source-map.md
+    source-link.md
+    examples/
+```
+
+---
+
+## manifest.yaml
+
+```yaml
+knowledge_pack:
+  id: example-4-layers
+  name: Example Strategic Framework (4 Layers)
+  type: proprietary_framework
+  owner: example-owner
+  version: 1.0.0
+
+  sensitivity: internal
+  authority_level: interpretive
+
+  scope:
+    - business_design
+    - product_strategy
+    - feature_governance
+
+  allowed_skills:
+    - strategic-value-analysis
+    - feature-value-governance
+    - opportunity-tree-alignment
+  allowed_agents:
+    - product-agent
+    - business-design-agent
+    - design-agent
+
+  retrieval_mode: capsule_first
+  citation_required: true
+  full_text_exposure: forbidden
+  export_allowed: false
+
+  human_review_required_for:
+    - external_publication
+    - client_delivery
+    - policy_conflict
+
+  expiry:
+    review_cycle: quarterly
+    expires_on: null
+
+  source_location: knowledge-packs/example-4-layers/source-link.md
+  source_integrity_notes: |
+    Authored and maintained by example-owner. Capsule reviewed each release.
+    Full source is held outside the workspace and referenced by link only.
+```
+
+---
+
+## capsule.md (excerpt)
+
+```markdown
+# Example 4-Layers — Operational Capsule
+
+## What it is for
+A framework that helps connect business intent, product bets, feature shape, and operational reality across four layers.
+
+## When to use
+- Framing a strategic feature against business objectives.
+- Auditing whether a proposed feature actually serves the layer it claims.
+- Aligning opportunity trees with revenue and operational levers.
+
+## When not to use
+- Small UI tweaks with no strategic component.
+- Tasks already governed by a higher-authority source (compliance, security, privacy).
+
+## Concepts (operational only)
+- Layer A: business intent
+- Layer B: product bet
+- Layer C: feature shape
+- Layer D: operational footprint
+
+## Key questions
+- Which layer does the proposed change primarily affect?
+- Is the change coherent across adjacent layers?
+- What would falsify the bet implied by Layer B?
+
+## Application criteria
+- Use capsule alone for analysis tasks.
+- Escalate to the full source only when authorized and necessary.
+
+## Limits
+- Interpretive only. Cannot override mandatory or normative sources.
+- Not a replacement for user research or compliance review.
+
+## Expected output format
+- Layer-by-layer mapping
+- Stated bet and falsifier
+- Conflicts with higher-authority sources, if any
+```
+
+The capsule deliberately contains no verbatim text from the underlying framework.
+
+---
+
+## What this example demonstrates
+
+- A proprietary framework is registered with **owner, version, sensitivity, authority, and scope**.
+- It is consumed **capsule-first**; full source is not exposed.
+- It is **bound to a few skills and agents**, not globally available.
+- It is **interpretive**, so any conflict with a mandatory source escalates per the [source-precedence-policy](../../docs/contracts/source-precedence-policy.md).
+- The capsule is **operational**, not narrative. It tells an agent how to use the framework, not what the framework is in detail.
+
+---
+
+## What this example is not
+
+- It is not a real framework.
+- It is not a marketing description.
+- It is not a substitute for the source owner's own documentation.
+- It is not a template for moving the framework's body into AletheIA core.

--- a/schemas/aletheia-knowledge-pack.schema.json
+++ b/schemas/aletheia-knowledge-pack.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia.local/schemas/knowledge-pack.schema.json",
+  "title": "AletheIA Knowledge Pack Manifest",
+  "description": "Conceptual JSON Schema for a knowledge pack manifest. See docs/contracts/knowledge-pack-manifest.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["knowledge_pack"],
+  "properties": {
+    "knowledge_pack": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "type",
+        "owner",
+        "version",
+        "sensitivity",
+        "authority_level",
+        "scope",
+        "retrieval_mode",
+        "citation_required",
+        "full_text_exposure",
+        "export_allowed",
+        "human_review_required_for",
+        "expiry",
+        "source_location",
+        "source_integrity_notes"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "minLength": 1
+        },
+        "name": { "type": "string", "minLength": 1 },
+        "type": { "$ref": "#/$defs/sourceType" },
+        "owner": { "type": "string", "minLength": 1 },
+        "version": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+(?:[-+][0-9A-Za-z.-]+)?$"
+        },
+        "sensitivity": { "$ref": "#/$defs/sensitivity" },
+        "authority_level": { "$ref": "#/$defs/authorityLevel" },
+        "scope": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "allowed_skills": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "allowed_agents": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "retrieval_mode": { "$ref": "#/$defs/retrievalMode" },
+        "citation_required": { "type": "boolean" },
+        "full_text_exposure": {
+          "type": "string",
+          "enum": ["allowed", "forbidden", "conditional"]
+        },
+        "export_allowed": { "type": "boolean" },
+        "human_review_required_for": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "expiry": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["review_cycle", "expires_on"],
+          "properties": {
+            "review_cycle": {
+              "type": "string",
+              "enum": ["weekly", "monthly", "quarterly", "yearly"]
+            },
+            "expires_on": {
+              "oneOf": [
+                { "type": "string", "format": "date" },
+                { "type": "null" }
+              ]
+            }
+          }
+        },
+        "source_location": { "type": "string", "minLength": 1 },
+        "source_integrity_notes": { "type": "string", "minLength": 1 },
+        "prerequisite_sources": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "supersedes": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "allOf": [
+        {
+          "$comment": "If sensitivity is restricted or regulated, human_review_required_for must list at least one condition.",
+          "if": {
+            "properties": {
+              "sensitivity": { "enum": ["restricted", "regulated"] }
+            },
+            "required": ["sensitivity"]
+          },
+          "then": {
+            "properties": {
+              "human_review_required_for": { "minItems": 1 }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "sourceType": {
+      "type": "string",
+      "enum": [
+        "compliance_policy",
+        "security_policy",
+        "privacy_policy",
+        "accessibility_guideline",
+        "operating_model",
+        "product_strategy",
+        "proprietary_framework",
+        "design_system",
+        "persona",
+        "research_finding",
+        "benchmark",
+        "stakeholder_input"
+      ]
+    },
+    "sensitivity": {
+      "type": "string",
+      "enum": ["public", "internal", "confidential", "restricted", "regulated"]
+    },
+    "authorityLevel": {
+      "type": "string",
+      "enum": [
+        "mandatory",
+        "normative",
+        "procedural",
+        "strategic",
+        "interpretive",
+        "evidence_proxy",
+        "evidential",
+        "comparative",
+        "contextual"
+      ]
+    },
+    "retrievalMode": {
+      "type": "string",
+      "enum": [
+        "capsule_first",
+        "excerpt_only",
+        "metadata_only",
+        "full_source_allowed",
+        "human_review_required",
+        "blocked"
+      ]
+    }
+  }
+}

--- a/schemas/aletheia-skill-knowledge-dependency.schema.json
+++ b/schemas/aletheia-skill-knowledge-dependency.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia.local/schemas/skill-knowledge-dependency.schema.json",
+  "title": "AletheIA Skill Knowledge Dependency",
+  "description": "Conceptual JSON Schema for how a skill declares knowledge dependencies. See docs/contracts/skill-knowledge-dependency-contract.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["skill", "version", "knowledge_dependencies", "fallback_behavior"],
+  "properties": {
+    "skill": { "type": "string", "minLength": 1 },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(?:[-+][0-9A-Za-z.-]+)?$"
+    },
+    "knowledge_dependencies": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": { "$ref": "#/$defs/dependency" }
+    },
+    "fallback_behavior": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "missing_required_source",
+        "missing_optional_source",
+        "restricted_source",
+        "conflicting_sources"
+      ],
+      "properties": {
+        "missing_required_source": {
+          "type": "string",
+          "enum": ["stop_and_request_source", "continue_in_generic_mode", "abort"]
+        },
+        "missing_optional_source": {
+          "type": "string",
+          "enum": ["continue_with_assumption_marker", "omit_silently"]
+        },
+        "restricted_source": {
+          "type": "string",
+          "enum": ["request_authorized_context_pack", "downgrade_to_capsule", "refuse"]
+        },
+        "conflicting_sources": {
+          "type": "string",
+          "enum": ["apply_source_precedence_policy", "escalate_to_human_review"]
+        }
+      }
+    },
+    "output_requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cite_satisfying_packs": { "type": "boolean" },
+        "cite_unsatisfied_slots": { "type": "boolean" },
+        "list_active_restrictions": { "type": "boolean" },
+        "list_conflicts_and_resolutions": { "type": "boolean" }
+      }
+    }
+  },
+  "$defs": {
+    "dependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["accepted_types"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "required_when": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "accepted_types": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "compliance_policy",
+              "security_policy",
+              "privacy_policy",
+              "accessibility_guideline",
+              "operating_model",
+              "product_strategy",
+              "proprietary_framework",
+              "business_design_framework",
+              "design_system",
+              "persona",
+              "research_finding",
+              "benchmark",
+              "stakeholder_input"
+            ]
+          }
+        },
+        "min_authority": {
+          "type": "string",
+          "enum": [
+            "mandatory",
+            "normative",
+            "procedural",
+            "strategic",
+            "interpretive",
+            "evidence_proxy",
+            "evidential",
+            "comparative",
+            "contextual"
+          ]
+        },
+        "preferred_retrieval_mode": {
+          "type": "string",
+          "enum": [
+            "capsule_first",
+            "excerpt_only",
+            "metadata_only",
+            "full_source_allowed",
+            "human_review_required",
+            "blocked"
+          ]
+        },
+        "notes": { "type": "string" }
+      },
+      "anyOf": [
+        { "required": ["required"] },
+        { "required": ["required_when"] }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add a Knowledge Governance Layer to govern user-provided knowledge bases used by agents and skills (vendor-agnostic, docs-only).
- Skills declare *types* of knowledge they need; AletheIA resolves access, scope, sensitivity, authority, precedence, exposure, and audit.
- Position the Feature Value Governance Pack as the **first consumer** of this layer, not its parent — no proprietary content moves into core.

## What's in this PR

**Concepts** (`docs/concepts/`)
- `knowledge-governance-layer.md`
- `user-provided-knowledge.md`
- `framework-capsules.md`
- `knowledge-resolver.md`

**Contracts** (`docs/contracts/`)
- `knowledge-source-contract.md`
- `knowledge-pack-manifest.md`
- `skill-knowledge-dependency-contract.md`
- `source-precedence-policy.md`
- `restricted-knowledge-usage-policy.md`
- `knowledge-audit-log-spec.md`

**Schemas** (`schemas/`)
- `aletheia-knowledge-pack.schema.json`
- `aletheia-skill-knowledge-dependency.schema.json`

**Examples** (`examples/project-extension/`, generic, no proprietary content)
- `proprietary-framework-pack-example.md`
- `internal-policy-pack-example.md`
- `persona-pack-example.md`
- `knowledge-aware-context-pack.json`
- `README.md` (index)

Indexes in `docs/concepts/README.md` and `docs/contracts/README.md` updated.

## Architecture decisions

- Skills declare slot **types**, never specific source ids — portability + governance from a single constraint.
- **Capsule-first** is the default unit of consumption; full source is the exception.
- Sensitivity (`public | internal | confidential | restricted | regulated`) and authority (`mandatory | normative | … | contextual`) are independent vocabularies and cannot collapse into one.
- Loud refusal over silent fallback: missing required slots, conflicts, and restricted-use violations all surface structured records.
- Continuity, not replacement: this layer extends existing context-pack and project-extension discipline; cross-links go to `context-graph-integration.md` and the project-extension examples.

## Out of scope (explicit)

- No runtime, loader, or validator code.
- No vector database, UI, IAM, DLP, or fine-tuning.
- No movement of enterprise-specific frameworks/policies into framework core.

## Companion PR

Skill-side counterpart: [nevitonsantana/adaptive-skills#feat/knowledge-governance-layer](https://github.com/nevitonsantana/adaptive-skills/pulls?q=is%3Apr+head%3Afeat%2Fknowledge-governance-layer).

## Test plan

- [ ] Read `docs/concepts/knowledge-governance-layer.md` and confirm the three-layer split (skill / resolver / source) lands clearly.
- [ ] Walk one example end-to-end: `proprietary-framework-pack-example.md` + `knowledge-aware-context-pack.json` + an audit entry.
- [ ] Confirm the two new JSON Schemas validate the inline YAML examples (`ajv` or equivalent).
- [ ] Confirm `docs/concepts/README.md` and `docs/contracts/README.md` link to the new docs and render correctly.
- [ ] Confirm sensitivity vocabulary (`internal` vs `private`) — examples now use the framework taxonomy; map locally in project extensions if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)