### PR TITLE
docs(governance): Skill Evolution Validation high-level contract

### DIFF
--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -40,3 +40,4 @@ If you need a step-by-step guide, see [`guides/`](../guides/README.md). If you n
 | [user-provided-knowledge.md](user-provided-knowledge.md) | How users register knowledge bases without dumping documents into prompts |
 | [framework-capsules.md](framework-capsules.md) | Operational summary of a framework or large source; the default unit a skill consumes |
 | [knowledge-resolver.md](knowledge-resolver.md) | Logical role that selects which knowledge sources enter task context |
+| [governed-skill-optimization.md](governed-skill-optimization.md) | Why skill optimization is governed: evidence vs. authority, and where the boundary sits |

--- a/docs/concepts/governed-skill-optimization.md
+++ b/docs/concepts/governed-skill-optimization.md
@@ -1,0 +1,89 @@
+# Governed Skill Optimization
+
+> **Optimization is evidence, not authority. Governance outranks optimization.**
+
+This document explains *why* AletheIA treats skill optimization as a governed activity and
+where the boundary sits between **producing evidence** about a proposed skill change and
+**deciding** to make that change.
+
+It is conceptual background. The normative rules live in
+[skill-evolution-validation-contract.md](../contracts/skill-evolution-validation-contract.md).
+
+## The problem
+
+As a skill library grows, proposals to evolve a skill can be accepted because they *seem*
+reasonable rather than because they were tested. Three failure modes follow:
+
+1. A skill improves in one scenario and silently regresses in another.
+2. A change looks cosmetic but shifts decision behavior.
+3. A knowledge-aware skill blurs *skill evolution* with *misuse of a governed source*.
+
+Optimization techniques that treat a natural-language skill document as an improvable
+artifact make these failures worse if their output is trusted directly. The risk is not the
+experimentation — it is letting an experiment's result act as authority.
+
+## The stance
+
+AletheIA governs the **decision**; it does not run the optimization. An experiment may
+generate evidence, a comparison, or a recommendation. It may never produce a canonical
+change. The strongest thing an experiment can do is create a *proposal*, which then re-enters
+the normal governed path: human review and a pull request.
+
+This mirrors how AletheIA already treats its own evolution (see
+[self-application.md](self-application.md)) and how it separates *what a skill needs* from
+*which source satisfies it* (see [knowledge-governance-layer.md](knowledge-governance-layer.md)).
+
+## Where it sits
+
+```txt
+AletheIA                      contracts, gates, policies, evaluation depth, human decision
+Knowledge Governance Layer    sources, authority, sensitivity, scope, restrictions, packs
+Adaptive Skills               skills, modules, triggers, verification, handoff signals
+Evolution Layer               observations, proposals, reviews, outcomes
+Skill Evolution Validation    validation cases, experiments, regression, comparative evidence
+```
+
+The execution side of this layer — validation cases, experiments, the regression check, and
+the structural validator — lives in the **Adaptive Skills** repository, beside the existing
+Evolution Layer. AletheIA holds only the **contract**: the conditions an experiment and its
+evidence must satisfy to be considered governed. AletheIA governs the decision; Adaptive
+Skills runs the experiment.
+
+## The authorized path
+
+```txt
+Observation
+  → Validation Case
+  → Skill Evolution Experiment
+  → Regression Check
+  → Proposal
+  → Human Review
+  → Pull Request
+  → Canonical Skill Update
+```
+
+Everything up to and including the experiment is **evidence**. Everything after the proposal
+is **human authority**. The two never collapse into a single automated step.
+
+## What this is not
+
+- Not an optimizer runtime, a benchmark engine, or a training loop.
+- Not an auto-writeback into any skill document.
+- Not a scoring system whose number becomes a decision.
+- Not a license to copy confidential, restricted, or regulated content into experiment
+  artifacts — synthetic-first applies, and the
+  [restricted-knowledge-usage-policy.md](../contracts/restricted-knowledge-usage-policy.md)
+  still binds.
+
+## Good outcomes that are not "a change"
+
+Confirming that a skill already behaves correctly under a new case (`reinforced`) or that a
+candidate is not worth adopting (`no-change`) are **successful** results. They prevent churn
+and are evidence in their own right. Few strong cases beat many weak ones.
+
+## Related
+
+- [skill-evolution-validation-contract.md](../contracts/skill-evolution-validation-contract.md) — the normative contract
+- [self-application.md](self-application.md) — how AletheIA governs its own evolution
+- [knowledge-governance-layer.md](knowledge-governance-layer.md) — source/skill/contract separation
+- [sensitivity-vocabulary-mapping.md](../contracts/sensitivity-vocabulary-mapping.md) — canonical sensitivity taxonomy

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -27,6 +27,7 @@ If you need conceptual background, see [`concepts/`](../concepts/README.md). If 
 | [restricted-knowledge-usage-policy.md](restricted-knowledge-usage-policy.md) | Usage rules for confidential, restricted, and regulated sources |
 | [knowledge-audit-log-spec.md](knowledge-audit-log-spec.md) | Minimum audit fields when a knowledge source influences output |
 | [sensitivity-vocabulary-mapping.md](sensitivity-vocabulary-mapping.md) | Canonical sensitivity taxonomy and how project extensions map local labels to it |
+| [skill-evolution-validation-contract.md](skill-evolution-validation-contract.md) | What a skill evolution experiment and its validation evidence must satisfy to be governed |
 
 ### Operationalized by security checklists
 

