### PR TITLE
feat(engine): KnowledgeRegistry with eligibility filtering (KGL step 2)

### DIFF
--- a/engine/index.ts
+++ b/engine/index.ts
@@ -10,3 +10,4 @@ export * from "./runtime";
 export * from "./types";
 export * from "./validation";
 export * from "./loader";
+export * from "./registry";

--- a/engine/registry.ts
+++ b/engine/registry.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs";
+import path from "node:path";
+import { loadKnowledgePack } from "./loader";
+import type {
+  KnowledgePackManifest,
+  KnowledgeSensitivity,
+  KnowledgeSourceType,
+} from "./types";
+
+/**
+ * Knowledge Governance Layer — registry (build step 2).
+ *
+ * A catalogue over a set of already-loaded knowledge-pack manifests that
+ * answers eligibility queries. This is a pure, deterministic data structure:
+ * it does not retrieve content, evaluate authority, resolve conflicts, or
+ * apply retrieval modes — those are the resolver's job (build step 3).
+ *
+ * Scope (per docs/roadmaps/knowledge-governance-implementation-prep.md):
+ * filter by `allowed_skills`, `allowed_agents`, scope, and sensitivity ceiling.
+ * No DB, no IAM, no network. File-backing is a thin helper over the loader.
+ */
+
+/** Canonical sensitivity ordering (low → high). */
+const SENSITIVITY_ORDER: Record<KnowledgeSensitivity, number> = {
+  public: 0,
+  internal: 1,
+  confidential: 2,
+  restricted: 3,
+  regulated: 4,
+};
+
+export interface EligibilityQuery {
+  /** Skill id; matched against a pack's `allowed_skills` allowlist. */
+  skill?: string;
+  /** Agent id; matched against a pack's `allowed_agents` allowlist. */
+  agent?: string;
+  /** Task scope tags; a pack is eligible if its `scope` intersects these. */
+  scope?: string[];
+  /** Sensitivity ceiling; packs above this level are excluded. */
+  maxSensitivity?: KnowledgeSensitivity;
+  /** Restrict to a single source type. */
+  type?: KnowledgeSourceType;
+}
+
+/**
+ * Decide whether a single pack satisfies an eligibility query.
+ *
+ * Allowlist semantics: an absent or empty `allowed_skills` / `allowed_agents`
+ * means the pack is unrestricted on that axis. A non-empty allowlist excludes
+ * any actor not named in it. Omitting a query field disables that filter.
+ */
+export function isEligible(
+  pack: KnowledgePackManifest,
+  query: EligibilityQuery = {},
+): boolean {
+  const kp = pack.knowledge_pack;
+
+  if (query.type && kp.type !== query.type) {
+    return false;
+  }
+
+  if (query.skill && kp.allowed_skills && kp.allowed_skills.length > 0) {
+    if (!kp.allowed_skills.includes(query.skill)) {
+      return false;
+    }
+  }
+
+  if (query.agent && kp.allowed_agents && kp.allowed_agents.length > 0) {
+    if (!kp.allowed_agents.includes(query.agent)) {
+      return false;
+    }
+  }
+
+  if (query.scope && query.scope.length > 0) {
+    const intersects = query.scope.some((tag) => kp.scope.includes(tag));
+    if (!intersects) {
+      return false;
+    }
+  }
+
+  if (query.maxSensitivity) {
+    if (SENSITIVITY_ORDER[kp.sensitivity] > SENSITIVITY_ORDER[query.maxSensitivity]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export class KnowledgeRegistry {
+  private readonly packs: KnowledgePackManifest[];
+
+  /**
+   * @throws Error if two packs share the same `id`.
+   */
+  constructor(packs: KnowledgePackManifest[] = []) {
+    const seen = new Set<string>();
+    for (const pack of packs) {
+      const id = pack.knowledge_pack.id;
+      if (seen.has(id)) {
+        throw new Error(`Duplicate knowledge pack id in registry: ${id}`);
+      }
+      seen.add(id);
+    }
+    this.packs = [...packs];
+  }
+
+  /** All registered packs (defensive copy). */
+  list(): KnowledgePackManifest[] {
+    return [...this.packs];
+  }
+
+  /** A single pack by id, or undefined. */
+  get(id: string): KnowledgePackManifest | undefined {
+    return this.packs.find((pack) => pack.knowledge_pack.id === id);
+  }
+
+  /** All packs of a given source type. */
+  byType(type: KnowledgeSourceType): KnowledgePackManifest[] {
+    return this.packs.filter((pack) => pack.knowledge_pack.type === type);
+  }
+
+  /** All packs that satisfy the eligibility query. */
+  eligible(query: EligibilityQuery = {}): KnowledgePackManifest[] {
+    return this.packs.filter((pack) => isEligible(pack, query));
+  }
+}
+
+/**
+ * Build a registry from every `*.json` knowledge-pack manifest in a directory.
+ * Each file is schema-validated by the loader; a malformed manifest throws.
+ *
+ * @throws Error if the directory does not exist.
+ * @throws SchemaValidationError if any manifest is invalid.
+ */
+export function loadKnowledgeRegistry(dir: string): KnowledgeRegistry {
+  const resolved = path.resolve(dir);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`Knowledge registry directory not found: ${resolved}`);
+  }
+  const packs = fs
+    .readdirSync(resolved)
+    .filter((file) => file.endsWith(".json"))
+    .sort()
+    .map((file) => loadKnowledgePack(path.join(resolved, file)));
+  return new KnowledgeRegistry(packs);
+}

--- a/tests/registry/test-registry.test.ts
+++ b/tests/registry/test-registry.test.ts
@@ -1,0 +1,188 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import {
+  KnowledgeRegistry,
+  isEligible,
+  loadKnowledgeRegistry,
+  SchemaValidationError,
+} from "../../engine";
+import type {
+  KnowledgePackManifest,
+  KnowledgeSourceType,
+  KnowledgeSensitivity,
+  KnowledgeAuthorityLevel,
+  KnowledgeRetrievalMode,
+} from "../../engine";
+
+interface PackOverrides {
+  id: string;
+  type?: KnowledgeSourceType;
+  sensitivity?: KnowledgeSensitivity;
+  authority_level?: KnowledgeAuthorityLevel;
+  scope?: string[];
+  allowed_skills?: string[];
+  allowed_agents?: string[];
+  retrieval_mode?: KnowledgeRetrievalMode;
+}
+
+function makePack(overrides: PackOverrides): KnowledgePackManifest {
+  return {
+    knowledge_pack: {
+      id: overrides.id,
+      name: `Pack ${overrides.id}`,
+      type: overrides.type ?? "proprietary_framework",
+      owner: "test-owner",
+      version: "1.0.0",
+      sensitivity: overrides.sensitivity ?? "internal",
+      authority_level: overrides.authority_level ?? "interpretive",
+      scope: overrides.scope ?? ["general"],
+      allowed_skills: overrides.allowed_skills,
+      allowed_agents: overrides.allowed_agents,
+      retrieval_mode: overrides.retrieval_mode ?? "capsule_first",
+      citation_required: true,
+      full_text_exposure: "forbidden",
+      export_allowed: false,
+      human_review_required_for: [],
+      expiry: { review_cycle: "quarterly", expires_on: null },
+      source_location: "examples/example.md",
+      source_integrity_notes: "test fixture",
+    },
+  };
+}
+
+describe("KnowledgeRegistry — construction", () => {
+  it("lists all registered packs", () => {
+    const reg = new KnowledgeRegistry([makePack({ id: "a" }), makePack({ id: "b" })]);
+    expect(reg.list().map((p) => p.knowledge_pack.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("returns a defensive copy from list()", () => {
+    const reg = new KnowledgeRegistry([makePack({ id: "a" })]);
+    reg.list().pop();
+    expect(reg.list()).toHaveLength(1);
+  });
+
+  it("throws on duplicate pack id", () => {
+    expect(() => new KnowledgeRegistry([makePack({ id: "dup" }), makePack({ id: "dup" })])).toThrow(
+      /Duplicate knowledge pack id/,
+    );
+  });
+
+  it("get() returns a pack by id or undefined", () => {
+    const reg = new KnowledgeRegistry([makePack({ id: "a" })]);
+    expect(reg.get("a")?.knowledge_pack.id).toBe("a");
+    expect(reg.get("missing")).toBeUndefined();
+  });
+
+  it("byType() filters by source type", () => {
+    const reg = new KnowledgeRegistry([
+      makePack({ id: "fw", type: "proprietary_framework" }),
+      makePack({ id: "persona", type: "persona" }),
+    ]);
+    expect(reg.byType("persona").map((p) => p.knowledge_pack.id)).toEqual(["persona"]);
+  });
+});
+
+describe("KnowledgeRegistry — eligibility", () => {
+  it("an empty query matches every pack", () => {
+    const reg = new KnowledgeRegistry([makePack({ id: "a" }), makePack({ id: "b" })]);
+    expect(reg.eligible()).toHaveLength(2);
+  });
+
+  it("filters by allowed_skills allowlist", () => {
+    const reg = new KnowledgeRegistry([
+      makePack({ id: "scoped", allowed_skills: ["skill-x"] }),
+      makePack({ id: "open" }), // no allowlist → unrestricted
+    ]);
+    const ids = reg.eligible({ skill: "skill-y" }).map((p) => p.knowledge_pack.id);
+    expect(ids).toEqual(["open"]);
+    const ids2 = reg.eligible({ skill: "skill-x" }).map((p) => p.knowledge_pack.id).sort();
+    expect(ids2).toEqual(["open", "scoped"]);
+  });
+
+  it("filters by allowed_agents allowlist", () => {
+    const reg = new KnowledgeRegistry([makePack({ id: "scoped", allowed_agents: ["agent-x"] })]);
+    expect(reg.eligible({ agent: "agent-y" })).toHaveLength(0);
+    expect(reg.eligible({ agent: "agent-x" })).toHaveLength(1);
+  });
+
+  it("filters by scope intersection", () => {
+    const reg = new KnowledgeRegistry([
+      makePack({ id: "ui", scope: ["interface_change", "content_decision"] }),
+      makePack({ id: "roadmap", scope: ["roadmap_decision"] }),
+    ]);
+    const ids = reg.eligible({ scope: ["interface_change"] }).map((p) => p.knowledge_pack.id);
+    expect(ids).toEqual(["ui"]);
+  });
+
+  it("filters by sensitivity ceiling", () => {
+    const reg = new KnowledgeRegistry([
+      makePack({ id: "pub", sensitivity: "public" }),
+      makePack({ id: "int", sensitivity: "internal" }),
+      makePack({ id: "reg", sensitivity: "regulated" }),
+    ]);
+    const ids = reg.eligible({ maxSensitivity: "internal" }).map((p) => p.knowledge_pack.id).sort();
+    expect(ids).toEqual(["int", "pub"]);
+  });
+
+  it("combines filters conjunctively", () => {
+    const reg = new KnowledgeRegistry([
+      makePack({
+        id: "match",
+        allowed_skills: ["s1"],
+        scope: ["interface_change"],
+        sensitivity: "internal",
+      }),
+      makePack({
+        id: "wrong-sensitivity",
+        allowed_skills: ["s1"],
+        scope: ["interface_change"],
+        sensitivity: "restricted",
+      }),
+    ]);
+    const ids = reg
+      .eligible({ skill: "s1", scope: ["interface_change"], maxSensitivity: "confidential" })
+      .map((p) => p.knowledge_pack.id);
+    expect(ids).toEqual(["match"]);
+  });
+
+  it("isEligible is exposed as a standalone predicate", () => {
+    const pack = makePack({ id: "a", sensitivity: "restricted" });
+    expect(isEligible(pack, { maxSensitivity: "internal" })).toBe(false);
+    expect(isEligible(pack, { maxSensitivity: "restricted" })).toBe(true);
+  });
+});
+
+describe("loadKnowledgeRegistry — file-backed", () => {
+  it("loads and validates every knowledge pack in a directory", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kg-registry-"));
+    try {
+      const repoPack = path.resolve(
+        process.cwd(),
+        "examples/project-extension/knowledge-pack.example.json",
+      );
+      fs.copyFileSync(repoPack, path.join(dir, "pack-a.json"));
+      const reg = loadKnowledgeRegistry(dir);
+      expect(reg.list()).toHaveLength(1);
+      expect(reg.get("example-accessibility-guideline")).toBeDefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws SchemaValidationError when a file is not a valid knowledge pack", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kg-registry-bad-"));
+    try {
+      fs.writeFileSync(path.join(dir, "bad.json"), JSON.stringify({ not: "a pack" }));
+      expect(() => loadKnowledgeRegistry(dir)).toThrow(SchemaValidationError);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when the directory does not exist", () => {
+    expect(() => loadKnowledgeRegistry("/nonexistent/kg/dir")).toThrow(/not found/);
+  });
+});


### PR DESCRIPTION
## Knowledge Governance Layer — engine, build step 2 (registry)

Implements **step 2** of the Phase 5 implementer brief (`docs/roadmaps/knowledge-governance-implementation-prep.md`), on top of the step-1 loaders (#167).

### What
A `KnowledgeRegistry` over already-loaded knowledge-pack manifests that answers eligibility queries — the catalogue the resolver (step 3) will query.

- `engine/registry.ts`
  - `KnowledgeRegistry`: `list()`, `get(id)`, `byType(type)`, `eligible(query)`.
  - `isEligible(pack, query)` standalone predicate.
  - `loadKnowledgeRegistry(dir)` — file-backed helper that validates each `*.json` via the existing loader.
- `engine/index.ts` — re-export.
- `tests/registry/test-registry.test.ts` — construction, defensive copies, duplicate-id detection, each filter dimension, conjunction, file-backed loader (valid / malformed / missing dir).

### Eligibility semantics
Conjunctive filters: `allowed_skills`, `allowed_agents`, scope **intersection**, sensitivity **ceiling** (canonical ordering public→regulated), and `type`. An absent/empty allowlist = unrestricted on that axis; omitting a query field disables that filter.

### Scope discipline (per brief)
- Pure data structure: **no** content retrieval, authority evaluation, conflict resolution, or retrieval-mode decisions — those are the resolver's job (step 3).
- No DB, IAM, DLP, or network. File-backing is a thin wrapper over the loader.
- No schema changes; no new taxonomy values.

### Validation
- `npx tsc --noEmit` → clean.
- `pnpm run test` → 39 passed (5 files).
- `pnpm run check:governance` → passes.

One PR. **Do not merge — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)