### PR TITLE
test(engine): end-to-end golden for the knowledge governance pipeline (KGL step 6)

### DIFF
--- a/examples/goldens/knowledge-resolution.json
+++ b/examples/goldens/knowledge-resolution.json
@@ -1,0 +1,210 @@
+{
+  "context_pack": {
+    "context_pack_version": "0.1.0",
+    "status": "resolved",
+    "task": {
+      "id": "task_2026-05-29_feat-001",
+      "purpose": "Decide whether the proposed checkout simplification should ship as-is.",
+      "audience": "internal_review",
+      "risk_class": "medium",
+      "scope_tags": [
+        "feature_governance",
+        "customer_facing_experience",
+        "interface_change"
+      ]
+    },
+    "skill": {
+      "id": "feature-value-governance",
+      "version": "0.1.0",
+      "mode": "knowledge_aware"
+    },
+    "knowledge_dependencies_resolution": {
+      "strategic_framework": {
+        "required": true,
+        "satisfied_by": {
+          "source_id": "example-4-layers",
+          "source_version": "1.0.0",
+          "retrieved_scope": "capsule",
+          "retrieval_mode_applied": "capsule_first"
+        },
+        "candidates_considered": 1
+      },
+      "personas": {
+        "required": false,
+        "satisfied_by": {
+          "source_id": "example-persona-casual-shopper",
+          "source_version": "0.4.0",
+          "retrieved_scope": "capsule",
+          "retrieval_mode_applied": "capsule_first"
+        },
+        "candidates_considered": 1
+      },
+      "accessibility_guidelines": {
+        "required": true,
+        "required_when_matched": true,
+        "satisfied_by": {
+          "source_id": "wcag-internal",
+          "source_version": "1.2.0",
+          "retrieved_scope": "excerpt",
+          "retrieval_mode_applied": "excerpt_only"
+        },
+        "candidates_considered": 1
+      }
+    },
+    "restrictions_active": [
+      "citation_required_for:example-4-layers",
+      "citation_required_for:example-persona-casual-shopper",
+      "citation_required_for:wcag-internal",
+      "no_export_for:example-4-layers",
+      "no_export_for:example-persona-casual-shopper",
+      "no_export_for:wcag-internal",
+      "no_verbatim_for:example-4-layers",
+      "no_verbatim_for:example-persona-casual-shopper"
+    ],
+    "conflicts_detected": [
+      {
+        "conflict_id": "conflict_2026-05-29_001",
+        "between": [
+          "example-persona-casual-shopper@0.4.0",
+          "wcag-internal@1.2.0"
+        ],
+        "topic": "explicit form labels on checkout fields",
+        "resolved_by": "source_precedence_policy",
+        "prevailing_source": "wcag-internal@1.2.0",
+        "suppressed_sources": [
+          "example-persona-casual-shopper@0.4.0"
+        ],
+        "human_review_required": false
+      }
+    ],
+    "gaps": [],
+    "human_review": {
+      "required": true,
+      "reasons": [
+        "source_condition:example-4-layers:external_publication",
+        "source_condition:wcag-internal:external_publication"
+      ]
+    },
+    "refusals": [],
+    "audit_log_entries_to_write": [
+      {
+        "source_id": "example-4-layers",
+        "source_version": "1.0.0",
+        "retrieved_scope": "capsule",
+        "sensitivity": "internal",
+        "authority_level": "interpretive"
+      },
+      {
+        "source_id": "example-persona-casual-shopper",
+        "source_version": "0.4.0",
+        "retrieved_scope": "capsule",
+        "sensitivity": "internal",
+        "authority_level": "evidence_proxy"
+      },
+      {
+        "source_id": "wcag-internal",
+        "source_version": "1.2.0",
+        "retrieved_scope": "excerpt",
+        "sensitivity": "internal",
+        "authority_level": "normative"
+      }
+    ],
+    "agent": {
+      "id": "product-agent",
+      "trust_boundary": "project-acme-internal"
+    }
+  },
+  "audit_entries": [
+    {
+      "task_id": "task_2026-05-29_feat-001",
+      "skill_id": "feature-value-governance",
+      "skill_version": "0.1.0",
+      "agent_id": "product-agent",
+      "project_id": "project-acme",
+      "trust_boundary": "project-acme-internal",
+      "resolver_version": "0.1.0",
+      "timestamp": "2026-05-29T12:00:00.000Z",
+      "entry_type": "select",
+      "source_id": "example-4-layers",
+      "source_version": "1.0.0",
+      "sensitivity": "internal",
+      "authority_level": "interpretive",
+      "retrieved_scope": "capsule",
+      "retrieval_mode_applied": "capsule_first",
+      "restrictions_applied": [
+        "citation_required",
+        "no_export",
+        "no_verbatim"
+      ],
+      "human_review_required": true,
+      "human_review_reason": "source_condition:example-4-layers:external_publication",
+      "decision_output": "Selected example-4-layers@1.0.0 for slot \"strategic_framework\" (capsule)."
+    },
+    {
+      "task_id": "task_2026-05-29_feat-001",
+      "skill_id": "feature-value-governance",
+      "skill_version": "0.1.0",
+      "agent_id": "product-agent",
+      "project_id": "project-acme",
+      "trust_boundary": "project-acme-internal",
+      "resolver_version": "0.1.0",
+      "timestamp": "2026-05-29T12:00:00.000Z",
+      "entry_type": "select",
+      "source_id": "example-persona-casual-shopper",
+      "source_version": "0.4.0",
+      "sensitivity": "internal",
+      "authority_level": "evidence_proxy",
+      "retrieved_scope": "capsule",
+      "retrieval_mode_applied": "capsule_first",
+      "restrictions_applied": [
+        "citation_required",
+        "no_export",
+        "no_verbatim"
+      ],
+      "human_review_required": false,
+      "decision_output": "Selected example-persona-casual-shopper@0.4.0 for slot \"personas\" (capsule)."
+    },
+    {
+      "task_id": "task_2026-05-29_feat-001",
+      "skill_id": "feature-value-governance",
+      "skill_version": "0.1.0",
+      "agent_id": "product-agent",
+      "project_id": "project-acme",
+      "trust_boundary": "project-acme-internal",
+      "resolver_version": "0.1.0",
+      "timestamp": "2026-05-29T12:00:00.000Z",
+      "entry_type": "select",
+      "source_id": "wcag-internal",
+      "source_version": "1.2.0",
+      "sensitivity": "internal",
+      "authority_level": "normative",
+      "retrieved_scope": "excerpt",
+      "retrieval_mode_applied": "excerpt_only",
+      "restrictions_applied": [
+        "citation_required",
+        "no_export"
+      ],
+      "human_review_required": true,
+      "human_review_reason": "source_condition:wcag-internal:external_publication",
+      "decision_output": "Selected wcag-internal@1.2.0 for slot \"accessibility_guidelines\" (excerpt)."
+    },
+    {
+      "task_id": "task_2026-05-29_feat-001",
+      "skill_id": "feature-value-governance",
+      "skill_version": "0.1.0",
+      "agent_id": "product-agent",
+      "project_id": "project-acme",
+      "trust_boundary": "project-acme-internal",
+      "resolver_version": "0.1.0",
+      "timestamp": "2026-05-29T12:00:00.000Z",
+      "entry_type": "conflict",
+      "conflict_id": "conflict_2026-05-29_001",
+      "prevailing_source": "wcag-internal@1.2.0",
+      "suppressed_sources": [
+        "example-persona-casual-shopper@0.4.0"
+      ],
+      "human_review_required": false,
+      "decision_output": "Conflict on \"explicit form labels on checkout fields\" resolved_by source_precedence_policy; prevailing wcag-internal@1.2.0."
+    }
+  ]
+}

