### PR TITLE
feat(engine): validated loaders for knowledge-pack + skill-knowledge-dependency

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -29,3 +29,4 @@ If you need conceptual background, see [`concepts/`](../concepts/README.md). If 
 | [github-project-operations.md](github-project-operations.md) | Using GitHub Projects for repo coordination |
 | [setting-up-harnesses.md](setting-up-harnesses.md) | Wiring a consumer project to Claude Code via the shim pack |
 | [pilot-crisis-monitor-overlay-handoff.md](pilot-crisis-monitor-overlay-handoff.md) | Brief for the Crisis Monitor team — Epic 7 overlay-adoption pilot |
+| [validating-knowledge-manifests.md](validating-knowledge-manifests.md) | How to load and schema-validate knowledge manifests via the engine loaders |

--- a/docs/guides/validating-knowledge-manifests.md
+++ b/docs/guides/validating-knowledge-manifests.md
@@ -1,0 +1,76 @@
+# Validating Knowledge Manifests
+
+## Goal
+
+Show an implementer how to load and validate knowledge-governance manifests using
+the engine's typed loaders, so authored manifests are checked against their schema
+before anything consumes them.
+
+This guide is bounded to **schema validation**. It does not cover retrieval, vector
+storage, IAM, or DLP — those are out of scope for this phase.
+
+---
+
+## What exists
+
+The engine ships three validated loaders. Each reads a JSON file, validates it
+against its JSON Schema, and returns a typed object — or throws
+`SchemaValidationError` if the file does not conform.
+
+| Loader | Schema | Returns |
+|---|---|---|
+| `loadGovernancePack` | `aletheia-governance-pack.schema.json` | `GovernancePack` |
+| `loadKnowledgePack` | `aletheia-knowledge-pack.schema.json` | `KnowledgePackManifest` |
+| `loadSkillKnowledgeDependency` | `aletheia-skill-knowledge-dependency.schema.json` | `SkillKnowledgeDependency` |
+
+All are exported from `engine/`.
+
+---
+
+## How to use
+
+```ts
+import {
+  loadKnowledgePack,
+  loadSkillKnowledgeDependency,
+  SchemaValidationError,
+} from "../engine";
+
+try {
+  const pack = loadKnowledgePack("path/to/knowledge-pack.json");
+  console.log(pack.knowledge_pack.id);
+
+  const dep = loadSkillKnowledgeDependency("path/to/skill-knowledge-dependency.json");
+  console.log(Object.keys(dep.knowledge_dependencies));
+} catch (err) {
+  if (err instanceof SchemaValidationError) {
+    // err.schemaId and err.errors describe what failed
+    console.error(err.message);
+  } else {
+    throw err; // e.g. file-not-found
+  }
+}
+```
+
+---
+
+## Reference fixtures
+
+Minimal, vendor-agnostic examples to validate against and to copy from:
+
+- `examples/project-extension/knowledge-pack.example.json`
+- `examples/project-extension/skill-knowledge-dependency.example.json`
+
+The contract test suite (`tests/contracts/test-contracts.test.ts`) validates these
+fixtures and exercises both loaders for valid-load and malformed-throws behavior.
+
+---
+
+## Boundaries
+
+When extending this surface, keep it model-agnostic and secure-by-default:
+
+- Do not embed proprietary or client content in fixtures or schemas.
+- Do not introduce premature implementation — no vector DB, no IAM integration, no
+  DLP pipeline, no fine-tuning.
+- Do not turn local company rules into framework core.

--- a/engine/loader.ts
+++ b/engine/loader.ts
@@ -1,12 +1,37 @@
 import path from "node:path";
 import fs from "node:fs";
 import { validateAgainstSchema } from "./validation";
-import type { GovernancePack } from "./types";
+import type {
+  GovernancePack,
+  KnowledgePackManifest,
+  SkillKnowledgeDependency,
+} from "./types";
 
