### PR TITLE
feat: Feature Value Governance Pack (contract, gates, examples)

### DIFF
--- a/docs/domain-governance-packs/product-feature-governance.md
+++ b/docs/domain-governance-packs/product-feature-governance.md
@@ -39,6 +39,11 @@ here — see [How the strategic lens plugs in](#how-the-strategic-lens-plugs-in)
   the seven gates and the default Build / Test / Discovery / Park / Kill / Sunset decisions.
 - **Worked examples** — [`examples/feature-governance/`](../../examples/feature-governance/):
   `build`, `test`, `kill`, and `sunset` decision records against the contract.
+- **Runtime governance pack** — [`policies/feature-value-governance.v1.json`](../../policies/feature-value-governance.v1.json):
+  the seven gates and born-measurable obligations encoded as engine-evaluable rules
+  (`before_execute` and `before_finalize` hooks), so the policy is *enforced* by the
+  AletheIA engine, not only documented. Loaded via `loadGovernancePack` and evaluated
+  with `evaluateGovernance`.
 
 ## When to use the contract
 

--- a/docs/domain-governance-packs/product-feature-governance.md
+++ b/docs/domain-governance-packs/product-feature-governance.md
@@ -1,0 +1,82 @@
+# Product Feature Governance Pack
+
+> A feature is not a deliverable. A feature is a **value bet that consumes permanent
+> complexity** until it proves it deserves to exist.
+
+This domain governance pack defines how AletheIA governs the evaluation of new
+features, opportunities, and existing features — by value, revenue lever, permanent
+cost, reversibility, metrics, and sunset criteria. It is **docs-first**,
+**vendor-agnostic**, and meant to be driven by agents and humans alike.
+
+It governs the contract and gates. The *capabilities* that produce the analysis live
+as flat skills in the Adaptive Skills repo. The *strategic lens* (a 4-layers value
+framework, or any equivalent) is supplied as a **knowledge pack**, never hard-coded
+here — see [How the strategic lens plugs in](#how-the-strategic-lens-plugs-in).
+
+## What problem this pack solves
+
+- Backlogs grow from political pressure, one-off requests, or tech enthusiasm, with no
+  sufficient value filter.
+- Features get prioritized by apparent desire but rarely pay the cognitive, technical,
+  operational, and support cost they add.
+- Opportunity trees organize opportunities but seldom connect each one to an explicit
+  revenue, margin, retention, or strategic-defense lever.
+- Roadmaps accept complexity with no visible complexity budget and no sunset criterion.
+
+## The three layers of the pack
+
+| Layer | Responsibility | Artifacts |
+| --- | --- | --- |
+| **Strategic lens** (knowledge pack) | Provide the value lens: existence, growth, sustainment, organization. | Resolved via the `strategic_framework` knowledge slot. |
+| **AletheIA** | Define the contract, gates, obligations, and depth of evaluation. | [Feature Value Governance Contract](../../schemas/feature-value-governance-contract.schema.json), [readiness gates](../../policies/feature-readiness-gates.md), decision record. |
+| **Adaptive Skills** | Execute the contextual analyses and rituals. | `feature-value-governance` (orchestrator), `revenue-lever-mapping`, `opportunity-tree-alignment`, `feature-complexity-audit`, `sunset-decision`. |
+
+## Artifacts in this repo
+
+- **Contract schema** — [`schemas/feature-value-governance-contract.schema.json`](../../schemas/feature-value-governance-contract.schema.json):
+  the minimum fields a feature must declare to advance.
+- **Readiness gates** — [`policies/feature-readiness-gates.md`](../../policies/feature-readiness-gates.md):
+  the seven gates and the default Build / Test / Discovery / Park / Kill / Sunset decisions.
+- **Worked examples** — [`examples/feature-governance/`](../../examples/feature-governance/):
+  `build`, `test`, `kill`, and `sunset` decision records against the contract.
+
+## When to use the contract
+
+- A new feature is a candidate for the roadmap.
+- A relevant expansion of an existing feature.
+- A stakeholder request that carries engineering or design cost.
+- An opportunity derived from an opportunity tree.
+- An existing feature that needs to be reviewed, simplified, or removed.
+
+## How the strategic lens plugs in
+
+This pack treats the strategic framework as **pluggable knowledge**, not as committed
+content. Skills declare a `strategic_framework` knowledge dependency (see the
+[skill-knowledge-dependency contract](../contracts/skill-knowledge-dependency-contract.md));
+the [Knowledge Governance Layer](../concepts/knowledge-governance-layer.md) resolver
+decides which pack — proprietary or a generic `example-4-layers` — fills it under the
+active permissions.
+
+Consequence: the four-layer value lens (existence / growth / sustainment / organization)
+is referenced by *role*, never reproduced verbatim in this public pack. Proprietary
+framework content stays in its own pack outside the public repos.
+
+## Guardrails this pack enforces
+
+- **No inflated framework.** Few mandatory fields, few documents, concrete examples.
+- **Score is not truth.** Every recommendation must state its evidence *and* its
+  uncertainty. The scoring matrix is an aid to a decision, never the decision.
+- **Born measurable.** Every approved feature is born with a primary metric, a
+  guardrail, an owner, and a review date (30/90 days).
+- **High permanent cost is never silent.** A high-complexity feature approved to build
+  requires an explicit scope reduction or a recorded exception approval (enforced by the
+  contract schema).
+- **Killing is not failure.** Park / Kill / Sunset decisions leave an auditable trace and
+  a resumption or removal criterion.
+
+## Related
+
+- [Feature readiness gates](../../policies/feature-readiness-gates.md)
+- [Knowledge Governance Layer](../concepts/knowledge-governance-layer.md)
+- Adaptive Skills: `feature-value-governance`, `revenue-lever-mapping`,
+  `opportunity-tree-alignment`, `feature-complexity-audit`, `sunset-decision`.

--- a/examples/feature-governance/build-example.md
+++ b/examples/feature-governance/build-example.md
@@ -1,0 +1,64 @@
+# Example — Build Now
+
+A feature with high value, sufficient evidence, acceptable permanent cost, and a clear
+metric. Passes all seven gates. Born with metric, guardrail, owner, and review dates.
+
+This is an illustrative record against the
+[Feature Value Governance Contract](../../schemas/feature-value-governance-contract.schema.json).
+The strategic lens is referenced by `strategic_framework_ref`, not reproduced here.
+
+```yaml
+feature_value_governance_contract:
+  id: FVG-2026-014
+  feature_name: One-click CSV export for saved reports
+  problem_statement: >
+    Power users rebuild reports manually in spreadsheets every week because there is no
+    export. 22 support tickets and 3 lost renewals in Q1 cited this gap.
+  target_icp: Operations analysts on the Team and Business plans
+  user_job: Get this week's report into my own spreadsheet without rebuilding it
+  value_proposition: Reinforces "your data, your way" — strengthens, does not dilute
+  opportunity_tree_node: OUTCOME-retention/reduce-manual-rework
+  strategic_framework_ref: example-4-layers@1.2.0
+  revenue_lever:
+    primary: retention
+    secondary: [efficiency]
+    rationale: Removes a recurring friction tied to renewal risk in the named ICP
+  expected_outcome: Weekly manual rework drops; renewal risk citations fall
+  evidence_level:
+    strength: strong
+    sources: ["22 Q1 support tickets", "3 lost-renewal call notes", "8 user interviews"]
+    uncertainty: >
+      Unknown whether export alone closes the renewal risk or is one of several factors.
+  complexity_cost:
+    level: low
+    permanent_carry: [support, maintenance]
+    drivers: Reuses existing report query layer; no new data model
+  reversibility:
+    level: reversible
+    mechanisms: [flag, cohort, rollback]
+  risk_of_not_doing: Continued renewal risk in a high-value segment
+  primary_metric:
+    name: Weekly active exporters in target ICP
+    target: ">= 25% of active analysts within 60 days"
+    baseline: "0 (feature does not exist)"
+  guardrail_metrics:
+    - name: Report page p95 latency
+      must_not_exceed: "+10% vs baseline"
+    - name: Export-related support tickets
+      must_not_exceed: baseline ticket rate
+  rollout_plan: 10% cohort behind a flag, then staged to 100% if guardrails hold
+  sunset_criteria: >
+    If exporters stay below 5% of the ICP at the 90-day review, downgrade to on-demand
+    and reassess.
+  owner: a.silva (Product, Reporting)
+  decision:
+    verdict: build_now
+    rationale: All gates pass; low permanent cost; reversible; clear metric and guardrails
+  review_dates:
+    day_30: 2026-07-01
+    day_90: 2026-08-30
+```
+
+**Why Build Now:** problem is real and evidenced, lands on the right ICP, pulls a named
+retention lever, evidence is strong (with stated uncertainty), permanent cost is low and
+reversible, and it ships measurable. No exception needed — cost is low.

--- a/examples/feature-governance/fixtures/build.json
+++ b/examples/feature-governance/fixtures/build.json
@@ -1,0 +1,51 @@
+{
+  "id": "FVG-2026-014",
+  "feature_name": "One-click CSV export for saved reports",
+  "problem_statement": "Power users rebuild reports manually in spreadsheets every week because there is no export. 22 support tickets and 3 lost renewals in Q1 cited this gap.",
+  "target_icp": "Operations analysts on the Team and Business plans",
+  "user_job": "Get this week's report into my own spreadsheet without rebuilding it",
+  "value_proposition": "Reinforces \"your data, your way\" — strengthens, does not dilute",
+  "opportunity_tree_node": "OUTCOME-retention/reduce-manual-rework",
+  "strategic_framework_ref": "example-4-layers@1.2.0",
+  "revenue_lever": {
+    "primary": "retention",
+    "secondary": ["efficiency"],
+    "rationale": "Removes a recurring friction tied to renewal risk in the named ICP"
+  },
+  "expected_outcome": "Weekly manual rework drops; renewal risk citations fall",
+  "evidence_level": {
+    "strength": "strong",
+    "sources": ["22 Q1 support tickets", "3 lost-renewal call notes", "8 user interviews"],
+    "uncertainty": "Unknown whether export alone closes the renewal risk or is one of several factors."
+  },
+  "complexity_cost": {
+    "level": "low",
+    "permanent_carry": ["support", "maintenance"],
+    "drivers": "Reuses existing report query layer; no new data model"
+  },
+  "reversibility": {
+    "level": "reversible",
+    "mechanisms": ["flag", "cohort", "rollback"]
+  },
+  "risk_of_not_doing": "Continued renewal risk in a high-value segment",
+  "primary_metric": {
+    "name": "Weekly active exporters in target ICP",
+    "target": ">= 25% of active analysts within 60 days",
+    "baseline": "0 (feature does not exist)"
+  },
+  "guardrail_metrics": [
+    { "name": "Report page p95 latency", "must_not_exceed": "+10% vs baseline" },
+    { "name": "Export-related support tickets", "must_not_exceed": "baseline ticket rate" }
+  ],
+  "rollout_plan": "10% cohort behind a flag, then staged to 100% if guardrails hold",
+  "sunset_criteria": "If exporters stay below 5% of the ICP at the 90-day review, downgrade to on-demand and reassess.",
+  "owner": "a.silva (Product, Reporting)",
+  "decision": {
+    "verdict": "build_now",
+    "rationale": "All gates pass; low permanent cost; reversible; clear metric and guardrails"
+  },
+  "review_dates": {
+    "day_30": "2026-07-01",
+    "day_90": "2026-08-30"
+  }
+}

--- a/examples/feature-governance/kill-example.md
+++ b/examples/feature-governance/kill-example.md
@@ -1,0 +1,54 @@
+# Example — Kill
+
+Low value, high complexity, weak ICP fit. The contract records *why* it was killed so the
+idea is not politically recycled later without new evidence.
+
+Illustrative record against the
+[Feature Value Governance Contract](../../schemas/feature-value-governance-contract.schema.json).
+
+```yaml
+feature_value_governance_contract:
+  id: FVG-2026-027
+  feature_name: Fully customizable dashboard widget framework
+  problem_statement: >
+    One enterprise prospect asked for arbitrary drag-and-drop widgets during a sales call.
+    No other signal. Sales is pushing it as a deal-closer.
+  target_icp: Unclear — one prospect, not a validated segment
+  user_job: "Build my own dashboard" — but the underlying job is already served by presets
+  value_proposition: Weakens focus; pulls product toward a generic BI tool
+  opportunity_tree_node: none
+  strategic_framework_ref: example-4-layers@1.2.0
+  revenue_lever:
+    primary: expansion
+    rationale: Claimed deal-closer, but no evidence the deal depends on it
+  expected_outcome: Unclear; no behavioral hypothesis survives scrutiny
+  evidence_level:
+    strength: assumption
+    sources: ["one sales call"]
+    uncertainty: >
+      No evidence of demand beyond a single prospect; high chance the deal closes without
+      it; strong chance it becomes a permanent maintenance sink used by almost no one.
+  complexity_cost:
+    level: high
+    permanent_carry: [ux, qa, documentation, operations, maintenance, support]
+    drivers: New layout engine, per-widget data contracts, migration surface forever
+  reversibility:
+    level: one_way_door
+    mechanisms: []
+  risk_of_not_doing: Possibly lose one deal — unverified
+  primary_metric:
+    name: "n/a — no credible metric defined"
+  decision:
+    verdict: kill
+    rationale: >
+      Orphan feature (no opportunity-tree node), assumption-level evidence, one-way-door
+      with high permanent cost, dilutes the value proposition. Cost/value is inverted.
+      Revisit only if a validated segment and a real opportunity node appear.
+  owner: a.silva (Product)
+  review_dates: {}
+```
+
+**Why Kill:** Problem gate is weak and ICP gate fails (one prospect ≠ a segment); the
+feature is an orphan (`opportunity_tree_node: none`) with one-way-door, high permanent
+cost. Recording the kill — and its resumption condition — prevents quiet recycling under
+renewed sales pressure.

--- a/examples/feature-governance/sunset-example.md
+++ b/examples/feature-governance/sunset-example.md
@@ -1,0 +1,68 @@
+# Example — Sunset
+
+An **existing** feature without traction and with an unjustifiable permanent cost. The
+verdict is `sunset` with a migration/removal plan — not a silent deprecation.
+
+Illustrative record against the
+[Feature Value Governance Contract](../../schemas/feature-value-governance-contract.schema.json).
+Produced by the `sunset-decision` skill and recorded here for audit.
+
+```yaml
+feature_value_governance_contract:
+  id: FVG-2026-031
+  feature_name: Legacy XML import (v1 endpoint)
+  problem_statement: >
+    Built three years ago for a migration wave that ended. Now used by < 0.5% of accounts
+    but carries an outsized maintenance and security burden.
+  target_icp: A handful of legacy accounts; no new adoption in 18 months
+  user_job: Import data from a format we no longer recommend
+  value_proposition: Neutral-to-negative; keeps a fragile path alive
+  opportunity_tree_node: none
+  strategic_framework_ref: example-4-layers@1.2.0
+  revenue_lever:
+    primary: margin
+    rationale: Removing it lowers TCO and shrinks the security surface
+  expected_outcome: Lower maintenance cost and attack surface with negligible churn risk
+  evidence_level:
+    strength: strong
+    sources: ["usage telemetry: 11 active accounts", "2 security findings in 12 months", "on-call load data"]
+    uncertainty: >
+      Two of the 11 accounts are strategic; migration friction for them is not yet sized.
+  complexity_cost:
+    level: high
+    permanent_carry: [security, maintenance, operations, qa]
+    drivers: Unmaintained parser, recurring CVEs, blocks a platform upgrade
+  reversibility:
+    level: partially_reversible
+    mechanisms: [migration_plan]
+  risk_of_not_doing: Ongoing security exposure and blocked platform upgrade
+  primary_metric:
+    name: Accounts migrated off the v1 endpoint
+    target: "100% of active accounts migrated before shutdown"
+    baseline: "11 active accounts"
+  guardrail_metrics:
+    - name: Involuntary churn from sunsetting
+      must_not_exceed: "0 strategic accounts"
+  rollout_plan: >
+    1) Announce 90-day deprecation. 2) Provide v2 import + assisted migration for the 2
+    strategic accounts. 3) Read-only grace period. 4) Decommission endpoint.
+  sunset_criteria: >
+    Trigger already met: usage < 1% AND permanent cost (security + upgrade block) exceeds
+    value. Proceed to removal once active accounts are migrated.
+  owner: r.lima (Platform)
+  decision:
+    verdict: sunset
+    rationale: >
+      Low traction, high and rising permanent cost, no live opportunity. Remove with a
+      migration plan that protects the two strategic accounts.
+    exception_approval: >
+      n/a — this is a removal, not a high-cost build. Strategic-account migration plan
+      signed off by Platform lead.
+  review_dates:
+    day_30: 2026-07-01
+    day_90: 2026-08-30
+```
+
+**Why Sunset:** an existing feature where the Complexity gate (high, rising cost) and the
+Lever gate (margin via removal) point the same way, and traction is near zero. The
+obligation is a migration/removal plan with a churn guardrail — not a quiet kill.

--- a/examples/feature-governance/test-example.md
+++ b/examples/feature-governance/test-example.md
@@ -1,0 +1,68 @@
+# Example — Test First
+
+Promising value but **incomplete evidence**. The Evidence gate routes to a small,
+coherent test rather than a full build. Note the high permanent cost — which is exactly
+why the contract refuses a `build_now` here without a recorded exception, and a test is
+the proportional move.
+
+Illustrative record against the
+[Feature Value Governance Contract](../../schemas/feature-value-governance-contract.schema.json).
+
+```yaml
+feature_value_governance_contract:
+  id: FVG-2026-021
+  feature_name: AI-assisted reply suggestions in the inbox
+  problem_statement: >
+    Support agents spend ~40% of handle time drafting routine replies. Leadership
+    believes AI suggestions could cut that, but we have no direct evidence for our queues.
+  target_icp: Tier-1 support agents on high-volume queues
+  user_job: Send a correct, on-brand reply faster without rewriting from scratch
+  value_proposition: Speed without losing the human, on-brand tone
+  opportunity_tree_node: OUTCOME-efficiency/reduce-handle-time
+  strategic_framework_ref: example-4-layers@1.2.0
+  revenue_lever:
+    primary: efficiency
+    rationale: Lower handle time → lower cost-to-serve at constant quality
+  expected_outcome: Median handle time drops without CSAT regression
+  evidence_level:
+    strength: weak
+    sources: ["industry benchmarks", "one internal hack-day demo"]
+    uncertainty: >
+      No evidence the suggestions are accurate on OUR queues; tone and accuracy risk is
+      unquantified; benchmark may not transfer.
+  complexity_cost:
+    level: high
+    permanent_carry: [operations, qa, maintenance, security]
+    drivers: New model dependency, prompt maintenance, PII review, eval harness
+  reversibility:
+    level: partially_reversible
+    mechanisms: [flag, cohort]
+  risk_of_not_doing: Sustained high handle time; competitor parity pressure
+  primary_metric:
+    name: Suggestion acceptance rate (edited or sent as-is)
+    target: ">= 30% acceptance in the test cohort"
+    baseline: "n/a"
+  guardrail_metrics:
+    - name: CSAT on AI-assisted replies
+      must_not_exceed: "no drop vs control"
+    - name: Incorrect-info escalations
+      must_not_exceed: control rate
+  rollout_plan: >
+    2-week shadow test on one queue, suggestions visible to agents only, measure
+    acceptance and CSAT against a control group before any commitment to build.
+  sunset_criteria: >
+    If acceptance < 15% or CSAT drops in the test, stop and Kill the build path.
+  owner: m.costa (Support Ops)
+  decision:
+    verdict: test_first
+    rationale: >
+      Value is plausible but evidence is weak and permanent cost is high. A bounded test
+      buys the evidence at proportional cost before committing to a one-way investment.
+  review_dates:
+    day_30: 2026-07-15
+    day_90: 2026-09-13
+```
+
+**Why Test First:** the Lever and ICP gates pass, but the Evidence gate fails (weak) and
+the Complexity gate flags high permanent cost. Building now would require an exception;
+the proportional move is a small test that produces the missing evidence.

--- a/policies/feature-readiness-gates.md
+++ b/policies/feature-readiness-gates.md
@@ -1,0 +1,98 @@
+# Feature Readiness Gates
+
+Gates a feature must pass before it advances in the product flow. They complement the
+generic [readiness-gates spec](../docs/contracts/readiness-gates-spec.md) with the
+product-value dimension, and operate on the
+[Feature Value Governance Contract](../schemas/feature-value-governance-contract.schema.json).
+
+These gates **do not decide**. They force the decision to be explicit, traceable, and
+proportional to risk. A passing score is never a substitute for the decision and its
+recorded rationale.
+
+## The seven gates
+
+| Gate | Question | Rule |
+| --- | --- | --- |
+| **Problem** | Is there a real, relevant problem? | Mandatory for Build / Test. |
+| **ICP** | Does the gain land on the right audience? | If not → Park or Discovery. |
+| **Lever** | Which revenue/value mechanism moves? | No lever → does not enter the roadmap. |
+| **Evidence** | How strong is the evidence? | Weak evidence → Test / Discovery. |
+| **Complexity** | Is the permanent cost acceptable? | High cost → scope review **or** recorded exception. |
+| **Reversibility** | Can it be tested, switched off, or removed? | No reversibility → requires a technical gate. |
+| **Metrics** | Is there a primary metric and guardrails? | No metric → no broad rollout. |
+
+Each gate maps to a contract field: `problem_statement`, `target_icp`, `revenue_lever`,
+`evidence_level`, `complexity_cost`, `reversibility`, `primary_metric` /
+`guardrail_metrics`.
+
+## Default decisions
+
+| Decision | When to use | Obligation |
+| --- | --- | --- |
+| **Build Now** | High value, sufficient evidence, acceptable cost, clear metric. | Ship with a rollout plan and review dates. |
+| **Test First** | Promising value, incomplete evidence. | Build the smallest coherent test. |
+| **Discovery First** | Problem, ICP, or lever still fragile. | Investigate before building. |
+| **Park** | Plausible idea, no urgency/capacity. | Record a resumption criterion. |
+| **Kill** | Low value, high complexity, or misalignment. | Record the reason; avoid political recycling. |
+| **Sunset** | Existing feature without traction or with unjustifiable permanent cost. | Create a migration/removal plan. |
+
+## Enforced obligations
+
+These are checked by the contract schema and by the `feature-value-governance` skill:
+
+1. **Born measurable.** A `build_now` or `test_first` verdict requires `primary_metric`,
+   at least one `guardrail_metric`, an `owner`, and `review_dates` (30/90).
+2. **High cost is never silent.** `complexity_cost.level: high` + `verdict: build_now`
+   requires `decision.exception_approval` — an explicit scope reduction or a named
+   approval of the permanent cost. (Schema-enforced.)
+3. **Evidence and uncertainty together.** `evidence_level` must carry both `strength`
+   and an `uncertainty` note. A high score with low evidence is a flag, not a pass.
+4. **No orphan features.** `opportunity_tree_node: none` is allowed only with an explicit
+   rationale; otherwise the Lever/ICP gates route to Discovery.
+
+## Gate → decision flow (default)
+
+```
+problem? ──no──▶ Kill / Discovery
+   │yes
+ICP? ──no──▶ Park / Discovery
+   │yes
+lever? ──no──▶ not on roadmap
+   │yes
+evidence strong? ──no──▶ Test / Discovery
+   │yes
+complexity acceptable? ──no──▶ scope review OR recorded exception
+   │yes
+reversible? ──no──▶ technical gate first
+   │yes
+metric + guardrails? ──no──▶ no broad rollout
+   │yes
+        ▶ Build Now (with rollout + 30/90 review)
+```
+
+## Scoring matrix (decision aid, not the decision)
+
+Weights sum to 100. Each criterion scored 0–5. **The total is an aid to a conversation,
+never a verdict.** Two features with the same total can warrant opposite decisions once
+evidence and uncertainty are read.
+
+| Criterion | Weight | Scale |
+| --- | --- | --- |
+| Real pain | 15 | 0–5 |
+| Evidence | 15 | 0–5 |
+| ICP fit | 10 | 0–5 |
+| Revenue/value lever | 20 | 0–5 |
+| Value-proposition reinforcement | 10 | 0–5 |
+| Permanent cost | 15 | 0–5 (5 = low cost) |
+| Reversibility | 10 | 0–5 |
+| Risk of not doing | 5 | 0–5 |
+
+## 30/90-day review checklist
+
+- Did the primary metric improve?
+- Did any guardrail get worse?
+- Did adoption come from the expected ICP?
+- Did support cost increase?
+- Did the feature strengthen or dilute the value proposition?
+- Has the flag been removed or given an expiry date?
+- Is the decision now expand, iterate, limit, or remove?

--- a/policies/feature-readiness-gates.md
+++ b/policies/feature-readiness-gates.md
@@ -9,6 +9,12 @@ These gates **do not decide**. They force the decision to be explicit, traceable
 proportional to risk. A passing score is never a substitute for the decision and its
 recorded rationale.
 
+The gates below are also encoded for **runtime enforcement** as a governance pack —
+[`feature-value-governance.v1.json`](./feature-value-governance.v1.json) — which the
+AletheIA engine evaluates at the `before_execute` and `before_finalize` hooks. Actions
+vary by mode (`strict` / `balanced` / `relaxed`): e.g. a high-cost build without an
+exception `block`s in strict mode and drops to `review` in relaxed.
+
 ## The seven gates
 
 | Gate | Question | Rule |

--- a/policies/feature-value-governance.v1.json
+++ b/policies/feature-value-governance.v1.json
@@ -1,0 +1,164 @@
+{
+  "meta": {
+    "name": "Feature Value Governance Pack",
+    "version": "1.0.0-alpha",
+    "domain": "product",
+    "status": "draft",
+    "default_mode": "strict"
+  },
+  "vocabulary": {
+    "feature": "A value bet that consumes permanent complexity until it proves it deserves to exist.",
+    "revenue_lever": "The single primary mechanism of value a feature moves (acquisition, activation, retention, expansion, efficiency, margin, strategic_defense).",
+    "permanent_cost": "The ongoing cognitive, technical, operational, and governance carry a feature adds once shipped.",
+    "born_measurable": "Obligation that an approved feature ships with a primary metric, a guardrail, an owner, and 30/90 review dates."
+  },
+  "hooks": [
+    {
+      "id": "before_execute",
+      "description": "Evaluate whether a feature is allowed to advance to build or test against the seven readiness gates."
+    },
+    {
+      "id": "before_finalize",
+      "description": "Evaluate the born-measurable obligations before a feature ships or tests broadly."
+    }
+  ],
+  "facts_model": {
+    "feature.verdict": "string",
+    "feature.problem_defined": "boolean",
+    "feature.icp_defined": "boolean",
+    "feature.lever_defined": "boolean",
+    "feature.evidence_strength": "string",
+    "feature.evidence_uncertainty_stated": "boolean",
+    "feature.complexity_level": "string",
+    "feature.exception_approved": "boolean",
+    "feature.reversibility_level": "string",
+    "feature.opportunity_node_present": "boolean",
+    "feature.has_primary_metric": "boolean",
+    "feature.guardrail_count": "number",
+    "feature.has_review_dates": "boolean"
+  },
+  "rules": [
+    {
+      "id": "gate.problem_required",
+      "stage": "before_execute",
+      "description": "A build or test verdict requires a real, defined problem.",
+      "enabled": true,
+      "when_all": [
+        { "fact": "feature.verdict", "op": "in", "value": ["build_now", "test_first"] },
+        { "fact": "feature.problem_defined", "op": "eq", "value": false }
+      ],
+      "action_by_mode": { "strict": "block", "balanced": "block", "relaxed": "review" }
+    },
+    {
+      "id": "gate.icp_required",
+      "stage": "before_execute",
+      "description": "If the gain does not land on a defined ICP, the feature should be parked or sent to discovery, not built.",
+      "enabled": true,
+      "when_all": [
+        { "fact": "feature.verdict", "op": "in", "value": ["build_now", "test_first"] },
+        { "fact": "feature.icp_defined", "op": "eq", "value": false }
+      ],
+      "action_by_mode": { "strict": "review", "balanced": "review", "relaxed": "review" }
+    },
+    {
+      "id": "gate.lever_required",
+      "stage": "before_execute",
+      "description": "Without a named revenue/value lever, a feature does not enter the roadmap.",
+      "enabled": true,
+      "when_all": [
+        { "fact": "feature.verdict", "op": "in", "value": ["build_now", "test_first", "park"] },
+        { "fact": "feature.lever_defined", "op": "eq", "value": false }
+      ],
+      "action_by_mode": { "strict": "block", "balanced": "block", "relaxed": "review" }
+    },
+    {
+      "id": "gate.evidence_sufficient_for_build",
+      "stage": "before_execute",
+      "description": "Weak or assumption-level evidence cannot support a build_now; it requires Test or Discovery first.",
+      "enabled": true,
+      "when_all": [
+        { "fact": "feature.verdict", "op": "eq", "value": "build_now" },
+        { "fact": "feature.evidence_strength", "op": "in", "value": ["weak", "assumption"] }
+      ],
+      "action_by_mode": { "strict": "block", "balanced": "review", "relaxed": "review" }
+    },
+    {
+      "id": "gate.evidence_uncertainty_required",
+      "stage": "before_execute",
+      "description": "Every recommendation must state its uncertainty so the score is never mistaken for truth.",
+      "enabled": true,
+      "when_all": [
+        { "fact": "feature.verdict", "op": "in", "value": ["build_now", "test_first"] },
+        { "fact": "feature.evidence_uncertainty_stated", "op": "eq", "value": false }
+      ],
+      "action_by_mode": { "strict": "block", "balanced": "block", "relaxed": "review" }
+    },
+    {
+      "id": "gate.high_cost_needs_exception",
+      "stage": "before_execute",
+      "description": "A high permanent-cost feature approved to build must carry an explicit scope reduction or exception approval.",
+      "enabled": true,
+      "when_all": [
+        { "fact": "feature.verdict", "op": "eq", "value": "build_now" },
+        { "fact": "feature.complexity_level", "op": "eq", "value": "high" },
+        { "fact": "feature.exception_approved", "op": "eq", "value": false }
+      ],
+      "action_by_mode": { "strict": "block", "balanced": "block", "relaxed": "review" }
+    },
+    {
+      "id": "gate.irreversible_needs_human",
+      "stage": "before_execute",
+      "description": "A one-way-door build requires a human technical gate before commitment.",
+      "enabled": true,
+      "when_all": [
+        { "fact": "feature.verdict", "op": "eq", "value": "build_now" },
+        { "fact": "feature.reversibility_level", "op": "eq", "value": "one_way_door" }
+      ],
+      "action_by_mode": { "strict": "ask_human", "balanced": "review", "relaxed": "review" }
+    },
+    {
+      "id": "gate.orphan_feature",
+      "stage": "before_execute",
+      "description": "A feature that serves no live opportunity-tree node is flagged for reconsideration.",
+      "enabled": true,
+      "when_all": [
+        { "fact": "feature.verdict", "op": "in", "value": ["build_now", "test_first"] },
+        { "fact": "feature.opportunity_node_present", "op": "eq", "value": false }
+      ],
+      "action_by_mode": { "strict": "review", "balanced": "review", "relaxed": "allow" }
+    },
+    {
+      "id": "measurable.primary_metric_required",
+      "stage": "before_finalize",
+      "description": "Born measurable: no primary metric, no broad rollout.",
+      "enabled": true,
+      "when_all": [
+        { "fact": "feature.verdict", "op": "in", "value": ["build_now", "test_first"] },
+        { "fact": "feature.has_primary_metric", "op": "eq", "value": false }
+      ],
+      "action_by_mode": { "strict": "block", "balanced": "block", "relaxed": "review" }
+    },
+    {
+      "id": "measurable.guardrails_required",
+      "stage": "before_finalize",
+      "description": "Born measurable: an approved feature must declare at least one guardrail metric that cannot regress.",
+      "enabled": true,
+      "when_all": [
+        { "fact": "feature.verdict", "op": "in", "value": ["build_now", "test_first"] },
+        { "fact": "feature.guardrail_count", "op": "lt", "value": 1 }
+      ],
+      "action_by_mode": { "strict": "block", "balanced": "review", "relaxed": "review" }
+    },
+    {
+      "id": "measurable.review_dates_required",
+      "stage": "before_finalize",
+      "description": "Born measurable: an approved feature must carry 30/90 review dates.",
+      "enabled": true,
+      "when_all": [
+        { "fact": "feature.verdict", "op": "in", "value": ["build_now", "test_first"] },
+        { "fact": "feature.has_review_dates", "op": "eq", "value": false }
+      ],
+      "action_by_mode": { "strict": "block", "balanced": "review", "relaxed": "review" }
+    }
+  ]
+}

--- a/schemas/feature-value-governance-contract.schema.json
+++ b/schemas/feature-value-governance-contract.schema.json
@@ -54,11 +54,11 @@
     "evidence_level": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["strength"],
+      "required": ["strength", "uncertainty"],
       "properties": {
         "strength": { "type": "string", "enum": ["strong", "moderate", "weak", "assumption"] },
         "sources": { "type": "array", "items": { "type": "string" }, "description": "Data, research, tickets, lost deals, interviews, benchmark." },
-        "uncertainty": { "type": "string", "description": "What is NOT known yet. Required reflection so the score is never mistaken for truth." }
+        "uncertainty": { "type": "string", "minLength": 1, "description": "What is NOT known yet. Required reflection so the score is never mistaken for truth." }
       }
     },
     "complexity_cost": {

--- a/schemas/feature-value-governance-contract.schema.json
+++ b/schemas/feature-value-governance-contract.schema.json
@@ -150,6 +150,22 @@
           "decision": { "required": ["exception_approval"] }
         }
       }