--- a/docs/contracts/skill-evolution-validation-contract.md
+++ b/docs/contracts/skill-evolution-validation-contract.md
@@ -1,0 +1,96 @@
+# Skill Evolution Validation Contract
+
+## Goal
+
+Define what a **skill evolution experiment** and its **validation evidence** must satisfy to
+be considered governed by AletheIA.
+
+This contract specifies; it does not explain. For conceptual background see
+[governed-skill-optimization.md](../concepts/governed-skill-optimization.md). The execution
+surface (validation cases, experiments, validator) lives in the Adaptive Skills repository;
+this contract governs the **decision**, not the execution.
+
+---
+
+## Principles
+
+1. **Optimization is evidence, not authority.** An experiment may produce evidence, a
+   comparison, or a recommendation — never a canonical change.
+2. **Governance outranks optimization.** No experimental result overrides AletheIA contracts,
+   the Knowledge Governance Layer, or human review.
+3. **Synthetic-first.** Validation evidence uses synthetic, public, or explicitly authorized
+   material only.
+4. **Regression matters.** A change is acceptable only if it improves the target case without
+   degrading cases already covered.
+
+---
+
+## Normative requirements
+
+### Evidence
+
+- **R1.** Every experiment MUST reference at least one validation case.
+- **R2.** Every validation case MUST declare `sensitivity` using the canonical taxonomy in
+  [sensitivity-vocabulary-mapping.md](sensitivity-vocabulary-mapping.md).
+- **R3.** Validation cases with sensitivity `confidential`, `restricted`, or `regulated` MUST
+  be synthetic-or-capsule only: no raw governed content may appear in any experiment artifact
+  (trace, prompt, example, export). This is bound by
+  [restricted-knowledge-usage-policy.md](restricted-knowledge-usage-policy.md).
+- **R4.** Every experiment MUST reference the skill it targets, and that skill MUST exist.
+
+### Surfaces
+
+- **R5.** An experiment's candidate change MUST target a non-protected skill surface. Protected
+  surfaces (skill identity, purpose, when-to-use boundaries, core moves, taxonomy) MUST NOT be
+  altered by experimental result.
+- **R6.** If an experiment claims to touch a protected surface, it MUST set
+  `human_review_required: true`.
+- **R7.** No experiment MAY write to a canonical skill document. Auto-writeback is forbidden.
+
+### Outcomes
+
+- **R8.** An experiment's recommendation MAY only be evidence-level — for example
+  `reinforced`, `no-change`, `proposal-created`, `defer`, or `rejected`. It MUST NOT be
+  `approved` or `merged`.
+- **R9.** The strongest authorized outcome is the creation of a proposal in the Evolution
+  Layer. Promotion beyond a proposal MUST follow human review and a pull request.
+- **R10.** `reinforced` and `no-change` are valid, acceptable outcomes — confirming current
+  behavior is governed evidence, not a failure.
+
+### Knowledge-aware skills
+
+- **R11.** Any experiment involving a knowledge-aware skill MUST set
+  `human_review_required: true`.
+- **R12.** Governed sources MAY appear in such experiments only as simulated metadata or a
+  fictional capsule — never as a copied excerpt of a real source.
+
+---
+
+## The authorized flow
+
+```txt
+Observation → Validation Case → Experiment → Regression Check
+  → Proposal → Human Review → Pull Request → Canonical Skill Update
+```
+
+Everything up to and including the experiment is evidence. Everything after the proposal is
+human authority.
+
+---
+
+## Conformance
+
+A skill evolution experiment is **conformant** when R1–R12 hold. The Adaptive Skills
+repository SHOULD enforce the structural subset of these requirements automatically (a
+dependency-free validator) and leave the judgment subset — whether the evidence is strong
+enough — to human review. AletheIA does not execute the validator; it requires that
+conformance be demonstrable before a derived change is accepted.
+
+---
+
+## Relationship to other contracts
+
+- [restricted-knowledge-usage-policy.md](restricted-knowledge-usage-policy.md) — binds R3, R12.
+- [sensitivity-vocabulary-mapping.md](sensitivity-vocabulary-mapping.md) — defines the taxonomy R2 uses.
+- [skill-knowledge-dependency-contract.md](skill-knowledge-dependency-contract.md) — how a skill declares knowledge needs; experiments must not bypass it.
+- [knowledge-audit-log-spec.md](knowledge-audit-log-spec.md) — audit fields when a governed source influences output.


### PR DESCRIPTION
## What

Adds the **AletheIA-side governance** for the Skill Evolution Validation Layer. The execution surface (validation cases, experiments, validator) lives in the Adaptive Skills repo and merged via adaptive-skills#49. **AletheIA governs the decision, not the optimization** — so only the high-level contract + concept doc belong here.

> Optimization is evidence, not authority. Governance outranks optimization.

## Files

- **`docs/concepts/governed-skill-optimization.md`** (concept) — the problem, the stance, where the layer sits, the authorized flow, and what it is not.
- **`docs/contracts/skill-evolution-validation-contract.md`** (normative) — requirements **R1–R12**: at least one validation case per experiment; sensitivity declared (canonical taxonomy); synthetic/capsule-only for confidential/restricted/regulated; protected surfaces require human review; no auto-writeback; outcomes are evidence-level only (never `approved`/`merged`); knowledge-aware skills require human review.
- Index rows added to `docs/concepts/README.md` and `docs/contracts/README.md`.

## Boundaries

Does not change `engine/`, `schemas/`, `policies/`, or any existing contract. Binds to `restricted-knowledge-usage-policy.md` and `sensitivity-vocabulary-mapping.md`.

## Validation

`bash scripts/check-governance.sh` → Governance baseline passed. No placeholder markers introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)