--- a/examples/project-extension/e2e/packs/example-4-layers.json
+++ b/examples/project-extension/e2e/packs/example-4-layers.json
@@ -1,0 +1,23 @@
+{
+  "knowledge_pack": {
+    "id": "example-4-layers",
+    "name": "Example 4 Layers Framework",
+    "type": "proprietary_framework",
+    "owner": "Knowledge Governance WG",
+    "version": "1.0.0",
+    "sensitivity": "internal",
+    "authority_level": "interpretive",
+    "scope": ["feature_governance", "product_strategy"],
+    "allowed_skills": ["feature-value-governance"],
+    "allowed_agents": ["product-agent", "design-agent"],
+    "retrieval_mode": "capsule_first",
+    "citation_required": true,
+    "full_text_exposure": "forbidden",
+    "export_allowed": false,
+    "human_review_required_for": ["external_publication", "client_delivery"],
+    "expiry": { "review_cycle": "quarterly", "expires_on": null },
+    "source_location": "examples/project-extension/knowledge-packs/example-4-layers/source-link.md",
+    "source_integrity_notes": "Generic, vendor-agnostic example pack; contains no proprietary or client content.",
+    "tags": ["framework", "interpretive", "example"]
+  }
+}

--- a/examples/project-extension/e2e/packs/persona-casual-shopper.json
+++ b/examples/project-extension/e2e/packs/persona-casual-shopper.json
@@ -1,0 +1,23 @@
+{
+  "knowledge_pack": {
+    "id": "example-persona-casual-shopper",
+    "name": "Example Persona — Casual Shopper",
+    "type": "persona",
+    "owner": "Research WG",
+    "version": "0.4.0",
+    "sensitivity": "internal",
+    "authority_level": "evidence_proxy",
+    "scope": ["interface_change", "customer_facing_experience"],
+    "allowed_skills": ["feature-value-governance"],
+    "allowed_agents": ["product-agent", "design-agent"],
+    "retrieval_mode": "capsule_first",
+    "citation_required": true,
+    "full_text_exposure": "forbidden",
+    "export_allowed": false,
+    "human_review_required_for": [],
+    "expiry": { "review_cycle": "quarterly", "expires_on": null },
+    "source_location": "examples/project-extension/knowledge-packs/example-persona-casual-shopper/source-link.md",
+    "source_integrity_notes": "Generic, vendor-agnostic example persona; contains no real user data.",
+    "tags": ["persona", "evidence", "example"]
+  }
+}

