### PR TITLE
feat(engine): knowledge audit-log writer (KGL step 5)

### DIFF
--- a/engine/audit-log.ts
+++ b/engine/audit-log.ts
@@ -1,0 +1,224 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { ResolverResult } from "./resolver";
+
+/**
+ * Knowledge Governance Layer — audit-log writer (build step 5).
+ *
+ * Emits audit entries per docs/contracts/knowledge-audit-log-spec.md from a
+ * resolver result: one `select` entry per satisfied dependency slot, one
+ * `conflict` entry per resolved conflict, and one `refusal` entry per refusal.
+ *
+ * INVARIANT: an audit entry carries identifiers, versions, scope, restrictions,
+ * and decisions — never source content. The {@link AuditLogEntry} shape has no
+ * field for excerpts, so restricted text cannot be logged by construction. Do
+ * not widen it to carry source text. (Per restricted-knowledge-usage-policy.md
+ * and docs/security/logs-and-handoffs-policy.md.)
+ *
+ * Out of scope (per the implementation-prep brief): DLP/secret scanning,
+ * retention enforcement, network sinks, encryption. The file sink is a thin,
+ * append-only reference implementation.
+ */
+
+export type AuditEntryType = "select" | "conflict" | "refusal";
+
+export interface AuditLogEntry {
+  entry_type: AuditEntryType;
+  task_id: string;
+  skill_id: string;
+  skill_version: string;
+  human_review_required: boolean;
+  decision_output: string;
+  timestamp: string;
+
+  agent_id?: string;
+  user_id?: string;
+  project_id?: string;
+  trust_boundary?: string;
+  resolver_version?: string;
+
+  source_id?: string;
+  source_version?: string;
+  sensitivity?: string;
+  authority_level?: string;
+  retrieved_scope?: string;
+  retrieval_mode_applied?: string;
+  restrictions_applied?: string[];
+
+  human_review_reason?: string;
+
+  conflict_id?: string;
+  prevailing_source?: string | null;
+  suppressed_sources?: string[];
+
+  fallback_applied?: string;
+  refusal_reason?: string;
+}
+
+export interface AuditContext {
+  agent_id?: string;
+  user_id?: string;
+  project_id?: string;
+  trust_boundary?: string;
+  resolver_version?: string;
+  /** Injectable for deterministic output; defaults to now (ISO 8601 UTC). */
+  timestamp?: string;
+}
+
+export interface AuditSink {
+  write(entry: AuditLogEntry): void;
+}
+
+/** Collects entries in memory; useful for tests and review-before-flush. */
+export class InMemoryAuditSink implements AuditSink {
+  readonly entries: AuditLogEntry[] = [];
+  write(entry: AuditLogEntry): void {
+    this.entries.push(entry);
+  }
+}
+
+/** Append-only JSON Lines sink. One JSON entry per line. */
+export class FileAuditSink implements AuditSink {
+  constructor(private readonly filePath: string) {
+    const dir = path.dirname(path.resolve(filePath));
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+  }
+  write(entry: AuditLogEntry): void {
+    fs.appendFileSync(this.filePath, `${JSON.stringify(entry)}\n`, "utf-8");
+  }
+}
+
+const RESTRICTION_PREFIX: Record<string, string> = {
+  citation_required_for: "citation_required",
+  no_export_for: "no_export",
+  no_verbatim_for: "no_verbatim",
+};
+
+/** Map `citation_required_for:<id>` tokens for one source to bare restriction names. */
+function restrictionsForSource(active: string[], sourceId: string): string[] {
+  const out: string[] = [];
+  for (const token of active) {
+    const idx = token.lastIndexOf(":");
+    if (idx === -1) continue;
+    const prefix = token.slice(0, idx);
+    const id = token.slice(idx + 1);
+    if (id === sourceId && RESTRICTION_PREFIX[prefix]) {
+      out.push(RESTRICTION_PREFIX[prefix]);
+    }
+  }
+  return out.sort();
+}
+
+function reviewReasonsForSource(reasons: string[], sourceId: string): string[] {
+  return reasons.filter((r) => r.includes(`:${sourceId}`));
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(obj: T): T {
+  for (const key of Object.keys(obj)) {
+    if (obj[key] === undefined) delete obj[key];
+  }
+  return obj;
+}
+
+/**
+ * Build spec-compliant audit entries from a resolver result. Pure: deterministic
+ * given a fixed `timestamp` in context.
+ */
+export function buildAuditEntries(
+  result: ResolverResult,
+  context: AuditContext = {},
+): AuditLogEntry[] {
+  const timestamp = context.timestamp ?? new Date().toISOString();
+  const base = pruneUndefined({
+    task_id: result.task_id,
+    skill_id: result.skill,
+    skill_version: result.skill_version,
+    agent_id: context.agent_id,
+    user_id: context.user_id,
+    project_id: context.project_id,
+    trust_boundary: context.trust_boundary,
+    resolver_version: context.resolver_version,
+    timestamp,
+  });
+
+  const entries: AuditLogEntry[] = [];
+
+  // select entries — one per satisfied slot
+  const auditBySource = new Map(
+    result.audit_log_entries_to_write.map((e) => [e.source_id, e]),
+  );
+  for (const [slot, res] of Object.entries(result.knowledge_dependencies_resolution)) {
+    const sat = res.satisfied_by;
+    if (!sat) continue;
+    const meta = auditBySource.get(sat.source_id);
+    const reviewReasons = reviewReasonsForSource(result.human_review.reasons, sat.source_id);
+    entries.push(
+      pruneUndefined({
+        ...base,
+        entry_type: "select",
+        source_id: sat.source_id,
+        source_version: sat.source_version,
+        sensitivity: meta?.sensitivity,
+        authority_level: meta?.authority_level,
+        retrieved_scope: sat.retrieved_scope,
+        retrieval_mode_applied: sat.retrieval_mode_applied,
+        restrictions_applied: restrictionsForSource(result.restrictions_active, sat.source_id),
+        human_review_required: reviewReasons.length > 0,
+        human_review_reason: reviewReasons.length > 0 ? reviewReasons.join("; ") : undefined,
+        decision_output: `Selected ${sat.source_id}@${sat.source_version} for slot "${slot}" (${sat.retrieved_scope}).`,
+      }) as AuditLogEntry,
+    );
+  }
+
+  // conflict entries
+  for (const conflict of result.conflicts_detected) {
+    entries.push(
+      pruneUndefined({
+        ...base,
+        entry_type: "conflict",
+        conflict_id: conflict.conflict_id,
+        prevailing_source: conflict.prevailing_source,
+        suppressed_sources: conflict.suppressed_sources,
+        human_review_required: conflict.human_review_required,
+        human_review_reason: conflict.human_review_reason,
+        decision_output: `Conflict on "${conflict.topic}" resolved_by ${conflict.resolved_by}${
+          conflict.prevailing_source ? `; prevailing ${conflict.prevailing_source}` : "; escalated"
+        }.`,
+      }) as AuditLogEntry,
+    );
+  }
+
+  // refusal entries
+  for (const refusal of result.refusals) {
+    entries.push(
+      pruneUndefined({
+        ...base,
+        entry_type: "refusal",
+        human_review_required: false,
+        fallback_applied: refusal.fallback,
+        refusal_reason: `${refusal.reason} for slot "${refusal.slot}"; fallback ${refusal.fallback}.`,
+        decision_output: `Refused slot "${refusal.slot}" (${refusal.reason}).`,
+      }) as AuditLogEntry,
+    );
+  }
+
+  return entries;
+}
+
+/**
+ * Build audit entries from a resolver result and write each to the sink.
+ * Returns the entries written.
+ */
+export function recordResolution(
+  result: ResolverResult,
+  sink: AuditSink,
+  context: AuditContext = {},
+): AuditLogEntry[] {
+  const entries = buildAuditEntries(result, context);
+  for (const entry of entries) {
+    sink.write(entry);
+  }
+  return entries;
+}

--- a/engine/index.ts
+++ b/engine/index.ts
@@ -13,3 +13,4 @@ export * from "./loader";
 export * from "./registry";
 export * from "./resolver";
 export * from "./context-pack";
+export * from "./audit-log";

--- a/tests/audit-log/test-audit-log.test.ts
+++ b/tests/audit-log/test-audit-log.test.ts
@@ -1,0 +1,218 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import {
+  KnowledgeRegistry,
+  resolveKnowledge,
+  buildAuditEntries,
+  recordResolution,
+  InMemoryAuditSink,
+  FileAuditSink,
+} from "../../engine";
+import type {
+  AuditLogEntry,
+  KnowledgePackManifest,
+  KnowledgeSourceType,
+  SkillKnowledgeDependency,
+} from "../../engine";
+
+const FIXED_TS = "2026-05-29T12:00:00.000Z";
+
+const ALLOWED_KEYS = new Set<keyof AuditLogEntry>([
+  "entry_type",
+  "task_id",
+  "skill_id",
+  "skill_version",
+  "human_review_required",
+  "decision_output",
+  "timestamp",
+  "agent_id",
+  "user_id",
+  "project_id",
+  "trust_boundary",
+  "resolver_version",
+  "source_id",
+  "source_version",
+  "sensitivity",
+  "authority_level",
+  "retrieved_scope",
+  "retrieval_mode_applied",
+  "restrictions_applied",
+  "human_review_reason",
+  "conflict_id",
+  "prevailing_source",
+  "suppressed_sources",
+  "fallback_applied",
+  "refusal_reason",
+]);
+
+function makePack(o: {
+  id: string;
+  type?: KnowledgeSourceType;
+  scope?: string[];
+  human_review_required_for?: string[];
+}): KnowledgePackManifest {
+  return {
+    knowledge_pack: {
+      id: o.id,
+      name: `Pack ${o.id}`,
+      type: o.type ?? "proprietary_framework",
+      owner: "test-owner",
+      version: "1.0.0",
+      sensitivity: "internal",
+      authority_level: "interpretive",
+      scope: o.scope ?? ["general"],
+      retrieval_mode: "capsule_first",
+      citation_required: true,
+      full_text_exposure: "forbidden",
+      export_allowed: false,
+      human_review_required_for: o.human_review_required_for ?? [],
+      expiry: { review_cycle: "quarterly", expires_on: null },
+      source_location: "examples/example.md",
+      source_integrity_notes: "test fixture",
+    },
+  };
+}
+
+function deps(
+  knowledge_dependencies: SkillKnowledgeDependency["knowledge_dependencies"],
+  fallbackOverrides: Partial<SkillKnowledgeDependency["fallback_behavior"]> = {},
+): SkillKnowledgeDependency {
+  return {
+    skill: "feature-value-governance",
+    version: "0.1.0",
+    knowledge_dependencies,
+    fallback_behavior: {
+      missing_required_source: "stop_and_request_source",
+      missing_optional_source: "continue_with_assumption_marker",
+      restricted_source: "request_authorized_context_pack",
+      conflicting_sources: "apply_source_precedence_policy",
+      ...fallbackOverrides,
+    },
+  };
+}
+
+describe("buildAuditEntries — select", () => {
+  const registry = new KnowledgeRegistry([makePack({ id: "fw", scope: ["general"] })]);
+  const skillDeps = deps({ strategic_framework: { required: true, accepted_types: ["proprietary_framework"] } });
+
+  it("emits one select entry per satisfied slot with full spec fields", () => {
+    const result = resolveKnowledge({ id: "t1", scope: ["general"] }, skillDeps, registry);
+    const [entry] = buildAuditEntries(result, { agent_id: "product-agent", timestamp: FIXED_TS });
+    expect(entry).toMatchObject({
+      entry_type: "select",
+      task_id: "t1",
+      skill_id: "feature-value-governance",
+      skill_version: "0.1.0",
+      agent_id: "product-agent",
+      source_id: "fw",
+      source_version: "1.0.0",
+      sensitivity: "internal",
+      authority_level: "interpretive",
+      retrieved_scope: "capsule",
+      retrieval_mode_applied: "capsule_first",
+      human_review_required: false,
+      timestamp: FIXED_TS,
+    });
+  });
+
+  it("translates restrictions_active tokens into per-source restriction names", () => {
+    const result = resolveKnowledge({ id: "t1", scope: ["general"] }, skillDeps, registry);
+    const [entry] = buildAuditEntries(result, { timestamp: FIXED_TS });
+    expect(entry.restrictions_applied).toEqual(["citation_required", "no_export", "no_verbatim"]);
+  });
+
+  it("never writes fields outside the audit schema (no source content)", () => {
+    const result = resolveKnowledge({ id: "t1", scope: ["general"] }, skillDeps, registry);
+    for (const entry of buildAuditEntries(result, { timestamp: FIXED_TS })) {
+      for (const key of Object.keys(entry)) {
+        expect(ALLOWED_KEYS.has(key as keyof AuditLogEntry)).toBe(true);
+      }
+    }
+  });
+
+  it("flags human review on the source whose condition matched the task", () => {
+    const reg = new KnowledgeRegistry([
+      makePack({ id: "fw", scope: ["general"], human_review_required_for: ["client_delivery"] }),
+    ]);
+    const result = resolveKnowledge(
+      { id: "t1", scope: ["general"], humanReviewConditions: ["client_delivery"] },
+      skillDeps,
+      reg,
+    );
+    const select = buildAuditEntries(result, { timestamp: FIXED_TS }).find((e) => e.entry_type === "select");
+    expect(select?.human_review_required).toBe(true);
+    expect(select?.human_review_reason).toContain("client_delivery");
+  });
+});
+
+describe("buildAuditEntries — conflict and refusal", () => {
+  it("emits a conflict entry with prevailing and suppressed sources", () => {
+    const registry = new KnowledgeRegistry([
+      makePack({ id: "persona", type: "persona", scope: ["interface_change"] }),
+      makePack({ id: "wcag", type: "accessibility_guideline", scope: ["interface_change"] }),
+    ]);
+    const skillDeps = deps({
+      personas: { required: false, accepted_types: ["persona"] },
+      accessibility_guidelines: { required_when: ["interface_change"], accepted_types: ["accessibility_guideline"] },
+    });
+    const result = resolveKnowledge(
+      { id: "t", scope: ["interface_change"] },
+      skillDeps,
+      registry,
+      { declaredConflicts: [{ between: ["personas", "accessibility_guidelines"], topic: "labels", conflictId: "c1" }] },
+    );
+    const conflict = buildAuditEntries(result, { timestamp: FIXED_TS }).find((e) => e.entry_type === "conflict");
+    expect(conflict).toMatchObject({ conflict_id: "c1", human_review_required: false });
+    expect(conflict?.prevailing_source).toBe("wcag@1.0.0");
+    expect(conflict?.suppressed_sources).toEqual(["persona@1.0.0"]);
+  });
+
+  it("emits a refusal entry for a missing required source", () => {
+    const registry = new KnowledgeRegistry([]);
+    const skillDeps = deps({ strategic_framework: { required: true, accepted_types: ["proprietary_framework"] } });
+    const result = resolveKnowledge({ id: "t", scope: ["general"] }, skillDeps, registry);
+    const refusal = buildAuditEntries(result, { timestamp: FIXED_TS }).find((e) => e.entry_type === "refusal");
+    expect(refusal).toBeDefined();
+    expect(refusal?.refusal_reason).toContain("required_source_missing");
+    expect(refusal?.fallback_applied).toBe("stop_and_request_source");
+  });
+
+  it("is deterministic for a fixed timestamp", () => {
+    const registry = new KnowledgeRegistry([makePack({ id: "fw", scope: ["general"] })]);
+    const skillDeps = deps({ strategic_framework: { required: true, accepted_types: ["proprietary_framework"] } });
+    const result = resolveKnowledge({ id: "t", scope: ["general"] }, skillDeps, registry);
+    const a = buildAuditEntries(result, { timestamp: FIXED_TS });
+    const b = buildAuditEntries(result, { timestamp: FIXED_TS });
+    expect(a).toEqual(b);
+  });
+});
+
+describe("sinks", () => {
+  const registry = new KnowledgeRegistry([makePack({ id: "fw", scope: ["general"] })]);
+  const skillDeps = deps({ strategic_framework: { required: true, accepted_types: ["proprietary_framework"] } });
+
+  it("recordResolution writes every entry to an in-memory sink", () => {
+    const result = resolveKnowledge({ id: "t", scope: ["general"] }, skillDeps, registry);
+    const sink = new InMemoryAuditSink();
+    const written = recordResolution(result, sink, { timestamp: FIXED_TS });
+    expect(sink.entries).toEqual(written);
+    expect(sink.entries.length).toBeGreaterThan(0);
+  });
+
+  it("FileAuditSink appends one JSON object per line", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kg-audit-"));
+    try {
+      const file = path.join(dir, "nested", "audit.jsonl");
+      const sink = new FileAuditSink(file);
+      const result = resolveKnowledge({ id: "t", scope: ["general"] }, skillDeps, registry);
+      const written = recordResolution(result, sink, { timestamp: FIXED_TS });
+      const lines = fs.readFileSync(file, "utf-8").trim().split("\n");
+      expect(lines).toHaveLength(written.length);
+      expect(JSON.parse(lines[0]).entry_type).toBe("select");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Knowledge Governance Layer — engine, build step 5 (audit-log writer)

Implements **step 5** of the Phase 5 brief, on top of loaders (#167), registry (#168), resolver (#169), and context-pack (#170).

### What
Turns a resolver result into an auditable trail per `docs/contracts/knowledge-audit-log-spec.md`.

- **`engine/audit-log.ts`**
  - `buildAuditEntries(result, context)` — emits one `select` entry per satisfied slot (full spec fields: source id/version, sensitivity, authority, `retrieved_scope`, `retrieval_mode_applied`, `restrictions_applied`, per-source `human_review`), one `conflict` entry per resolved conflict (prevailing/suppressed, escalation), and one `refusal` entry per refusal.
  - `AuditSink` interface + `InMemoryAuditSink` and an append-only JSONL `FileAuditSink`.
  - `recordResolution(result, sink, context)` — build + write.

### Security invariant
An entry carries **identifiers, versions, scope, restrictions, and decisions — never source content.** The entry shape has no excerpt field, so restricted text cannot be logged by construction (per `restricted-knowledge-usage-policy.md` and `docs/security/logs-and-handoffs-policy.md`). A test asserts no entry ever carries a field outside the audit schema.

### Scope discipline (per brief)
- Pure + deterministic given a fixed timestamp.
- No DLP/secret scanning, retention enforcement, network sinks, or crypto.

### Validation
- `npx tsc --noEmit` → clean.
- `pnpm run test` → **74 passed** (8 files; 9 new).
- `pnpm run check:governance` → passes.

Remaining: step 6 — end-to-end golden.

One PR. **Do not merge — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)