### PR TITLE
docs(knowledge-governance): materialize example-4-layers knowledge pack on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- materialize the `example-4-layers` knowledge pack on disk under `examples/project-extension/knowledge-packs/` (schema-valid `manifest.yaml`, operational capsule, usage policy, version history, source map/link, and a `feature-value-governance` consumption walkthrough); generic and fictional, illustrating a proprietary framework registered as a `capsule_first` pack with `full_text_exposure: forbidden`
+
 - lock the canonical sensitivity vocabulary (`public | internal | confidential | restricted | regulated`) and document how project extensions map local labels (e.g. `private`, regulatory tags) to it; add a project-extension mapping example
 - align `aletheia-context-pack.schema.json` `sources[].sensitivity` enum with the canonical taxonomy (replaces the non-canonical `secret` and adds `confidential` + `regulated`); existing context-pack examples continue to validate
 

--- a/examples/project-extension/README.md
+++ b/examples/project-extension/README.md
@@ -10,7 +10,8 @@ These examples are **not** real policies, frameworks, or personas. They are mini
 |---|---|
 | [restricted-enterprise-context.md](restricted-enterprise-context.md) | How a constrained enterprise project layers local rules on top of the framework |
 | [local-trust-boundary-mapping.md](local-trust-boundary-mapping.md) | A small posture mapping for data class, model, and tool permission |
-| [proprietary-framework-pack-example.md](proprietary-framework-pack-example.md) | A proprietary framework registered as a knowledge pack (manifest + capsule) |
+| [proprietary-framework-pack-example.md](proprietary-framework-pack-example.md) | A proprietary framework registered as a knowledge pack (manifest + capsule), illustrated inline |
+| [knowledge-packs/example-4-layers/](knowledge-packs/example-4-layers/) | The same example **materialized as an on-disk pack**: schema-valid `manifest.yaml`, capsule, usage policy, version history, source map/link, and a consumption walkthrough |
 | [internal-policy-pack-example.md](internal-policy-pack-example.md) | An internal policy registered as a knowledge pack with `excerpt_only` retrieval |
 | [persona-pack-example.md](persona-pack-example.md) | A persona registered as an `evidence_proxy` source |
 | [knowledge-aware-context-pack.json](knowledge-aware-context-pack.json) | Resolver output: which slots got filled, conflicts, restrictions, audit hints |

--- a/examples/project-extension/knowledge-packs/example-4-layers/capsule.md
+++ b/examples/project-extension/knowledge-packs/example-4-layers/capsule.md
@@ -1,0 +1,84 @@
+# Example 4-Layers — Operational Capsule
+
+> Operational summary of a **fictional** strategic framework, registered as a knowledge pack.
+> This capsule is *how to use* the framework, not *what it is in detail*. It contains no verbatim
+> framework text, no diagrams, and no real engagement examples.
+
+## Identity
+
+- **pack_id:** example-4-layers
+- **version:** 1.0.0
+- **type:** proprietary_framework
+- **sensitivity:** internal
+- **authority_level:** interpretive
+
+## What it is for
+
+A framework that helps connect business intent, product bets, feature shape, and operational
+reality across four layers. It is used to judge whether a proposed feature is coherent across the
+layers it claims to serve.
+
+## When to use
+
+- Framing a strategic feature against business objectives.
+- Auditing whether a proposed feature actually serves the layer it claims.
+- Aligning opportunity trees with revenue and operational levers.
+
+## When not to use
+
+- Small UI tweaks with no strategic component.
+- Tasks already governed by a higher-authority source (compliance, security, privacy, mandatory accessibility).
+- Decisions that need user research the framework does not itself provide.
+
+## Concepts (operational only)
+
+- **Layer A — business intent:** the outcome the business is buying.
+- **Layer B — product bet:** the hypothesis about how the feature produces that outcome.
+- **Layer C — feature shape:** the concrete change proposed.
+- **Layer D — operational footprint:** the cost to build, run, and carry the change.
+
+## Key questions the framework prompts
+
+- Which layer does the proposed change primarily affect?
+- Is the change coherent across adjacent layers (does C actually serve B, does B actually serve A)?
+- What would falsify the bet implied by Layer B?
+- Does Layer D (operational footprint) erode the value claimed in Layer A?
+
+## Application criteria
+
+- **when to apply:** a feature is proposed and its value across layers is contested.
+- **when to escalate:** a conflict with a mandatory or normative source appears.
+- **when to refuse:** the task asks for verbatim framework text or export.
+
+## Limits
+
+- Interpretive only. Cannot override mandatory or normative sources.
+- Not a replacement for user research, accessibility review, or compliance review.
+- A coherent layer mapping is not, by itself, evidence that the bet is true.
+
+## Misuse signals
+
+- Treating the layer mapping as proof of value rather than a structuring aid.
+- Using the framework to justify overreach into compliance / accessibility / privacy.
+- Stretching it to settle a decision a higher-authority source already governs.
+
+## Expected output format when this capsule is in play
+
+- Layer-by-layer mapping (A → B → C → D).
+- Stated bet (Layer B) and its falsifier.
+- Conflicts with higher-authority sources, if any, routed per the source-precedence-policy.
+- Citation block: `example-4-layers@1.0.0`, restrictions applied (no_verbatim, no_export, citation_required).
+
+## What this capsule must NOT contain
+
+- verbatim text from the underlying framework
+- proprietary diagrams or full scoring tables
+- client, customer, or partner identifiers
+- carve-outs that belong to one organization
+
+## Review
+
+- **review_cycle:** quarterly
+- **last_reviewed:** 2026-05-28
+- **next_review_due:** 2026-08-28
+- **reviewers:** example-owner + one reviewer other than the author