+    },
+    {
+      "$comment": "Born measurable: a build_now or test_first verdict must carry at least one guardrail metric and both 30/90 review dates. A primary metric alone is not enough to ship or test broadly.",
+      "if": {
+        "required": ["decision"],
+        "properties": {
+          "decision": { "properties": { "verdict": { "enum": ["build_now", "test_first"] } }, "required": ["verdict"] }
+        }
+      },
+      "then": {
+        "required": ["guardrail_metrics", "review_dates"],
+        "properties": {
+          "guardrail_metrics": { "minItems": 1 },
+          "review_dates": { "required": ["day_30", "day_90"] }
+        }
+      }
     }
   ]
 }

--- a/schemas/feature-value-governance-contract.schema.json
+++ b/schemas/feature-value-governance-contract.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia.local/schemas/feature-value-governance-contract.schema.json",
+  "title": "Feature Value Governance Contract",
+  "description": "Minimum fields a feature, opportunity, or relevant increment must declare to advance through the product flow. The contract does not decide; it forces the decision to be explicit, traceable, and proportional to risk. Strategic lens (e.g. a 4-layers framework) is supplied via a knowledge pack on the strategic_framework slot, never hard-coded here.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "feature_name",
+    "problem_statement",
+    "target_icp",
+    "revenue_lever",
+    "evidence_level",
+    "complexity_cost",
+    "reversibility",
+    "primary_metric",
+    "decision",
+    "owner",
+    "review_dates"
+  ],
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "feature_name": { "type": "string", "minLength": 1 },
+    "problem_statement": { "type": "string", "minLength": 1 },
+    "target_icp": { "type": "string", "minLength": 1, "description": "Who gains value primarily." },
+    "user_job": { "type": "string", "description": "The job-to-be-done the feature serves." },
+    "value_proposition": { "type": "string", "description": "How this strengthens (not dilutes) the value proposition." },
+    "opportunity_tree_node": { "type": "string", "description": "Reference to the opportunity / outcome this bet serves; 'none' flags an orphan feature." },
+    "strategic_framework_ref": {
+      "type": "string",
+      "description": "pack_id@version of the strategic_framework knowledge pack used as the value lens, or 'generic' when none was resolved. The framework content lives in the pack, not in this contract."
+    },
+    "revenue_lever": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["primary"],
+      "properties": {
+        "primary": {
+          "type": "string",
+          "enum": ["acquisition", "activation", "retention", "expansion", "efficiency", "margin", "strategic_defense"]
+        },
+        "secondary": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["acquisition", "activation", "retention", "expansion", "efficiency", "margin", "strategic_defense"]
+          }
+        },
+        "rationale": { "type": "string" }
+      }
+    },
+    "expected_outcome": { "type": "string", "description": "Behavioral or business change expected." },
+    "evidence_level": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["strength"],
+      "properties": {
+        "strength": { "type": "string", "enum": ["strong", "moderate", "weak", "assumption"] },
+        "sources": { "type": "array", "items": { "type": "string" }, "description": "Data, research, tickets, lost deals, interviews, benchmark." },
+        "uncertainty": { "type": "string", "description": "What is NOT known yet. Required reflection so the score is never mistaken for truth." }
+      }
+    },
+    "complexity_cost": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level"],
+      "properties": {
+        "level": { "type": "string", "enum": ["low", "medium", "high"] },
+        "permanent_carry": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["ux", "support", "qa", "documentation", "operations", "security", "maintenance"] },
+          "description": "Where the permanent cost lands."
+        },
+        "drivers": { "type": "string" }
+      }
+    },
+    "reversibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level"],
+      "properties": {
+        "level": { "type": "string", "enum": ["reversible", "partially_reversible", "one_way_door"] },
+        "mechanisms": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["flag", "cohort", "rollback", "sunset", "migration_plan"] }
+        }
+      }
+    },
+    "risk_of_not_doing": { "type": "string", "description": "Cost or risk of inaction." },
+    "primary_metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "target": { "type": "string" },
+        "baseline": { "type": "string" }
+      }
+    },
+    "guardrail_metrics": {
+      "type": "array",
+      "description": "Metrics that must not get worse.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "must_not_exceed": { "type": "string" }
+        }
+      }
+    },
+    "rollout_plan": { "type": "string" },
+    "sunset_criteria": { "type": "string", "description": "Condition under which the feature is limited, refactored, deprecated, or removed." },
+    "owner": { "type": "string", "minLength": 1 },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verdict"],
+      "properties": {
+        "verdict": { "type": "string", "enum": ["build_now", "test_first", "discovery_first", "park", "kill", "sunset"] },
+        "rationale": { "type": "string" },
+        "exception_approval": {
+          "type": "string",
+          "description": "Required when complexity_cost.level is 'high' and the verdict is build_now: who explicitly approved the permanent cost, or the scope reduction that was applied instead."
+        }
+      }
+    },
+    "review_dates": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "day_30": { "type": "string", "format": "date" },
+        "day_90": { "type": "string", "format": "date" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "High permanent cost approved to build must carry an explicit exception or a scope reduction. Score is never sufficient on its own.",
+      "if": {
+        "properties": {
+          "complexity_cost": { "properties": { "level": { "const": "high" } } },
+          "decision": { "properties": { "verdict": { "const": "build_now" } } }
+        }
+      },
+      "then": {
+        "properties": {
+          "decision": { "required": ["exception_approval"] }
+        }
+      }
+    }
+  ]
+}

