### PR TITLE
docs(knowledge-governance): reconcile brief + ADR-008 with the built engine

### DIFF
--- a/docs/adr/ADR-008-knowledge-governance-layer.md
+++ b/docs/adr/ADR-008-knowledge-governance-layer.md
@@ -69,9 +69,20 @@ The layer ships as concepts, contracts, schemas, and generic examples in this re
 
 ## 6. Review
 
+> **Update (2026-05-29).** A reference engine for the layer now exists in `engine/`
+> (`loader`, `registry`, `resolver`, `context-pack`, `audit-log`) with an end-to-end golden
+> in `tests/e2e/`, built per [knowledge-governance-implementation-prep](../roadmaps/knowledge-governance-implementation-prep.md).
+> The resolver is therefore no longer only a "logical role": it is a concrete, contract-
+> conformant implementation. The decision and its non-negotiables are unchanged — the engine
+> stayed docs-first and inside the IN/OUT boundary (no vector DB, IAM, DLP, UI, or embeddings).
+> Decision §2 point 8 ("first phase is docs-only") remains the historical record of phase one;
+> the engine is the bounded phase-two reference build, not a change to the architecture.
+
 This ADR should be revisited when any of the following becomes true:
 
-- A runtime resolver implementation is proposed (would change "logical role" → contract).
+- ~~A runtime resolver implementation is proposed~~ — **done**; a reference resolver exists
+  (see the update above). Revisit if the resolver's selection or precedence semantics need to
+  change a contract rather than merely implement it.
 - A vector store or retrieval-stack integration is on the table.
 - Multiple consumers (beyond Feature Value Governance) exist and reveal gaps in the taxonomy or precedence policy.
 - IAM, DLP, or formal IP governance are integrated and reshape the restricted-use policy.

--- a/docs/roadmaps/knowledge-governance-implementation-prep.md
+++ b/docs/roadmaps/knowledge-governance-implementation-prep.md
@@ -15,6 +15,12 @@ phase prepares — but does not perform — the technical build.
 The single most important rule for the implementer: **build the logical roles already
 specified; do not invent scope.** When a contract is silent, ask; do not improvise.
 
+> **Implementation status (2026-05-29): all six build steps below are delivered.**
+> The reference engine lives in `engine/` (`loader`, `registry`, `resolver`, `context-pack`,
+> `audit-log`) with an end-to-end golden in `tests/e2e/`. It stayed inside the IN/OUT
+> boundary — no vector DB, IAM, DLP, UI, embeddings, or crypto entered the core. The brief
+> is retained as the build's contract of record; the per-step PRs are noted in "Build order".
+
 ---
 
 ## What already exists — do not duplicate
@@ -113,34 +119,34 @@ per the resolver's own refusal posture.
 ## Build order
 
 Each step is a thin, independently testable slice. Do not start a step before the prior
-step's tests are green.
+step's tests are green. **All six are delivered** (PR per step noted below).
 
-1. **Knowledge-pack loader + validation.** Extend `engine/loader.ts` with
+1. ✅ (#167) **Knowledge-pack loader + validation.** Extend `engine/loader.ts` with
    `loadKnowledgePack(path)` and `loadSkillKnowledgeDependency(path)`, validating against
    the existing schemas. Add types to `engine/types.ts`. *Test:* valid example loads;
    malformed manifest throws `SchemaValidationError`; non-canonical `sensitivity` rejected.
 
-2. **Registry.** `KnowledgeRegistry` over a set of loaded packs. Methods: `list()`,
+2. ✅ (#168) **Registry.** `KnowledgeRegistry` over a set of loaded packs. Methods: `list()`,
    `byType(type)`, `eligible(task, agent, user)`. Pure data in, pure data out. *Test:*
    allowlist filtering, scope filtering, sensitivity-ceiling filtering.
 
-3. **Resolver.** Implement the 8-step selection logic and the 4 refusal conditions from
+3. ✅ (#169) **Resolver.** Implement the 8-step selection logic and the 4 refusal conditions from
    [knowledge-resolver.md](../concepts/knowledge-resolver.md). Precedence ranking calls
    into the [source-precedence-policy](../contracts/source-precedence-policy.md) tiers.
    *Test:* required-dependency-satisfied, required-missing → refusal, capsule_first
    applied, conflict detected and resolved by precedence.
 
-4. **Context-pack assembly.** Serialize the resolver output to a knowledge-aware context
+4. ✅ (#170) **Context-pack assembly.** Serialize the resolver output to a knowledge-aware context
    pack in the shape of [`knowledge-aware-context-pack.json`](../../examples/project-extension/knowledge-aware-context-pack.json)
    (`restrictions_active`, `conflicts_detected`, `gaps`, `human_review`,
    `audit_log_entries_to_write`). *Test:* output matches the example shape; restricted
    sources never carry verbatim text.
 
-5. **Audit-log writer.** Interface + file sink emitting the required fields. *Test:* an
+5. ✅ (#171) **Audit-log writer.** Interface + file sink emitting the required fields. *Test:* an
    entry is written for select / consult / conflict / fallback / refusal; no restricted
    excerpt appears in any entry.
 
-6. **End-to-end golden.** One task + one skill-dependency manifest + a small registry →
+6. ✅ (#172) **End-to-end golden.** One task + one skill-dependency manifest + a small registry →
    a golden context pack + a golden audit trail. *Test:* deterministic output matches
    golden.
 


### PR DESCRIPTION
## Close the docs loop after the engine build

The Knowledge Governance Layer reference engine (steps 1–6) is now merged (#167–#172). This docs-only PR reconciles the two documents that still described the engine as future work.

- **`docs/roadmaps/knowledge-governance-implementation-prep.md`** — adds an implementation-status note and marks each of the six build steps **delivered** with its PR. The brief is retained as the build's contract of record.
- **`docs/adr/ADR-008-knowledge-governance-layer.md`** — the ADR's own review trigger ("a runtime resolver implementation is proposed") has fired, so a 2026-05-29 review note records that a reference engine now exists in `engine/` + `tests/e2e/`. The decision and its non-negotiables are **unchanged**; the engine stayed docs-first and inside the IN/OUT boundary (no vector DB, IAM, DLP, UI, embeddings).

Docs-only. `pnpm run check:governance` passes.

One PR. **Do not merge — for review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)