--- a/examples/project-extension/knowledge-packs/example-4-layers/examples/value-analysis-walkthrough.md
+++ b/examples/project-extension/knowledge-packs/example-4-layers/examples/value-analysis-walkthrough.md
@@ -1,0 +1,78 @@
+# Walkthrough — feature-value-governance consuming example-4-layers
+
+A generic, safe illustration of the `feature-value-governance` skill (Adaptive Skills) running in
+**knowledge-aware mode** with this pack filling its `strategic_framework` slot.
+
+It pairs with the resolver-output example
+[knowledge-aware-context-pack.json](../../../knowledge-aware-context-pack.json), which shows the
+slots the resolver filled (this pack + a persona + an internal accessibility guideline), the active
+restrictions, and the conflict it resolved.
+
+## Scenario
+
+A team proposes simplifying a checkout flow by removing inline field labels. The question:
+**is this feature worth doing, and is it safe to ship as proposed?**
+
+## Skill output (illustrative)
+
+```yaml
+feature_value_analysis:
+  feature: "Remove inline labels on checkout fields to simplify the flow"
+  mode: knowledge_aware
+  business_intent: "Reduce checkout friction to lift conversion (Layer A intent)"
+  lever:
+    primary: conversion
+    rationale: "Fewer visual elements is hypothesized to reduce drop-off at payment (Layer B bet)"
+  user_evidence:
+    summary: "Persona prefers minimal visual density"
+    is_assumption: false
+  opportunity_alignment:
+    serves: "Reduce checkout abandonment"
+    aligned: true
+  complexity:
+    cost: low
+    drivers: ["front-end only", "no backend change"]
+  overreach_risk:
+    compliance: none
+    accessibility: likely
+    privacy: none
+    notes: "Removing labels collides with the internal accessibility guideline"
+  verdict:
+    worth_doing: conditional
+    conditions:
+      - "Keep explicit labels; achieve simplification without removing them"
+    rationale: >
+      The conversion bet is coherent across layers A–C and cheap (Layer D), but the proposed
+      shape (Layer C) overreaches into accessibility. The mandatory/normative guideline outranks
+      the persona, so the simplification must be redesigned rather than shipped as proposed.
+  knowledge_used:
+    - slot: strategic_framework
+      pack: example-4-layers@1.0.0
+      retrieved_scope: capsule
+      restrictions: [no_verbatim, no_export, citation_required]
+    - slot: personas
+      pack: example-persona-casual-shopper@0.4.0
+      retrieved_scope: capsule
+      restrictions: [citation_required]
+    - slot: accessibility_guidelines
+      pack: wcag-internal@1.2.0
+      retrieved_scope: excerpt
+      restrictions: [citation_required]
+  unsatisfied_slots:
+    - slot: operating_model
+      fallback: omit_silently        # not required for this task shape
+  conflicts:
+    - between: [example-persona-casual-shopper@0.4.0, wcag-internal@1.2.0]
+      prevailing: wcag-internal@1.2.0
+      reason: source_precedence_policy
+```
+
+## What this demonstrates
+
+- The pack fills `strategic_framework` **capsule-first**; no verbatim framework text appears.
+- Every consumed pack is cited as `pack_id@version`.
+- The persona-vs-accessibility conflict resolves via the
+  [source-precedence-policy](../../../../../docs/contracts/source-precedence-policy.md): the normative
+  accessibility guideline outranks the persona, so the verdict is `conditional`, not `yes`.
+- The framework is **interpretive**: it structures the value judgment but cannot override a
+  higher-authority source.

