### PR TITLE
feat(engine): knowledge-aware context pack assembly + schema (KGL step 4)

### DIFF
--- a/engine/context-pack.ts
+++ b/engine/context-pack.ts
@@ -1,0 +1,139 @@
+import path from "node:path";
+import { validateAgainstSchema } from "./validation";
+import type { ResolverResult } from "./resolver";
+
+/**
+ * Knowledge Governance Layer — context-pack assembly (build step 4).
+ *
+ * Serializes a {@link ResolverResult} into a knowledge-aware context pack that
+ * conforms to schemas/aletheia-knowledge-aware-context-pack.schema.json and
+ * matches examples/project-extension/knowledge-aware-context-pack.json.
+ *
+ * Pure serialization + schema validation. No I/O beyond reading the schema, no
+ * content retrieval, no network. The resolver already computes the resolution;
+ * this step gives it a stable, validated on-the-wire shape with the task /
+ * agent / skill envelope.
+ */
+
+const CONTEXT_PACK_SCHEMA = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  "../schemas/aletheia-knowledge-aware-context-pack.schema.json",
+);
+
+const DEFAULT_CONTEXT_PACK_VERSION = "0.1.0";
+
+export interface ContextPackEnvelope {
+  task?: {
+    purpose?: string;
+    audience?: string;
+    risk_class?: string;
+    scope_tags?: string[];
+  };
+  agent?: {
+    id: string;
+    trust_boundary?: string;
+  };
+  /** Override the skill mode; defaults to `knowledge_aware` when any slot was satisfied. */
+  mode?: "knowledge_aware" | "generic";
+  contextPackVersion?: string;
+}
+
+export interface KnowledgeAwareContextPack {
+  context_pack_version: string;
+  status: ResolverResult["status"];
+  task: {
+    id: string;
+    purpose?: string;
+    audience?: string;
+    risk_class?: string;
+    scope_tags?: string[];
+  };
+  agent?: {
+    id: string;
+    trust_boundary?: string;
+  };
+  skill: {
+    id: string;
+    version: string;
+    mode: "knowledge_aware" | "generic";
+  };
+  knowledge_dependencies_resolution: ResolverResult["knowledge_dependencies_resolution"];
+  restrictions_active: string[];
+  conflicts_detected: ResolverResult["conflicts_detected"];
+  gaps: string[];
+  human_review: ResolverResult["human_review"];
+  refusals: ResolverResult["refusals"];
+  audit_log_entries_to_write: ResolverResult["audit_log_entries_to_write"];
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(obj: T): T {
+  for (const key of Object.keys(obj)) {
+    if (obj[key] === undefined) delete obj[key];
+  }
+  return obj;
+}
+
+/**
+ * Build a knowledge-aware context pack from a resolver result and an optional
+ * task / agent / skill envelope. The pack's `skill.mode` defaults to
+ * `knowledge_aware` when at least one dependency slot was satisfied, otherwise
+ * `generic`.
+ */
+export function assembleContextPack(
+  result: ResolverResult,
+  envelope: ContextPackEnvelope = {},
+): KnowledgeAwareContextPack {
+  const anySatisfied = Object.values(result.knowledge_dependencies_resolution).some(
+    (slot) => slot.satisfied_by !== null,
+  );
+  const mode = envelope.mode ?? (anySatisfied ? "knowledge_aware" : "generic");
+
+  const pack: KnowledgeAwareContextPack = {
+    context_pack_version: envelope.contextPackVersion ?? DEFAULT_CONTEXT_PACK_VERSION,
+    status: result.status,
+    task: pruneUndefined({
+      id: result.task_id,
+      purpose: envelope.task?.purpose,
+      audience: envelope.task?.audience,
+      risk_class: envelope.task?.risk_class,
+      scope_tags: envelope.task?.scope_tags,
+    }),
+    skill: {
+      id: result.skill,
+      version: result.skill_version,
+      mode,
+    },
+    knowledge_dependencies_resolution: result.knowledge_dependencies_resolution,
+    restrictions_active: result.restrictions_active,
+    conflicts_detected: result.conflicts_detected,
+    gaps: result.gaps,
+    human_review: result.human_review,
+    refusals: result.refusals,
+    audit_log_entries_to_write: result.audit_log_entries_to_write,
+  };
+
+  if (envelope.agent) {
+    pack.agent = pruneUndefined({
+      id: envelope.agent.id,
+      trust_boundary: envelope.agent.trust_boundary,
+    });
+  }
+
+  return pack;
+}
+
+/**
+ * Validate a knowledge-aware context pack against the schema.
+ * @throws SchemaValidationError if the pack does not conform.
+ */
+export function validateContextPack(pack: unknown): KnowledgeAwareContextPack {
+  return validateAgainstSchema<KnowledgeAwareContextPack>(pack, CONTEXT_PACK_SCHEMA);
+}
+
+/** Assemble and validate in one step. */
+export function buildContextPack(
+  result: ResolverResult,
+  envelope: ContextPackEnvelope = {},
+): KnowledgeAwareContextPack {
+  return validateContextPack(assembleContextPack(result, envelope));
+}

--- a/engine/index.ts
+++ b/engine/index.ts
@@ -12,3 +12,4 @@ export * from "./validation";
 export * from "./loader";
 export * from "./registry";
 export * from "./resolver";
+export * from "./context-pack";

--- a/examples/project-extension/knowledge-aware-context-pack.json
+++ b/examples/project-extension/knowledge-aware-context-pack.json
@@ -1,6 +1,7 @@
 {
   "$comment": "Example output of the knowledge-resolver for a knowledge-aware skill. Generic and safe. Not a runtime artifact.",
   "context_pack_version": "0.1.0",
+  "status": "resolved",
   "task": {
     "id": "task_2026-05-28_feat-001",
     "purpose": "Decide whether the proposed checkout simplification should ship as-is.",

--- a/schemas/aletheia-knowledge-aware-context-pack.schema.json
+++ b/schemas/aletheia-knowledge-aware-context-pack.schema.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia.local/schemas/knowledge-aware-context-pack.schema.json",
+  "title": "AletheIA Knowledge-Aware Context Pack",
+  "description": "Output of the knowledge resolver. See docs/concepts/knowledge-resolver.md and examples/project-extension/knowledge-aware-context-pack.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "context_pack_version",
+    "task",
+    "skill",
+    "knowledge_dependencies_resolution",
+    "restrictions_active",
+    "conflicts_detected",
+    "gaps",
+    "human_review",
+    "audit_log_entries_to_write"
+  ],
+  "properties": {
+    "$comment": { "type": "string" },
+    "context_pack_version": { "type": "string", "minLength": 1 },
+    "status": { "type": "string", "enum": ["resolved", "refused"] },
+    "task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "purpose": { "type": "string" },
+        "audience": { "type": "string" },
+        "risk_class": { "type": "string" },
+        "scope_tags": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "trust_boundary": { "type": "string" }
+      }
+    },
+    "skill": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version", "mode"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "mode": { "type": "string", "enum": ["knowledge_aware", "generic"] }
+      }
+    },
+    "knowledge_dependencies_resolution": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["satisfied_by"],
+        "properties": {
+          "required": { "type": "boolean" },
+          "required_when_matched": { "type": "boolean" },
+          "candidates_considered": { "type": "integer", "minimum": 0 },
+          "fallback_applied": { "type": "string" },
+          "satisfied_by": {
+            "oneOf": [
+              { "type": "null" },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["source_id", "source_version", "retrieved_scope", "retrieval_mode_applied"],
+                "properties": {
+                  "source_id": { "type": "string", "minLength": 1 },
+                  "source_version": { "type": "string", "minLength": 1 },
+                  "retrieved_scope": {
+                    "type": "string",
+                    "enum": ["capsule", "excerpt", "metadata", "full", "pending_review"]
+                  },
+                  "retrieval_mode_applied": {
+                    "type": "string",
+                    "enum": [
+                      "capsule_first",
+                      "excerpt_only",
+                      "metadata_only",
+                      "full_source_allowed",
+                      "human_review_required",
+                      "blocked"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "restrictions_active": { "type": "array", "items": { "type": "string" } },
+    "conflicts_detected": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["between", "topic", "resolved_by", "prevailing_source", "suppressed_sources", "human_review_required"],
+        "properties": {
+          "conflict_id": { "type": "string" },
+          "between": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 2,
+            "maxItems": 2
+          },
+          "topic": { "type": "string", "minLength": 1 },
+          "resolved_by": { "type": "string", "enum": ["source_precedence_policy", "escalation"] },
+          "prevailing_source": { "type": ["string", "null"] },
+          "suppressed_sources": { "type": "array", "items": { "type": "string" } },
+          "human_review_required": { "type": "boolean" },
+          "human_review_reason": { "type": "string" }
+        }
+      }
+    },
+    "gaps": { "type": "array", "items": { "type": "string" } },
+    "human_review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "reasons"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "reasons": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "refusals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["slot", "reason", "fallback"],
+        "properties": {
+          "slot": { "type": "string" },
+          "reason": { "type": "string", "enum": ["required_source_missing", "restricted_not_authorized"] },
+          "fallback": { "type": "string" }
+        }
+      }
+    },
+    "audit_log_entries_to_write": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source_id", "source_version", "retrieved_scope", "sensitivity", "authority_level"],
+        "properties": {
+          "source_id": { "type": "string", "minLength": 1 },
+          "source_version": { "type": "string", "minLength": 1 },
+          "retrieved_scope": {
+            "type": "string",
+            "enum": ["capsule", "excerpt", "metadata", "full", "pending_review"]
+          },
+          "sensitivity": {
+            "type": "string",
+            "enum": ["public", "internal", "confidential", "restricted", "regulated"]
+          },
+          "authority_level": {
+            "type": "string",
+            "enum": [
+              "mandatory",
+              "normative",
+              "procedural",
+              "strategic",
+              "interpretive",
+              "evidence_proxy",
+              "evidential",
+              "comparative",
+              "contextual"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/context-pack/test-context-pack.test.ts
+++ b/tests/context-pack/test-context-pack.test.ts
@@ -1,0 +1,152 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import {
+  KnowledgeRegistry,
+  resolveKnowledge,
+  assembleContextPack,
+  validateContextPack,
+  buildContextPack,
+  SchemaValidationError,
+} from "../../engine";
+import type {
+  KnowledgePackManifest,
+  KnowledgeSourceType,
+  SkillKnowledgeDependency,
+} from "../../engine";
+
+function makePack(o: {
+  id: string;
+  type?: KnowledgeSourceType;
+  scope?: string[];
+}): KnowledgePackManifest {
+  return {
+    knowledge_pack: {
+      id: o.id,
+      name: `Pack ${o.id}`,
+      type: o.type ?? "proprietary_framework",
+      owner: "test-owner",
+      version: "1.0.0",
+      sensitivity: "internal",
+      authority_level: "interpretive",
+      scope: o.scope ?? ["general"],
+      retrieval_mode: "capsule_first",
+      citation_required: true,
+      full_text_exposure: "forbidden",
+      export_allowed: false,
+      human_review_required_for: [],
+      expiry: { review_cycle: "quarterly", expires_on: null },
+      source_location: "examples/example.md",
+      source_integrity_notes: "test fixture",
+    },
+  };
+}
+
+function deps(
+  knowledge_dependencies: SkillKnowledgeDependency["knowledge_dependencies"],
+  fallbackOverrides: Partial<SkillKnowledgeDependency["fallback_behavior"]> = {},
+): SkillKnowledgeDependency {
+  return {
+    skill: "feature-value-governance",
+    version: "0.1.0",
+    knowledge_dependencies,
+    fallback_behavior: {
+      missing_required_source: "stop_and_request_source",
+      missing_optional_source: "continue_with_assumption_marker",
+      restricted_source: "request_authorized_context_pack",
+      conflicting_sources: "apply_source_precedence_policy",
+      ...fallbackOverrides,
+    },
+  };
+}
+
+describe("knowledge-aware context pack — schema", () => {
+  it("the committed example validates against the schema", () => {
+    const example = JSON.parse(
+      fs.readFileSync(
+        path.resolve(process.cwd(), "examples/project-extension/knowledge-aware-context-pack.json"),
+        "utf-8",
+      ),
+    );
+    expect(() => validateContextPack(example)).not.toThrow();
+  });
+
+  it("rejects a malformed pack", () => {
+    expect(() => validateContextPack({ context_pack_version: "0.1.0" })).toThrow(SchemaValidationError);
+  });
+});
+
+describe("assembleContextPack", () => {
+  const registry = new KnowledgeRegistry([makePack({ id: "fw", scope: ["general"] })]);
+  const skillDeps = deps({
+    strategic_framework: { required: true, accepted_types: ["proprietary_framework"] },
+  });
+
+  it("maps resolver fields into the pack envelope", () => {
+    const result = resolveKnowledge({ id: "t1", scope: ["general"] }, skillDeps, registry);
+    const pack = assembleContextPack(result, {
+      task: { purpose: "decide", scope_tags: ["general"] },
+      agent: { id: "product-agent", trust_boundary: "project-internal" },
+    });
+    expect(pack.task.id).toBe("t1");
+    expect(pack.task.purpose).toBe("decide");
+    expect(pack.skill).toEqual({ id: "feature-value-governance", version: "0.1.0", mode: "knowledge_aware" });
+    expect(pack.agent).toEqual({ id: "product-agent", trust_boundary: "project-internal" });
+    expect(pack.status).toBe("resolved");
+  });
+
+  it("defaults skill mode to generic when nothing was satisfied", () => {
+    const emptyReg = new KnowledgeRegistry([]);
+    const result = resolveKnowledge(
+      { id: "t2", scope: ["general"] },
+      deps(
+        { strategic_framework: { required: true, accepted_types: ["proprietary_framework"] } },
+        { missing_required_source: "continue_in_generic_mode" },
+      ),
+      emptyReg,
+    );
+    const pack = assembleContextPack(result);
+    expect(pack.skill.mode).toBe("generic");
+  });
+
+  it("omits the agent block when no agent is provided", () => {
+    const result = resolveKnowledge({ id: "t3", scope: ["general"] }, skillDeps, registry);
+    const pack = assembleContextPack(result);
+    expect(pack.agent).toBeUndefined();
+  });
+
+  it("does not emit undefined task fields", () => {
+    const result = resolveKnowledge({ id: "t4", scope: ["general"] }, skillDeps, registry);
+    const pack = assembleContextPack(result);
+    expect(Object.prototype.hasOwnProperty.call(pack.task, "purpose")).toBe(false);
+  });
+});
+
+describe("buildContextPack — assemble + validate roundtrip", () => {
+  it("produces a schema-valid pack for a resolved task", () => {
+    const registry = new KnowledgeRegistry([
+      makePack({ id: "fw", scope: ["feature_governance"] }),
+      makePack({ id: "persona", type: "persona", scope: ["feature_governance"] }),
+    ]);
+    const skillDeps = deps({
+      strategic_framework: { required: true, accepted_types: ["proprietary_framework"] },
+      personas: { required: false, accepted_types: ["persona"] },
+    });
+    const result = resolveKnowledge({ id: "t", scope: ["feature_governance"] }, skillDeps, registry);
+    expect(() =>
+      buildContextPack(result, { task: { scope_tags: ["feature_governance"] }, agent: { id: "a" } }),
+    ).not.toThrow();
+  });
+
+  it("produces a schema-valid pack for a refused task", () => {
+    const registry = new KnowledgeRegistry([]);
+    const skillDeps = deps({
+      strategic_framework: { required: true, accepted_types: ["proprietary_framework"] },
+    });
+    const result = resolveKnowledge({ id: "t", scope: ["general"] }, skillDeps, registry);
+    const pack = buildContextPack(result);
+    expect(pack.status).toBe("refused");
+    expect(pack.refusals.length).toBeGreaterThan(0);
+    expect(pack.gaps).toContain("strategic_framework");
+  });
+});

--- a/tests/contracts/test-contracts.test.ts
+++ b/tests/contracts/test-contracts.test.ts
@@ -51,6 +51,11 @@ const fixtures = [
     fixture: "examples/project-extension/skill-knowledge-dependency.example.json",
     schema: "aletheia-skill-knowledge-dependency.schema.json",
   },
+  {
+    name: "Knowledge-Aware Context Pack",
+    fixture: "examples/project-extension/knowledge-aware-context-pack.json",
+    schema: "aletheia-knowledge-aware-context-pack.schema.json",
+  },
 ];
 
 describe("Contract validation", () => {


### PR DESCRIPTION
## Knowledge Governance Layer — engine, build step 4 (context-pack assembly)

Implements **step 4** of the Phase 5 brief, on top of loaders (#167), registry (#168), and resolver (#169).

### What
Gives the resolver's output a stable, schema-validated on-the-wire shape.

- **`schemas/aletheia-knowledge-aware-context-pack.schema.json`** — JSON Schema for the knowledge-aware context pack (task/agent/skill envelope + `knowledge_dependencies_resolution`, `restrictions_active`, `conflicts_detected`, `gaps`, `human_review`, `refusals`, `audit_log_entries_to_write`). This is the distinct shape the brief flagged — *not* the generic `aletheia-context-pack.schema.json`.
- **`engine/context-pack.ts`**
  - `assembleContextPack(result, envelope)` — serializes a `ResolverResult`; `skill.mode` defaults to `knowledge_aware` when any slot was satisfied, else `generic`; prunes undefined envelope fields.
  - `validateContextPack(pack)` — schema validation.
  - `buildContextPack(result, envelope)` — assemble + validate in one step.
- **`examples/project-extension/knowledge-aware-context-pack.json`** — added `status`; now schema-validated in the contracts test fixtures.
- **`tests/context-pack/`** — example validates, field mapping, generic-mode default, agent omission, and assemble→validate roundtrips for resolved and refused tasks.

### Scope discipline (per brief)
- Pure serialization + schema validation; no content retrieval, network, DB/IAM/DLP/embeddings.
- The generic context-pack schema was not bent to cover this; a dedicated schema was added (IN scope per the brief).
- No new taxonomy values.

### Validation
- `npx tsc --noEmit` → clean.
- `pnpm run test` → **65 passed** (7 files).
- `pnpm run check:governance` → passes.

Remaining: step 5 (audit-log writer), step 6 (e2e golden).

One PR. **Do not merge — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)