-const GOVERNANCE_PACK_SCHEMA = path.resolve(
+const SCHEMA_DIR = path.resolve(
   path.dirname(new URL(import.meta.url).pathname),
-  "../schemas/aletheia-governance-pack.schema.json",
+  "../schemas",
 );
+
+const GOVERNANCE_PACK_SCHEMA = path.join(
+  SCHEMA_DIR,
+  "aletheia-governance-pack.schema.json",
+);
+const KNOWLEDGE_PACK_SCHEMA = path.join(
+  SCHEMA_DIR,
+  "aletheia-knowledge-pack.schema.json",
+);
+const SKILL_KNOWLEDGE_DEPENDENCY_SCHEMA = path.join(
+  SCHEMA_DIR,
+  "aletheia-skill-knowledge-dependency.schema.json",
+);
+
+function readJsonFile(filePath: string, label: string): unknown {
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`${label} file not found: ${resolved}`);
+  }
+  return JSON.parse(fs.readFileSync(resolved, "utf-8"));
+}
 
 /**
  * Load and validate a GovernancePack from a JSON file.
@@ -16,10 +41,35 @@ const GOVERNANCE_PACK_SCHEMA = path.resolve(
  * be read.
  */
 export function loadGovernancePack(filePath: string): GovernancePack {
-  const resolved = path.resolve(filePath);
-  if (!fs.existsSync(resolved)) {
-    throw new Error(`Governance pack file not found: ${resolved}`);
-  }
-  const raw: unknown = JSON.parse(fs.readFileSync(resolved, "utf-8"));
+  const raw = readJsonFile(filePath, "Governance pack");
   return validateAgainstSchema<GovernancePack>(raw, GOVERNANCE_PACK_SCHEMA);
+}
+
+/**
+ * Load and validate a knowledge-pack manifest from a JSON file.
+ *
+ * Throws `SchemaValidationError` if the file does not conform to the
+ * knowledge-pack schema. Throws a standard `Error` if the file cannot
+ * be read.
+ */
+export function loadKnowledgePack(filePath: string): KnowledgePackManifest {
+  const raw = readJsonFile(filePath, "Knowledge pack");
+  return validateAgainstSchema<KnowledgePackManifest>(raw, KNOWLEDGE_PACK_SCHEMA);
+}
+
+/**
+ * Load and validate a skill knowledge-dependency manifest from a JSON file.
+ *
+ * Throws `SchemaValidationError` if the file does not conform to the
+ * skill-knowledge-dependency schema. Throws a standard `Error` if the file
+ * cannot be read.
+ */
+export function loadSkillKnowledgeDependency(
+  filePath: string,
+): SkillKnowledgeDependency {
+  const raw = readJsonFile(filePath, "Skill knowledge dependency");
+  return validateAgainstSchema<SkillKnowledgeDependency>(
+    raw,
+    SKILL_KNOWLEDGE_DEPENDENCY_SCHEMA,
+  );
 }

--- a/engine/types.ts
+++ b/engine/types.ts
@@ -346,3 +346,111 @@ export interface GovernanceHookRunResult {
   policy_trace: PolicyTrace;
   policy_evaluation: PolicyEvaluation;
 }
+
+export type KnowledgeSourceType =
+  | "compliance_policy"
+  | "security_policy"
+  | "privacy_policy"
+  | "accessibility_guideline"
+  | "operating_model"
+  | "product_strategy"
+  | "proprietary_framework"
+  | "design_system"
+  | "persona"
+  | "research_finding"
+  | "benchmark"
+  | "stakeholder_input";
+
+export type KnowledgeSensitivity =
+  | "public"
+  | "internal"
+  | "confidential"
+  | "restricted"
+  | "regulated";
+
+export type KnowledgeAuthorityLevel =
+  | "mandatory"
+  | "normative"
+  | "procedural"
+  | "strategic"
+  | "interpretive"
+  | "evidence_proxy"
+  | "evidential"
+  | "comparative"
+  | "contextual";
+
+export type KnowledgeRetrievalMode =
+  | "capsule_first"
+  | "excerpt_only"
+  | "metadata_only"
+  | "full_source_allowed"
+  | "human_review_required"
+  | "blocked";
+
+export interface KnowledgePackManifest {
+  knowledge_pack: {
+    id: string;
+    name: string;
+    type: KnowledgeSourceType;
+    owner: string;
+    version: string;
+    sensitivity: KnowledgeSensitivity;
+    authority_level: KnowledgeAuthorityLevel;
+    scope: string[];
+    allowed_skills?: string[];
+    allowed_agents?: string[];
+    retrieval_mode: KnowledgeRetrievalMode;
+    citation_required: boolean;
+    full_text_exposure: "allowed" | "forbidden" | "conditional";
+    export_allowed: boolean;
+    human_review_required_for: string[];
+    expiry: {
+      review_cycle: "weekly" | "monthly" | "quarterly" | "yearly";
+      expires_on: string | null;
+    };
+    source_location: string;
+    source_integrity_notes: string;
+    prerequisite_sources?: string[];
+    supersedes?: string[];
+    tags?: string[];
+  };
+}
+
+export type SkillDependencyAcceptedType =
+  | KnowledgeSourceType
+  | "business_design_framework";
+
+export interface SkillKnowledgeDependencySlot {
+  required?: boolean;
+  required_when?: string[];
+  accepted_types: SkillDependencyAcceptedType[];
+  min_authority?: KnowledgeAuthorityLevel;
+  preferred_retrieval_mode?: KnowledgeRetrievalMode;
+  notes?: string;
+}
+
+export interface SkillKnowledgeDependency {
+  skill: string;
+  version: string;
+  knowledge_dependencies: Record<string, SkillKnowledgeDependencySlot>;
+  fallback_behavior: {
+    missing_required_source:
+      | "stop_and_request_source"
+      | "continue_in_generic_mode"
+      | "abort";
+    missing_optional_source: "continue_with_assumption_marker" | "omit_silently";
+    restricted_source:
+      | "request_authorized_context_pack"
+      | "downgrade_to_capsule"
+      | "refuse";
+    conflicting_sources:
+      | "apply_source_precedence_policy"
+      | "escalate_to_human_review";
+  };
+  output_requirements?: {
+    cite_satisfying_packs?: boolean;
+    cite_unsatisfied_slots?: boolean;
+    list_active_restrictions?: boolean;
+    list_conflicts_and_resolutions?: boolean;
+  };
+}