--- a/examples/project-extension/knowledge-packs/example-4-layers/manifest.yaml
+++ b/examples/project-extension/knowledge-packs/example-4-layers/manifest.yaml
@@ -1,0 +1,55 @@
+knowledge_pack:
+  # Identity
+  id: example-4-layers
+  name: Example Strategic Framework (4 Layers)
+  type: proprietary_framework
+  owner: example-owner
+  version: 1.0.0
+
+  # Classification
+  sensitivity: internal            # local label "private" maps to internal (see sensitivity-vocabulary-mapping)
+  authority_level: interpretive
+
+  # Use
+  scope:
+    - business_design
+    - product_strategy
+    - feature_governance
+
+  allowed_skills:
+    - strategic-value-analysis
+    - feature-value-governance
+    - opportunity-tree-alignment
+  allowed_agents:
+    - product-agent
+    - business-design-agent
+    - design-agent
+
+  # Retrieval
+  retrieval_mode: capsule_first
+  citation_required: true
+  full_text_exposure: forbidden
+  export_allowed: false
+
+  # Review
+  human_review_required_for:
+    - external_publication
+    - client_delivery
+    - policy_conflict
+  expiry:
+    review_cycle: quarterly
+    expires_on: null
+
+  # Provenance
+  source_location: examples/project-extension/knowledge-packs/example-4-layers/source-link.md
+  source_integrity_notes: |
+    Fictional framework authored and maintained by example-owner for demonstration only.
+    The full source is held outside the workspace and referenced by link (source-link.md).
+    The capsule is reviewed alongside every minor version bump; changes are tracked in
+    version-history.md. This pack carries no verbatim framework body.
+
+  # Optional
+  tags:
+    - example
+    - generic
+    - non-confidential

--- a/examples/project-extension/knowledge-packs/example-4-layers/source-link.md
+++ b/examples/project-extension/knowledge-packs/example-4-layers/source-link.md
@@ -1,0 +1,13 @@
+# Example 4-Layers — Source Link
+
+The full source for this fictional framework is **held outside the workspace** and referenced by
+link only, per the manifest (`full_text_exposure: forbidden`, `export_allowed: false`).
+
+- **Location type:** external (outside this repository).
+- **Reference:** `<external location managed by example-owner>` — intentionally a placeholder in this
+  generic example. A real pack would point to a governed store (DMS, internal wiki, signed artifact),
+  never to content committed in-repo.
+- **Access:** authorized consultation only; the default analysis runs from `capsule.md`.
+
+This file exists so the manifest `source_location` resolves to a real path while keeping the full
+framework body out of the repository.

--- a/examples/project-extension/knowledge-packs/example-4-layers/source-map.md
+++ b/examples/project-extension/knowledge-packs/example-4-layers/source-map.md
@@ -1,0 +1,18 @@
+# Example 4-Layers — Source Map
+
+Maps capsule concepts back to where they live in the full (external) source, so a reviewer can
+trace a capsule claim to its origin without the full source entering the workspace.
+
+> This map references **locations**, not content. It carries no verbatim framework text.
+
+| Capsule concept | Location in full source |
+|---|---|
+| Layer A — business intent | full source §1 |
+| Layer B — product bet | full source §2 |
+| Layer C — feature shape | full source §3 |
+| Layer D — operational footprint | full source §4 |
+| Coherence questions | full source §5 (application guide) |
+| Falsifier discipline | full source §5.3 |
+
+The full source itself is reached only via `source-link.md`, under authorization, and is never
+copied into the pack or the workspace.