--- a/examples/project-extension/e2e/packs/wcag-internal.json
+++ b/examples/project-extension/e2e/packs/wcag-internal.json
@@ -1,0 +1,23 @@
+{
+  "knowledge_pack": {
+    "id": "wcag-internal",
+    "name": "Internal Accessibility Guideline (WCAG-aligned)",
+    "type": "accessibility_guideline",
+    "owner": "Accessibility WG",
+    "version": "1.2.0",
+    "sensitivity": "internal",
+    "authority_level": "normative",
+    "scope": ["interface_change", "content_decision", "navigation_decision"],
+    "allowed_skills": ["feature-value-governance"],
+    "allowed_agents": ["product-agent", "design-agent"],
+    "retrieval_mode": "excerpt_only",
+    "citation_required": true,
+    "full_text_exposure": "conditional",
+    "export_allowed": false,
+    "human_review_required_for": ["external_publication"],
+    "expiry": { "review_cycle": "quarterly", "expires_on": null },
+    "source_location": "examples/project-extension/knowledge-packs/wcag-internal/source-link.md",
+    "source_integrity_notes": "Generic, vendor-agnostic accessibility example; no proprietary content.",
+    "tags": ["accessibility", "normative", "example"]
+  }
+}

--- a/examples/project-extension/e2e/skill-knowledge-dependency.json
+++ b/examples/project-extension/e2e/skill-knowledge-dependency.json
@@ -1,0 +1,34 @@
+{
+  "skill": "feature-value-governance",
+  "version": "0.1.0",
+  "knowledge_dependencies": {
+    "strategic_framework": {
+      "required": true,
+      "accepted_types": ["proprietary_framework", "product_strategy", "business_design_framework"],
+      "min_authority": "interpretive",
+      "preferred_retrieval_mode": "capsule_first"
+    },
+    "personas": {
+      "required": false,
+      "accepted_types": ["persona", "research_finding"]
+    },
+    "accessibility_guidelines": {
+      "required_when": ["interface_change", "content_decision", "navigation_decision", "customer_facing_experience"],
+      "accepted_types": ["accessibility_guideline"],
+      "min_authority": "normative",
+      "notes": "Pulled in only for customer-facing experience changes."
+    }
+  },
+  "fallback_behavior": {
+    "missing_required_source": "stop_and_request_source",
+    "missing_optional_source": "continue_with_assumption_marker",
+    "restricted_source": "request_authorized_context_pack",
+    "conflicting_sources": "apply_source_precedence_policy"
+  },
+  "output_requirements": {
+    "cite_satisfying_packs": true,
+    "cite_unsatisfied_slots": true,
+    "list_active_restrictions": true,
+    "list_conflicts_and_resolutions": true
+  }
+}