--- a/examples/project-extension/knowledge-pack.example.json
+++ b/examples/project-extension/knowledge-pack.example.json
@@ -1,0 +1,43 @@
+{
+  "knowledge_pack": {
+    "id": "example-accessibility-guideline",
+    "name": "Example Accessibility Guideline Pack",
+    "type": "accessibility_guideline",
+    "owner": "Knowledge Governance WG",
+    "version": "1.0.0",
+    "sensitivity": "internal",
+    "authority_level": "normative",
+    "scope": [
+      "interface_change",
+      "content_decision",
+      "navigation_decision"
+    ],
+    "allowed_skills": [
+      "knowledge-source-evaluation",
+      "restricted-context-check"
+    ],
+    "allowed_agents": [
+      "design-agent",
+      "product-agent"
+    ],
+    "retrieval_mode": "capsule_first",
+    "citation_required": true,
+    "full_text_exposure": "conditional",
+    "export_allowed": false,
+    "human_review_required_for": [
+      "external_publication",
+      "policy_conflict"
+    ],
+    "expiry": {
+      "review_cycle": "quarterly",
+      "expires_on": null
+    },
+    "source_location": "examples/project-extension/knowledge-packs/example-accessibility-guideline/source-link.md",
+    "source_integrity_notes": "Generic, vendor-agnostic example pack; contains no proprietary or client content.",
+    "tags": [
+      "accessibility",
+      "normative",
+      "example"
+    ]
+  }
+}

--- a/examples/project-extension/skill-knowledge-dependency.example.json
+++ b/examples/project-extension/skill-knowledge-dependency.example.json
@@ -1,0 +1,40 @@
+{
+  "skill": "feature-value-governance",
+  "version": "0.1.0",
+  "knowledge_dependencies": {
+    "strategic_framework": {
+      "required": true,
+      "accepted_types": [
+        "proprietary_framework",
+        "product_strategy",
+        "business_design_framework"
+      ],
+      "min_authority": "interpretive",
+      "preferred_retrieval_mode": "capsule_first"
+    },
+    "accessibility_guidelines": {
+      "required_when": [
+        "interface_change",
+        "content_decision",
+        "navigation_decision"
+      ],
+      "accepted_types": [
+        "accessibility_guideline"
+      ],
+      "min_authority": "normative",
+      "notes": "Pulled in only for customer-facing experience changes."
+    }
+  },
+  "fallback_behavior": {
+    "missing_required_source": "stop_and_request_source",
+    "missing_optional_source": "continue_with_assumption_marker",
+    "restricted_source": "request_authorized_context_pack",
+    "conflicting_sources": "apply_source_precedence_policy"
+  },
+  "output_requirements": {
+    "cite_satisfying_packs": true,
+    "cite_unsatisfied_slots": true,
+    "list_active_restrictions": true,
+    "list_conflicts_and_resolutions": true
+  }
+}