--- a/examples/project-extension/knowledge-packs/example-4-layers/usage-policy.md
+++ b/examples/project-extension/knowledge-packs/example-4-layers/usage-policy.md
@@ -1,0 +1,45 @@
+# Example 4-Layers — Usage Policy
+
+Usage rules for this pack, derived from its manifest classification (`sensitivity: internal`,
+`authority_level: interpretive`) and the [restricted-knowledge-usage-policy](../../../../docs/contracts/restricted-knowledge-usage-policy.md).
+
+## What may be consulted
+
+- The **capsule** (`capsule.md`) is the default surface. Reason from it.
+- The full source is **not** consulted by default. It is held outside the workspace
+  (see `source-link.md`) and is only reachable under explicit authorization.
+
+## What may be cited
+
+- Citation is **required** when this pack influences a decision: cite as `example-4-layers@1.0.0`.
+- Cite the capsule and the conclusion drawn — never paste framework body text.
+
+## What may be summarized
+
+- Operational conclusions (layer mapping, stated bet, falsifier) may be summarized in outputs.
+- Inside the project/org boundary: summaries are fine.
+- Outside the boundary (`internal` sensitivity): **summary only**, never the source itself.
+
+## What must NOT be exposed
+
+- No verbatim framework text in outputs, logs, traces, or handoffs (`full_text_exposure: forbidden`).
+- No export of pack content (`export_allowed: false`).
+- No proprietary diagrams, scoring tables, or organization-specific carve-outs.
+
+## When human review is required
+
+Per the manifest `human_review_required_for`:
+
+- `external_publication`
+- `client_delivery`
+- `policy_conflict` — including any conflict with a mandatory or normative source.
+
+## Retrieval mode
+
+- `capsule_first`. Escalation to the full source requires authorization and a task that genuinely
+  needs it; the default analysis runs from the capsule alone.
+
+## Logs and handoffs
+
+- Carry active restrictions forward (no_verbatim, no_export, citation_required).
+- Do not let restrictions drop at a boundary. Mask any incidental sensitive content in logs.

--- a/examples/project-extension/knowledge-packs/example-4-layers/version-history.md
+++ b/examples/project-extension/knowledge-packs/example-4-layers/version-history.md
@@ -1,0 +1,12 @@
+# Example 4-Layers — Version History
+
+Tracks content and scope changes. Bump the manifest `version` (semver) on any change here.
+
+## 1.0.0 — 2026-05-28
+
+- Initial registration of the fictional Example 4-Layers framework as a knowledge pack.
+- Capsule authored (operational summary only; no verbatim framework body).
+- Classification: `sensitivity: internal`, `authority_level: interpretive`.
+- Retrieval: `capsule_first`; `full_text_exposure: forbidden`; `export_allowed: false`.
+- Bound to skills `strategic-value-analysis`, `feature-value-governance`,
+  `opportunity-tree-alignment` and to product / business-design / design agents.

--- a/examples/project-extension/proprietary-framework-pack-example.md
+++ b/examples/project-extension/proprietary-framework-pack-example.md
@@ -6,6 +6,11 @@ Show a generic, non-confidential example of a proprietary framework registered a
 
 The framework below is fictional. Do not treat it as a real method, and do not reuse the name in real engagements.
 
+> **Now materialized on disk.** This example is no longer illustrative-only: the same pack exists as
+> schema-valid files under [knowledge-packs/example-4-layers/](knowledge-packs/example-4-layers/)
+> (manifest, capsule, usage policy, version history, source map/link, and a consumption walkthrough).
+> The inline snippets below mirror those files.
+
 ---
 
 ## Pack layout


### PR DESCRIPTION
## Summary

Materializes the previously illustrative `example-4-layers` framework as an **on-disk knowledge pack** under `examples/project-extension/knowledge-packs/example-4-layers/`. Generic and fictional — no proprietary content, no real framework name or body.

The pack demonstrates a proprietary framework registered for governed consumption:

- **`manifest.yaml`** — schema-valid against `schemas/aletheia-knowledge-pack.schema.json`; `type: proprietary_framework`, `sensitivity: internal`, `authority_level: interpretive`, `retrieval_mode: capsule_first`, `full_text_exposure: forbidden`, `export_allowed: false`; bound to a few skills/agents (incl. `feature-value-governance`).
- **`capsule.md`** — operational capsule only (Layers A–D), no verbatim framework body.
- **`usage-policy.md`** — links the Restricted Knowledge Usage Policy contract.
- **`version-history.md`**, **`source-map.md`**, **`source-link.md`** — provenance: full source held outside the workspace, referenced by link only.
- **`examples/value-analysis-walkthrough.md`** — illustrative `feature-value-governance` run consuming the pack capsule-first, citing `pack_id@version`, resolving a persona-vs-accessibility conflict via the source-precedence-policy.

Also updates `examples/project-extension/README.md` (contents table) and the inline `proprietary-framework-pack-example.md` to point at the now-materialized pack, plus a CHANGELOG Unreleased entry.

Docs-only: no runtime, no enforcement code, no schema changes.

## Test plan

- [x] `pnpm run check:governance` — governance baseline passed
- [x] `pnpm run test` — 18/18 vitest tests pass
- [x] `manifest.yaml` validated against `aletheia-knowledge-pack.schema.json` (Ajv2020 + ajv-formats) → VALID
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)