--- a/examples/project-extension/knowledge-packs/example-persona-casual-shopper/source-link.md
+++ b/examples/project-extension/knowledge-packs/example-persona-casual-shopper/source-link.md
@@ -1,0 +1,13 @@
+# Example Persona "Casual Shopper" — Source Link
+
+The full research behind this fictional persona is **held outside the workspace** and referenced by
+link only, per the manifest (`full_text_exposure: forbidden`, `export_allowed: false`).
+
+- **Location type:** external (outside this repository).
+- **Reference:** `<external location managed by Research WG>` — intentionally a placeholder in this
+  generic example. A real pack would point to a governed store (research repository, internal wiki,
+  signed artifact), never to content committed in-repo.
+- **Access:** authorized consultation only; the default analysis runs from the pack capsule.
+
+This file exists so the manifest `source_location` resolves to a real path while keeping the
+underlying persona research — and any real user data — out of the repository.

--- a/examples/project-extension/knowledge-packs/wcag-internal/source-link.md
+++ b/examples/project-extension/knowledge-packs/wcag-internal/source-link.md
@@ -1,0 +1,13 @@
+# Internal Accessibility Guideline (WCAG-aligned) — Source Link
+
+The full guideline is **held outside the workspace** and referenced by link only, per the manifest
+(`full_text_exposure: conditional`, `export_allowed: false`).
+
+- **Location type:** external (outside this repository).
+- **Reference:** `<external location managed by Accessibility WG>` — intentionally a placeholder in
+  this generic example. A real pack would point to a governed store (internal accessibility handbook,
+  signed artifact), never to content committed in-repo.
+- **Access:** authorized consultation; the default retrieval mode is `excerpt_only`.
+
+This file exists so the manifest `source_location` resolves to a real path while keeping the full
+guideline body out of the repository.