--- a/tests/contracts/test-contracts.test.ts
+++ b/tests/contracts/test-contracts.test.ts
@@ -1,7 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, it, expect } from "vitest";
-import { validateAgainstSchema, SchemaValidationError, loadGovernancePack } from "../../engine";
+import {
+  validateAgainstSchema,
+  SchemaValidationError,
+  loadGovernancePack,
+  loadKnowledgePack,
+  loadSkillKnowledgeDependency,
+} from "../../engine";
 
 function readJsonFile<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, "utf-8")) as T;
@@ -35,6 +41,16 @@ const fixtures = [
     fixture: "policies/aletheia-development-governance.v1.json",
     schema: "aletheia-governance-pack.schema.json",
   },
+  {
+    name: "Knowledge Pack",
+    fixture: "examples/project-extension/knowledge-pack.example.json",
+    schema: "aletheia-knowledge-pack.schema.json",
+  },
+  {
+    name: "Skill Knowledge Dependency",
+    fixture: "examples/project-extension/skill-knowledge-dependency.example.json",
+    schema: "aletheia-skill-knowledge-dependency.schema.json",
+  },
 ];
 
 describe("Contract validation", () => {
@@ -56,6 +72,39 @@ describe("Contract validation", () => {
   it("loadGovernancePack throws SchemaValidationError for a malformed pack", () => {
     expect(() =>
       loadGovernancePack(path.resolve(process.cwd(), "examples/hello-world/task-brief.json")),
+    ).toThrow(SchemaValidationError);
+  });
+
+  it("loadKnowledgePack validates and returns a valid manifest", () => {
+    const pack = loadKnowledgePack(
+      path.resolve(process.cwd(), "examples/project-extension/knowledge-pack.example.json"),
+    );
+    expect(pack.knowledge_pack.id).toBeTruthy();
+    expect(Array.isArray(pack.knowledge_pack.scope)).toBe(true);
+  });
+
+  it("loadKnowledgePack throws SchemaValidationError for a malformed manifest", () => {
+    expect(() =>
+      loadKnowledgePack(path.resolve(process.cwd(), "examples/hello-world/task-brief.json")),
+    ).toThrow(SchemaValidationError);
+  });
+
+  it("loadSkillKnowledgeDependency validates and returns a valid manifest", () => {
+    const dep = loadSkillKnowledgeDependency(
+      path.resolve(
+        process.cwd(),
+        "examples/project-extension/skill-knowledge-dependency.example.json",
+      ),
+    );
+    expect(dep.skill).toBeTruthy();
+    expect(Object.keys(dep.knowledge_dependencies).length).toBeGreaterThan(0);
+  });
+
+  it("loadSkillKnowledgeDependency throws SchemaValidationError for a malformed manifest", () => {
+    expect(() =>
+      loadSkillKnowledgeDependency(
+        path.resolve(process.cwd(), "examples/hello-world/task-brief.json"),
+      ),
     ).toThrow(SchemaValidationError);
   });
 


### PR DESCRIPTION
## Knowledge Governance Layer — engine, build step 1 (loaders)

Implements **step 1** of the Phase 5 implementer brief (`docs/roadmaps/knowledge-governance-implementation-prep.md`): validated loaders, bounded to schema validation only.

> ⚠️ **Base correction:** PR #165 was accidentally merged into the `feat/knowledge-governance-phase4-security` branch instead of `main`, so the loaders never reached `main`. This PR targets `main` with the same content, rebased clean on current `main`. The stranded branch from #165 can be deleted.

### Changes
- `engine/loader.ts` — adds `loadKnowledgePack()` and `loadSkillKnowledgeDependency()`, sharing a `readJsonFile` helper with the existing governance-pack loader. Pure schema validation against the existing JSON Schemas.
- `engine/types.ts` — adds `KnowledgePackManifest`, `SkillKnowledgeDependency`, and supporting unions. Conforms to the contracts: canonical **five** sensitivities, **nine** authority levels, **six** retrieval modes.
- `tests/contracts/test-contracts.test.ts` — valid examples load; malformed/non-canonical manifests rejected.
- `examples/project-extension/` — `knowledge-pack.example.json`, `skill-knowledge-dependency.example.json`.
- `docs/guides/` — knowledge-manifest validation guide for implementers.

### Scope discipline (per Phase 5 brief)
- No vector DB, IAM, DLP, UI, embeddings, or crypto — bounded to load + validate.
- No schema was modified to fit code; loaders conform to existing schemas.
- No new taxonomy values; no company-specific rules in core.

Steps 2–6 (registry → resolver → context-pack assembly → audit writer → e2e golden) are follow-ups.

One PR. **Do not merge — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)