--- a/tests/contracts/test-feature-value-governance-pack.test.ts
+++ b/tests/contracts/test-feature-value-governance-pack.test.ts
@@ -4,8 +4,17 @@ import { loadGovernancePack, evaluateGovernance, type GovernanceFacts } from "..
 
 const packPath = path.resolve(process.cwd(), "policies/feature-value-governance.v1.json");
 
+// The pack's facts live under a "feature" namespace. GovernanceFacts is the fixed
+// shape for the development pack; the engine traverses facts generically at runtime,
+// so we model feature facts locally and cast at the call site.
+type FeatureFacts = { feature: Record<string, string | number | boolean> };
+
+function asFacts(facts: FeatureFacts): GovernanceFacts {
+  return facts as unknown as GovernanceFacts;
+}
+
 // A clean build_now feature that passes every gate.
-function approvableFeature(): GovernanceFacts {
+function approvableFeature(): FeatureFacts {
   return {
     feature: {
       verdict: "build_now",
@@ -22,7 +31,7 @@ function approvableFeature(): GovernanceFacts {
       guardrail_count: 2,
       has_review_dates: true,
     },
-  } as unknown as GovernanceFacts;
+  };
 }
 
 describe("Feature Value Governance Pack (runtime enforcement)", () => {
@@ -35,15 +44,15 @@ describe("Feature Value Governance Pack (runtime enforcement)", () => {
   it("allows a clean build_now at both hooks", () => {
     const pack = loadGovernancePack(packPath);
     const facts = approvableFeature();
-    expect(evaluateGovernance({ pack, facts, hook: "before_execute" }).final_action).toBe("allow");
-    expect(evaluateGovernance({ pack, facts, hook: "before_finalize" }).final_action).toBe("allow");
+    expect(evaluateGovernance({ pack, facts: asFacts(facts), hook: "before_execute" }).final_action).toBe("allow");
+    expect(evaluateGovernance({ pack, facts: asFacts(facts), hook: "before_finalize" }).final_action).toBe("allow");
   });
 
   it("blocks a high-cost build with no exception (strict)", () => {
     const pack = loadGovernancePack(packPath);
     const facts = approvableFeature();
-    (facts.feature as Record<string, unknown>).complexity_level = "high";
-    const trace = evaluateGovernance({ pack, facts, hook: "before_execute" });
+    facts.feature.complexity_level = "high";
+    const trace = evaluateGovernance({ pack, facts: asFacts(facts), hook: "before_execute" });
     expect(trace.final_action).toBe("block");
     expect(trace.matched_rules.map((r) => r.id)).toContain("gate.high_cost_needs_exception");
   });
@@ -51,37 +60,37 @@ describe("Feature Value Governance Pack (runtime enforcement)", () => {
   it("clears the high-cost block once an exception is approved", () => {
     const pack = loadGovernancePack(packPath);
     const facts = approvableFeature();
-    (facts.feature as Record<string, unknown>).complexity_level = "high";
-    (facts.feature as Record<string, unknown>).exception_approved = true;
-    expect(evaluateGovernance({ pack, facts, hook: "before_execute" }).final_action).toBe("allow");
+    facts.feature.complexity_level = "high";
+    facts.feature.exception_approved = true;
+    expect(evaluateGovernance({ pack, facts: asFacts(facts), hook: "before_execute" }).final_action).toBe("allow");
   });
 
   it("blocks a build_now on weak evidence in strict, softens to review in balanced", () => {
     const pack = loadGovernancePack(packPath);
     const facts = approvableFeature();
-    (facts.feature as Record<string, unknown>).evidence_strength = "weak";
+    facts.feature.evidence_strength = "weak";
     expect(
-      evaluateGovernance({ pack, facts, hook: "before_execute", mode: "strict" }).final_action,
+      evaluateGovernance({ pack, facts: asFacts(facts), hook: "before_execute", mode: "strict" }).final_action,
     ).toBe("block");
     expect(
-      evaluateGovernance({ pack, facts, hook: "before_execute", mode: "balanced" }).final_action,
+      evaluateGovernance({ pack, facts: asFacts(facts), hook: "before_execute", mode: "balanced" }).final_action,
     ).toBe("review");
   });
 
   it("requires a human gate for a one-way-door build", () => {
     const pack = loadGovernancePack(packPath);
     const facts = approvableFeature();
-    (facts.feature as Record<string, unknown>).reversibility_level = "one_way_door";
-    expect(evaluateGovernance({ pack, facts, hook: "before_execute" }).final_action).toBe("ask_human");
+    facts.feature.reversibility_level = "one_way_door";
+    expect(evaluateGovernance({ pack, facts: asFacts(facts), hook: "before_execute" }).final_action).toBe("ask_human");
   });
 
   it("blocks finalize when the feature is not born measurable", () => {
     const pack = loadGovernancePack(packPath);
     const facts = approvableFeature();
-    (facts.feature as Record<string, unknown>).has_primary_metric = false;
-    (facts.feature as Record<string, unknown>).guardrail_count = 0;
-    (facts.feature as Record<string, unknown>).has_review_dates = false;
-    const trace = evaluateGovernance({ pack, facts, hook: "before_finalize" });
+    facts.feature.has_primary_metric = false;
+    facts.feature.guardrail_count = 0;
+    facts.feature.has_review_dates = false;
+    const trace = evaluateGovernance({ pack, facts: asFacts(facts), hook: "before_finalize" });
     expect(trace.final_action).toBe("block");
     expect(trace.matched_rules.map((r) => r.id)).toEqual(
       expect.arrayContaining([
@@ -95,11 +104,11 @@ describe("Feature Value Governance Pack (runtime enforcement)", () => {
   it("leaves kill/park verdicts unconstrained by build gates", () => {
     const pack = loadGovernancePack(packPath);
     const facts = approvableFeature();
-    (facts.feature as Record<string, unknown>).verdict = "kill";
-    (facts.feature as Record<string, unknown>).problem_defined = false;
-    (facts.feature as Record<string, unknown>).has_primary_metric = false;
-    (facts.feature as Record<string, unknown>).guardrail_count = 0;
-    expect(evaluateGovernance({ pack, facts, hook: "before_execute" }).final_action).toBe("allow");
-    expect(evaluateGovernance({ pack, facts, hook: "before_finalize" }).final_action).toBe("allow");
+    facts.feature.verdict = "kill";
+    facts.feature.problem_defined = false;
+    facts.feature.has_primary_metric = false;
+    facts.feature.guardrail_count = 0;
+    expect(evaluateGovernance({ pack, facts: asFacts(facts), hook: "before_execute" }).final_action).toBe("allow");
+    expect(evaluateGovernance({ pack, facts: asFacts(facts), hook: "before_finalize" }).final_action).toBe("allow");
   });
 });

--- a/tests/contracts/test-feature-value-governance-pack.test.ts
+++ b/tests/contracts/test-feature-value-governance-pack.test.ts
@@ -1,0 +1,105 @@
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { loadGovernancePack, evaluateGovernance, type GovernanceFacts } from "../../engine";
+
+const packPath = path.resolve(process.cwd(), "policies/feature-value-governance.v1.json");
+
+// A clean build_now feature that passes every gate.
+function approvableFeature(): GovernanceFacts {
+  return {
+    feature: {
+      verdict: "build_now",
+      problem_defined: true,
+      icp_defined: true,
+      lever_defined: true,
+      evidence_strength: "strong",
+      evidence_uncertainty_stated: true,
+      complexity_level: "low",
+      exception_approved: false,
+      reversibility_level: "reversible",
+      opportunity_node_present: true,
+      has_primary_metric: true,
+      guardrail_count: 2,
+      has_review_dates: true,
+    },
+  } as unknown as GovernanceFacts;
+}
+
+describe("Feature Value Governance Pack (runtime enforcement)", () => {
+  it("loads and validates as a governance pack", () => {
+    const pack = loadGovernancePack(packPath);
+    expect(pack.meta.name).toBe("Feature Value Governance Pack");
+    expect(pack.rules.length).toBeGreaterThan(0);
+  });
+
+  it("allows a clean build_now at both hooks", () => {
+    const pack = loadGovernancePack(packPath);
+    const facts = approvableFeature();
+    expect(evaluateGovernance({ pack, facts, hook: "before_execute" }).final_action).toBe("allow");
+    expect(evaluateGovernance({ pack, facts, hook: "before_finalize" }).final_action).toBe("allow");
+  });
+
+  it("blocks a high-cost build with no exception (strict)", () => {
+    const pack = loadGovernancePack(packPath);
+    const facts = approvableFeature();
+    (facts.feature as Record<string, unknown>).complexity_level = "high";
+    const trace = evaluateGovernance({ pack, facts, hook: "before_execute" });
+    expect(trace.final_action).toBe("block");
+    expect(trace.matched_rules.map((r) => r.id)).toContain("gate.high_cost_needs_exception");
+  });
+
+  it("clears the high-cost block once an exception is approved", () => {
+    const pack = loadGovernancePack(packPath);
+    const facts = approvableFeature();
+    (facts.feature as Record<string, unknown>).complexity_level = "high";
+    (facts.feature as Record<string, unknown>).exception_approved = true;
+    expect(evaluateGovernance({ pack, facts, hook: "before_execute" }).final_action).toBe("allow");
+  });
+
+  it("blocks a build_now on weak evidence in strict, softens to review in balanced", () => {
+    const pack = loadGovernancePack(packPath);
+    const facts = approvableFeature();
+    (facts.feature as Record<string, unknown>).evidence_strength = "weak";
+    expect(
+      evaluateGovernance({ pack, facts, hook: "before_execute", mode: "strict" }).final_action,
+    ).toBe("block");
+    expect(
+      evaluateGovernance({ pack, facts, hook: "before_execute", mode: "balanced" }).final_action,
+    ).toBe("review");
+  });
+
+  it("requires a human gate for a one-way-door build", () => {
+    const pack = loadGovernancePack(packPath);
+    const facts = approvableFeature();
+    (facts.feature as Record<string, unknown>).reversibility_level = "one_way_door";
+    expect(evaluateGovernance({ pack, facts, hook: "before_execute" }).final_action).toBe("ask_human");
+  });
+
+  it("blocks finalize when the feature is not born measurable", () => {
+    const pack = loadGovernancePack(packPath);
+    const facts = approvableFeature();
+    (facts.feature as Record<string, unknown>).has_primary_metric = false;
+    (facts.feature as Record<string, unknown>).guardrail_count = 0;
+    (facts.feature as Record<string, unknown>).has_review_dates = false;
+    const trace = evaluateGovernance({ pack, facts, hook: "before_finalize" });
+    expect(trace.final_action).toBe("block");
+    expect(trace.matched_rules.map((r) => r.id)).toEqual(
+      expect.arrayContaining([
+        "measurable.primary_metric_required",
+        "measurable.guardrails_required",
+        "measurable.review_dates_required",
+      ]),
+    );
+  });
+
+  it("leaves kill/park verdicts unconstrained by build gates", () => {
+    const pack = loadGovernancePack(packPath);
+    const facts = approvableFeature();
+    (facts.feature as Record<string, unknown>).verdict = "kill";
+    (facts.feature as Record<string, unknown>).problem_defined = false;
+    (facts.feature as Record<string, unknown>).has_primary_metric = false;
+    (facts.feature as Record<string, unknown>).guardrail_count = 0;
+    expect(evaluateGovernance({ pack, facts, hook: "before_execute" }).final_action).toBe("allow");
+    expect(evaluateGovernance({ pack, facts, hook: "before_finalize" }).final_action).toBe("allow");
+  });
+});

--- a/tests/contracts/test-feature-value-governance.test.ts
+++ b/tests/contracts/test-feature-value-governance.test.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { validateAgainstSchema, SchemaValidationError } from "../../engine";
+
+const schemasDir = path.resolve(process.cwd(), "schemas");
+const schemaPath = path.join(schemasDir, "feature-value-governance-contract.schema.json");
+const fixturePath = path.resolve(
+  process.cwd(),
+  "examples/feature-governance/fixtures/build.json",
+);
+
+function loadFixture(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(fixturePath, "utf-8")) as Record<string, unknown>;
+}
+
+describe("Feature Value Governance Contract", () => {
+  it("validates a realistic Build Now record against the schema", () => {
+    const data = loadFixture();
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a high-cost build with no exception_approval (guardrail fires)", () => {
+    const data = loadFixture();
+    (data.complexity_cost as Record<string, unknown>).level = "high";
+    // decision.verdict is already build_now and carries no exception_approval
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a high-cost build once exception_approval is recorded", () => {
+    const data = loadFixture();
+    (data.complexity_cost as Record<string, unknown>).level = "high";
+    (data.decision as Record<string, unknown>).exception_approval =
+      "Scope reduced to single-format export; permanent cost approved by Platform lead.";
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects evidence_level without an uncertainty statement (score is not truth)", () => {
+    const data = loadFixture();
+    delete (data.evidence_level as Record<string, unknown>).uncertainty;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a record missing the primary metric (born measurable)", () => {
+    const data = loadFixture();
+    delete data.primary_metric;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a lever outside the canonical taxonomy", () => {
+    const data = loadFixture();
+    (data.revenue_lever as Record<string, unknown>).primary = "conversion";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+});

--- a/tests/contracts/test-feature-value-governance.test.ts
+++ b/tests/contracts/test-feature-value-governance.test.ts
@@ -52,4 +52,30 @@ describe("Feature Value Governance Contract", () => {
     (data.revenue_lever as Record<string, unknown>).primary = "conversion";
     expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
   });
+
+  it("rejects a build_now record with no guardrail metric (born measurable)", () => {
+    const data = loadFixture();
+    delete data.guardrail_metrics;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a build_now record with an empty guardrail list", () => {
+    const data = loadFixture();
+    data.guardrail_metrics = [];
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a build_now record missing a 30/90 review date", () => {
+    const data = loadFixture();
+    delete (data.review_dates as Record<string, unknown>).day_90;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("allows a kill verdict without guardrails or review dates", () => {
+    const data = loadFixture();
+    (data.decision as Record<string, unknown>).verdict = "kill";
+    delete data.guardrail_metrics;
+    data.review_dates = {};
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

AletheIA side of the **Feature Value Governance Pack** — governs evaluating features as *value bets that consume permanent complexity*. Companion PR in `adaptive-skills` adds the executing skills.

- **Contract schema** — `schemas/feature-value-governance-contract.schema.json`: minimum fields + the seven gates. Schema-enforced: high permanent cost + Build requires `exception_approval`; `evidence_level` requires an `uncertainty` field so the score is never mistaken for truth.
- **Readiness gates** — `policies/feature-readiness-gates.md`: seven gates, six default decisions (Build/Test/Discovery/Park/Kill/Sunset), 30/90 review checklist.
- **Pack overview** — `docs/domain-governance-packs/product-feature-governance.md`. The strategic lens (4 Layers) stays **pluggable** via the `strategic_framework` knowledge slot; no proprietary content committed.
- **Examples** — `examples/feature-governance/{build,test,kill,sunset}-example.md`.

## Verification
- `pnpm run check:governance` ✅
- `pnpm test` (vitest) ✅ 24 passing
- Cross-repo links to the adaptive-skills pack resolve.

## Notes
- Draft — not for merge yet. Suggested next: validate on 3 real/historical features, then optionally ship the contract as a governance-pack JSON instance for runtime enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)