--- a/examples/project-extension/resolver-trace.example.json
+++ b/examples/project-extension/resolver-trace.example.json
@@ -1,0 +1,242 @@
+{
+  "$comment": "Worked end-to-end trace of the Knowledge Governance Layer pipeline (registry -> resolver -> context-pack -> audit). Generated from examples/project-extension/e2e/ and verified against examples/goldens/knowledge-resolution.json by tests/e2e/test-knowledge-e2e.test.ts. Generic and safe; not a runtime artifact.",
+  "inputs": {
+    "task": {
+      "id": "task_2026-05-29_feat-001",
+      "scope": [
+        "feature_governance",
+        "customer_facing_experience",
+        "interface_change"
+      ],
+      "max_sensitivity": "internal",
+      "agent_id": "product-agent",
+      "human_review_conditions": [
+        "external_publication"
+      ]
+    },
+    "skill_dependency_manifest": "examples/project-extension/e2e/skill-knowledge-dependency.json",
+    "registry_packs": [
+      "example-4-layers@1.0.0",
+      "example-persona-casual-shopper@0.4.0",
+      "wcag-internal@1.2.0"
+    ],
+    "declared_conflicts": [
+      {
+        "between": [
+          "personas",
+          "accessibility_guidelines"
+        ],
+        "topic": "explicit form labels on checkout fields",
+        "conflictId": "conflict_2026-05-29_001"
+      }
+    ]
+  },
+  "context_pack": {
+    "context_pack_version": "0.1.0",
+    "status": "resolved",
+    "task": {
+      "id": "task_2026-05-29_feat-001",
+      "purpose": "Decide whether the proposed checkout simplification should ship as-is.",
+      "audience": "internal_review",
+      "risk_class": "medium",
+      "scope_tags": [
+        "feature_governance",
+        "customer_facing_experience",
+        "interface_change"
+      ]
+    },
+    "skill": {
+      "id": "feature-value-governance",
+      "version": "0.1.0",
+      "mode": "knowledge_aware"
+    },
+    "knowledge_dependencies_resolution": {
+      "strategic_framework": {
+        "required": true,
+        "satisfied_by": {
+          "source_id": "example-4-layers",
+          "source_version": "1.0.0",
+          "retrieved_scope": "capsule",
+          "retrieval_mode_applied": "capsule_first"
+        },
+        "candidates_considered": 1
+      },
+      "personas": {
+        "required": false,
+        "satisfied_by": {
+          "source_id": "example-persona-casual-shopper",
+          "source_version": "0.4.0",
+          "retrieved_scope": "capsule",
+          "retrieval_mode_applied": "capsule_first"
+        },
+        "candidates_considered": 1
+      },
+      "accessibility_guidelines": {
+        "required": true,
+        "required_when_matched": true,
+        "satisfied_by": {
+          "source_id": "wcag-internal",
+          "source_version": "1.2.0",
+          "retrieved_scope": "excerpt",
+          "retrieval_mode_applied": "excerpt_only"
+        },
+        "candidates_considered": 1
+      }
+    },
+    "restrictions_active": [
+      "citation_required_for:example-4-layers",
+      "citation_required_for:example-persona-casual-shopper",
+      "citation_required_for:wcag-internal",
+      "no_export_for:example-4-layers",
+      "no_export_for:example-persona-casual-shopper",
+      "no_export_for:wcag-internal",
+      "no_verbatim_for:example-4-layers",
+      "no_verbatim_for:example-persona-casual-shopper"
+    ],
+    "conflicts_detected": [
+      {
+        "conflict_id": "conflict_2026-05-29_001",
+        "between": [
+          "example-persona-casual-shopper@0.4.0",
+          "wcag-internal@1.2.0"
+        ],
+        "topic": "explicit form labels on checkout fields",
+        "resolved_by": "source_precedence_policy",
+        "prevailing_source": "wcag-internal@1.2.0",
+        "suppressed_sources": [
+          "example-persona-casual-shopper@0.4.0"
+        ],
+        "human_review_required": false
+      }
+    ],
+    "gaps": [],
+    "human_review": {
+      "required": true,
+      "reasons": [
+        "source_condition:example-4-layers:external_publication",
+        "source_condition:wcag-internal:external_publication"
+      ]
+    },
+    "refusals": [],
+    "audit_log_entries_to_write": [
+      {
+        "source_id": "example-4-layers",
+        "source_version": "1.0.0",
+        "retrieved_scope": "capsule",
+        "sensitivity": "internal",
+        "authority_level": "interpretive"
+      },
+      {
+        "source_id": "example-persona-casual-shopper",
+        "source_version": "0.4.0",
+        "retrieved_scope": "capsule",
+        "sensitivity": "internal",
+        "authority_level": "evidence_proxy"
+      },
+      {
+        "source_id": "wcag-internal",
+        "source_version": "1.2.0",
+        "retrieved_scope": "excerpt",
+        "sensitivity": "internal",
+        "authority_level": "normative"
+      }
+    ],
+    "agent": {
+      "id": "product-agent",
+      "trust_boundary": "project-acme-internal"
+    }
+  },
+  "audit_entries": [
+    {
+      "task_id": "task_2026-05-29_feat-001",
+      "skill_id": "feature-value-governance",
+      "skill_version": "0.1.0",
+      "agent_id": "product-agent",
+      "project_id": "project-acme",
+      "trust_boundary": "project-acme-internal",
+      "resolver_version": "0.1.0",
+      "timestamp": "2026-05-29T12:00:00.000Z",
+      "entry_type": "select",
+      "source_id": "example-4-layers",
+      "source_version": "1.0.0",
+      "sensitivity": "internal",
+      "authority_level": "interpretive",
+      "retrieved_scope": "capsule",
+      "retrieval_mode_applied": "capsule_first",
+      "restrictions_applied": [
+        "citation_required",
+        "no_export",
+        "no_verbatim"
+      ],
+      "human_review_required": true,
+      "human_review_reason": "source_condition:example-4-layers:external_publication",
+      "decision_output": "Selected example-4-layers@1.0.0 for slot \"strategic_framework\" (capsule)."
+    },
+    {
+      "task_id": "task_2026-05-29_feat-001",
+      "skill_id": "feature-value-governance",
+      "skill_version": "0.1.0",
+      "agent_id": "product-agent",
+      "project_id": "project-acme",
+      "trust_boundary": "project-acme-internal",
+      "resolver_version": "0.1.0",
+      "timestamp": "2026-05-29T12:00:00.000Z",
+      "entry_type": "select",
+      "source_id": "example-persona-casual-shopper",
+      "source_version": "0.4.0",
+      "sensitivity": "internal",
+      "authority_level": "evidence_proxy",
+      "retrieved_scope": "capsule",
+      "retrieval_mode_applied": "capsule_first",
+      "restrictions_applied": [
+        "citation_required",
+        "no_export",
+        "no_verbatim"
+      ],
+      "human_review_required": false,
+      "decision_output": "Selected example-persona-casual-shopper@0.4.0 for slot \"personas\" (capsule)."
+    },
+    {
+      "task_id": "task_2026-05-29_feat-001",
+      "skill_id": "feature-value-governance",
+      "skill_version": "0.1.0",
+      "agent_id": "product-agent",
+      "project_id": "project-acme",
+      "trust_boundary": "project-acme-internal",
+      "resolver_version": "0.1.0",
+      "timestamp": "2026-05-29T12:00:00.000Z",
+      "entry_type": "select",
+      "source_id": "wcag-internal",
+      "source_version": "1.2.0",
+      "sensitivity": "internal",
+      "authority_level": "normative",
+      "retrieved_scope": "excerpt",
+      "retrieval_mode_applied": "excerpt_only",
+      "restrictions_applied": [
+        "citation_required",
+        "no_export"
+      ],
+      "human_review_required": true,
+      "human_review_reason": "source_condition:wcag-internal:external_publication",
+      "decision_output": "Selected wcag-internal@1.2.0 for slot \"accessibility_guidelines\" (excerpt)."
+    },
+    {
+      "task_id": "task_2026-05-29_feat-001",
+      "skill_id": "feature-value-governance",
+      "skill_version": "0.1.0",
+      "agent_id": "product-agent",
+      "project_id": "project-acme",
+      "trust_boundary": "project-acme-internal",
+      "resolver_version": "0.1.0",
+      "timestamp": "2026-05-29T12:00:00.000Z",
+      "entry_type": "conflict",
+      "conflict_id": "conflict_2026-05-29_001",
+      "prevailing_source": "wcag-internal@1.2.0",
+      "suppressed_sources": [
+        "example-persona-casual-shopper@0.4.0"
+      ],
+      "human_review_required": false,
+      "decision_output": "Conflict on \"explicit form labels on checkout fields\" resolved_by source_precedence_policy; prevailing wcag-internal@1.2.0."
+    }
+  ]
+}

--- a/tests/e2e/test-knowledge-e2e.test.ts
+++ b/tests/e2e/test-knowledge-e2e.test.ts
@@ -94,6 +94,17 @@ describe("Knowledge Governance Layer — end-to-end golden", () => {
     expect(sink.entries).toEqual(golden.audit_entries);
   });
 
+  it("every e2e pack's source_location resolves to a real provenance file", () => {
+    const registry = loadKnowledgeRegistry(path.resolve(process.cwd(), E2E_DIR, "packs"));
+    for (const pack of registry.list()) {
+      const loc = pack.knowledge_pack.source_location;
+      expect(
+        fs.existsSync(path.resolve(process.cwd(), loc)),
+        `source_location for ${pack.knowledge_pack.id} does not resolve: ${loc}`,
+      ).toBe(true);
+    }
+  });
+
   it("no audit entry leaks restricted source content", () => {
     const { audit_entries } = runPipeline();
     const blob = JSON.stringify(audit_entries);

--- a/tests/e2e/test-knowledge-e2e.test.ts
+++ b/tests/e2e/test-knowledge-e2e.test.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import {
+  loadKnowledgeRegistry,
+  loadSkillKnowledgeDependency,
+  resolveKnowledge,
+  assembleContextPack,
+  validateContextPack,
+  buildAuditEntries,
+  InMemoryAuditSink,
+  recordResolution,
+} from "../../engine";
+import type { ResolverTask } from "../../engine";
+
+function readJson<T>(p: string): T {
+  return JSON.parse(fs.readFileSync(path.resolve(process.cwd(), p), "utf-8")) as T;
+}
+
+const E2E_DIR = "examples/project-extension/e2e";
+const GOLDEN = "examples/goldens/knowledge-resolution.json";
+const TRACE = "examples/project-extension/resolver-trace.example.json";
+const FIXED_TS = "2026-05-29T12:00:00.000Z";
+
+/** Run the full registry -> resolver -> context-pack -> audit pipeline. */
+function runPipeline() {
+  const registry = loadKnowledgeRegistry(path.resolve(process.cwd(), E2E_DIR, "packs"));
+  const skillDeps = loadSkillKnowledgeDependency(
+    path.resolve(process.cwd(), E2E_DIR, "skill-knowledge-dependency.json"),
+  );
+  const task: ResolverTask = {
+    id: "task_2026-05-29_feat-001",
+    scope: ["feature_governance", "customer_facing_experience", "interface_change"],
+    maxSensitivity: "internal",
+    agentId: "product-agent",
+    humanReviewConditions: ["external_publication"],
+  };
+  const result = resolveKnowledge(task, skillDeps, registry, {
+    declaredConflicts: [
+      {
+        between: ["personas", "accessibility_guidelines"],
+        topic: "explicit form labels on checkout fields",
+        conflictId: "conflict_2026-05-29_001",
+      },
+    ],
+  });
+  const context_pack = assembleContextPack(result, {
+    task: {
+      purpose: "Decide whether the proposed checkout simplification should ship as-is.",
+      audience: "internal_review",
+      risk_class: "medium",
+      scope_tags: ["feature_governance", "customer_facing_experience", "interface_change"],
+    },
+    agent: { id: "product-agent", trust_boundary: "project-acme-internal" },
+  });
+  const audit_entries = buildAuditEntries(result, {
+    agent_id: "product-agent",
+    project_id: "project-acme",
+    trust_boundary: "project-acme-internal",
+    resolver_version: "0.1.0",
+    timestamp: FIXED_TS,
+  });
+  return { result, context_pack, audit_entries };
+}
+
+describe("Knowledge Governance Layer — end-to-end golden", () => {
+  const golden = readJson<{ context_pack: unknown; audit_entries: unknown[] }>(GOLDEN);
+
+  it("produces the golden context pack", () => {
+    const { context_pack } = runPipeline();
+    expect(context_pack).toEqual(golden.context_pack);
+  });
+
+  it("produces the golden audit trail", () => {
+    const { audit_entries } = runPipeline();
+    expect(audit_entries).toEqual(golden.audit_entries);
+  });
+
+  it("the produced context pack is schema-valid", () => {
+    const { context_pack } = runPipeline();
+    expect(() => validateContextPack(context_pack)).not.toThrow();
+  });
+
+  it("recordResolution writes exactly the golden entries to a sink", () => {
+    const { result } = runPipeline();
+    const sink = new InMemoryAuditSink();
+    recordResolution(result, sink, {
+      agent_id: "product-agent",
+      project_id: "project-acme",
+      trust_boundary: "project-acme-internal",
+      resolver_version: "0.1.0",
+      timestamp: FIXED_TS,
+    });
+    expect(sink.entries).toEqual(golden.audit_entries);
+  });
+
+  it("no audit entry leaks restricted source content", () => {
+    const { audit_entries } = runPipeline();
+    const blob = JSON.stringify(audit_entries);
+    // entries carry ids/versions/scope/decisions only — never a source_location or notes
+    expect(blob).not.toContain("source_location");
+    expect(blob).not.toContain("source_integrity_notes");
+  });
+
+  it("the committed resolver-trace example matches the golden (no drift)", () => {
+    const trace = readJson<{ context_pack: unknown; audit_entries: unknown[] }>(TRACE);
+    expect(trace.context_pack).toEqual(golden.context_pack);
+    expect(trace.audit_entries).toEqual(golden.audit_entries);
+  });
+});


### PR DESCRIPTION
## Knowledge Governance Layer — engine, build step 6 (e2e golden) — final

Implements the **last** step of the Phase 5 brief, on top of loaders (#167), registry (#168), resolver (#169), context-pack (#170), and audit-log (#171). Closes the engine build.

### What
Runs a realistic scenario through the **full stack** — loaders → registry → resolver → context-pack assembly → audit writer — and pins it to a committed golden.

- **`examples/project-extension/e2e/`** — fixture inputs: three generic, vendor-agnostic packs (`example-4-layers`, `example-persona-casual-shopper`, `wcag-internal`) + a skill-knowledge-dependency manifest, loaded via the **real loaders** (so they're schema-validated too).
- **`examples/goldens/knowledge-resolution.json`** — golden context pack + audit trail. The scenario exercises: a required slot (capsule), an optional slot (capsule), a `required_when` accessibility slot (excerpt), a **precedence-resolved conflict** (accessibility prevails over persona), **source-conditioned human review** (`external_publication`), and `select`/`conflict` audit entries.
- **`examples/project-extension/resolver-trace.example.json`** — the brief's optional human-readable worked trace, **drift-guarded** against the golden by the test.
- **`tests/e2e/test-knowledge-e2e.test.ts`** — asserts the produced context pack and audit trail equal the golden, the pack is schema-valid, `recordResolution` writes the golden entries, and **no entry leaks** `source_location` / `source_integrity_notes`.

Deterministic via an injected timestamp.

### Validation
- `npx tsc --noEmit` → clean.
- `pnpm run test` → **80 passed** (9 files; 6 new).
- `pnpm run check:governance` → passes.

### Engine build — complete
Steps 1–6 (loaders → registry → resolver → context-pack → audit → e2e golden) are now implemented, each as a thin, contract-conformant slice per the implementer brief. No vector DB, IAM, DLP, UI, embeddings, or crypto entered the core.

One PR. **Do not merge — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)