### PR TITLE
docs(governance): Runtime Effort Governance Contract (REGC)

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -27,6 +27,7 @@ If you need conceptual background, see [`concepts/`](../concepts/README.md). If 
 | [restricted-knowledge-usage-policy.md](restricted-knowledge-usage-policy.md) | Usage rules for confidential, restricted, and regulated sources |
 | [knowledge-audit-log-spec.md](knowledge-audit-log-spec.md) | Minimum audit fields when a knowledge source influences output |
 | [sensitivity-vocabulary-mapping.md](sensitivity-vocabulary-mapping.md) | Canonical sensitivity taxonomy and how project extensions map local labels to it |
+| [runtime-effort-governance-contract.md](runtime-effort-governance-contract.md) | How an agent decides runtime effort for a work slice: start, escalate, de-escalate, stop, and human checkpoint |
 
 ### Operationalized by security checklists
 

--- a/docs/contracts/runtime-effort-governance-contract.md
+++ b/docs/contracts/runtime-effort-governance-contract.md
@@ -1,0 +1,380 @@
+# Runtime Effort Governance Contract
+
+## Purpose
+
+This contract defines how AletheIA-governed agents decide runtime effort for a work slice.
+
+It governs cognitive effort, context expansion, tool usage, escalation, de-escalation, signal priority, intent conflict resolution, stop conditions, human checkpoints, minimum telemetry, and versioning.
+
+The goal is not to minimize tokens at any cost. The goal is to preserve quality while avoiding unnecessary resource waste.
+
+## Scope
+
+This contract applies to work slices handled by an AletheIA-compatible runtime or project overlay.
+
+It can be used by any model, coding agent, chat assistant, runtime adapter, or project-specific harness.
+
+This contract specifies operational behavior; it does not explain it. For the planning-depth vocabulary it builds on, see [planning-depth-profiles.md](../reference/planning-depth-profiles.md). For the signals it reacts to, see [effort-escalation-signals.md](../reference/effort-escalation-signals.md).
+
+## Non-goals
+
+This contract does not:
+
+- choose a model;
+- implement automatic model routing;
+- replace runtime adapters;
+- replace planning-depth profiles;
+- replace readiness gates;
+- replace token policy;
+- create a heavy policy engine.
+
+## Core rule
+
+AletheIA must start each work slice with the lowest sufficient effort, escalate only when observable signals justify it, de-escalate when the task becomes bounded, and stop when the next step requires human authority, not more reasoning.
+
+## Quality policy
+
+Quality is the floor. Token saving is secondary.
+
+The agent must not reduce required quality, evidence, safety, or clarity for token savings.
+
+If the quality floor is at risk, the agent must escalate effort, ask for missing context, or stop with an explicit limitation.
+
+```yaml
+quality_policy:
+  quality_floor: "required"
+  token_saving_priority: "secondary"
+  rule: "Do not reduce required quality, evidence, safety, or clarity for token savings."
+```
+
+## Default effort policy
+
+```yaml
+default_policy:
+  start_mode: "minimal_sufficient_effort"
+  escalation_mode: "evidence_based"
+  deescalation_allowed: true
+  human_checkpoint_required_for:
+    - "irreversible_action"
+    - "external_side_effect"
+    - "high_cost_change"
+    - "ambiguous_tradeoff"
+    - "risk_exceeds_authority"
+```
+
+## Work slice classification
+
+```yaml
+work_slice_classification:
+  task_type:
+    - "answer"
+    - "edit"
+    - "plan"
+    - "code_change"
+    - "review"
+    - "research"
+    - "automation"
+  reversibility:
+    - "high"
+    - "medium"
+    - "low"
+  blast_radius:
+    - "local"
+    - "multi_file"
+    - "systemic"
+    - "external_system"
+  uncertainty:
+    - "low"
+    - "medium"
+    - "high"
+  risk_of_error:
+    - "low"
+    - "medium"
+    - "high"
+  context_need:
+    - "none"
+    - "local"
+    - "project"
+    - "external"
+  tool_need:
+    - "none"
+    - "read_only"
+    - "write"
+    - "execute"
+```
+
+## User intent model
+
+The user should not be required to choose an abstract reasoning level. The user may express operational intent.
+
+```yaml
+user_intent:
+  priority:
+    - "speed"
+    - "precision"
+    - "safety"
+    - "autonomy"
+    - "cost_saving"
+  confirmation_style:
+    - "ask_before_write"
+    - "ask_on_risk"
+    - "autonomous_with_summary"
+```
+
+## Intent conflict resolution
+
+User intent informs effort, but does not override quality, safety, reversibility, or authority boundaries.
+
+```yaml
+intent_resolution:
+  rule: "User intent informs effort, but does not override quality, safety, reversibility, or authority boundaries."
+  priority_order:
+    - "safety"
+    - "precision"
+    - "autonomy"
+    - "speed"
+    - "cost_saving"
+  conflict_rules:
+    - "safety overrides all other intents."
+    - "precision overrides speed when risk_of_error is medium or high."
+    - "cost_saving never overrides quality_floor."
+    - "autonomy is limited by human_checkpoint_required_for."
+    - "speed may reduce verbosity, but not required validation."
+```
+
+## Effort budget
+
+```yaml
+effort_budget:
+  initial_depth:
+    - "lite"
+    - "standard"
+    - "high_assurance"
+  max_depth:
+    - "lite"
+    - "standard"
+    - "high_assurance"
+  max_context_expansion:
+    - "none"
+    - "targeted"
+    - "broad"
+  max_tool_iterations: 3
+  max_revision_loops: 2
+```
+
+## Escalation triggers
+
+The agent may escalate only when at least one observable trigger is present.
+
+```yaml
+escalation_triggers:
+  - "missing_required_context"
+  - "conflicting_requirements"
+  - "multi_file_dependency_detected"
+  - "test_or_validation_failure"
+  - "low_confidence"
+  - "security_privacy_or_compliance_risk"
+  - "irreversible_or_external_action"
+  - "quality_floor_at_risk"
+```
+
+## De-escalation triggers
+
+The agent may reduce effort when the task becomes bounded and no blocking escalation signal is active.
+
+```yaml
+deescalation_triggers:
+  - "scope_became_local"
+  - "required_context_found"
+  - "risk_confirmed_low"
+  - "answer_sufficient_without_more_tools"
+```
+
+## Signal priority order
+
+Escalation signals override de-escalation signals when quality, safety, reversibility, or authority is at risk.
+
+```yaml
+signal_priority:
+  rule: "Escalation signals override de-escalation signals when quality, safety, reversibility, or authority is at risk."
+
+  always_escalate:
+    - "security_privacy_or_compliance_risk"
+    - "irreversible_or_external_action"
+    - "risk_exceeds_authority"
+    - "quality_floor_at_risk"
+
+  escalate_before_deescalate:
+    - "test_or_validation_failure"
+    - "conflicting_requirements"
+    - "low_confidence"
+
+  conditional_escalation:
+    - "multi_file_dependency_detected"
+    - "missing_required_context"
+
+  deescalate_only_when_no_blocking_risk:
+    - "answer_sufficient_without_more_tools"
+    - "scope_became_local"
+    - "risk_confirmed_low"
+    - "required_context_found"
+```
+
+## Stop conditions
+
+The agent must stop when continuing would add cost without improving quality or when the next step requires human authority.
+
+```yaml
+stop_conditions:
+  - "sufficient_quality_reached"
+  - "budget_exhausted"
+  - "human_decision_required"
+  - "risk_exceeds_authority"
+  - "next_action_is_not_reversible"
+```
+
+## Human checkpoint rules
+
+The agent must stop and request a human decision — not more reasoning — when an action crosses the authority boundary.
+
+```yaml
+human_checkpoint:
+  required_for:
+    - "irreversible_action"
+    - "external_side_effect"
+    - "high_cost_change"
+    - "ambiguous_tradeoff"
+    - "risk_exceeds_authority"
+  behavior: "stop, summarize the decision needed, and wait for human confirmation"
+  rule: "More reasoning must not substitute for human authority."
+```
+
+## Telemetry requirements
+
+```yaml
+telemetry:
+  record_effort_decision: true
+  record_escalation_reason: true
+  record_deescalation_reason: true
+  record_stop_reason: true
+  record_context_expansion: true
+  record_tool_iterations: true
+  record_quality_floor_risk: true
+```
+
+## Telemetry output format
+
+The contract does not require a heavy telemetry engine. It defines a minimum structured output that adapters and projects can implement.
+
+```yaml
+telemetry_output:
+  format: "structured_log"
+  minimum_fields:
+    - "slice_id"
+    - "task_type"
+    - "classification"
+    - "user_intent"
+    - "initial_effort"
+    - "final_effort"
+    - "escalation_count"
+    - "escalation_reasons"
+    - "deescalation_count"
+    - "deescalation_reasons"
+    - "stop_reason"
+    - "human_checkpoint_triggered"
+    - "quality_floor_maintained"
+    - "context_expansion_level"
+    - "tool_iterations"
+    - "timestamp"
+```
+
+Example:
+
+```yaml
+runtime_effort_telemetry:
+  slice_id: "slice-2026-06-02-001"
+  task_type: "code_change"
+  classification:
+    reversibility: "medium"
+    blast_radius: "multi_file"
+    uncertainty: "medium"
+    risk_of_error: "medium"
+    context_need: "project"
+    tool_need: "write"
+  user_intent:
+    priority: ["precision", "cost_saving"]
+    confirmation_style: "ask_on_risk"
+  initial_effort: "standard"
+  final_effort: "high_assurance"
+  escalation_count: 1
+  escalation_reasons:
+    - "multi_file_dependency_detected"
+  deescalation_count: 0
+  deescalation_reasons: []
+  stop_reason: "human_decision_required"
+  human_checkpoint_triggered: true
+  quality_floor_maintained: true
+  context_expansion_level: "targeted"
+  tool_iterations: 2
+  timestamp: "2026-06-02T00:00:00Z"
+```
+
+## Versioning
+
+```yaml
+versioning:
+  current: "0.1"
+  compatibility: "backward_compatible_within_minor"
+  breaking_changes: "require_major_version_bump"
+  deprecation_policy: "deprecated fields must remain documented for at least one minor version"
+```
+
+## Relationship with planning-depth profiles
+
+Lite, Standard, and High-Assurance remain the planning-depth vocabulary.
+
+This contract defines when to start, escalate, reduce, or stop across those profiles.
+
+## Relationship with runtime adapters
+
+Runtime adapters translate the contract into local runtime behavior.
+
+The contract must not name a vendor as the default implementation.
+
+Example:
+
+```yaml
+runtime_mapping_example:
+  lite:
+    runtime_behavior: "targeted read, minimal planning, concise output"
+  standard:
+    runtime_behavior: "short plan, related context inspection, focused validation"
+  high_assurance:
+    runtime_behavior: "dependency mapping, explicit plan, validation, checkpoint before risky action"
+```
+
+## Relationship with waste heuristics
+
+Waste heuristics detect inefficient behavior. This contract defines the operational response.
+
+Examples:
+
+- if context expansion produces no relevant signal, de-escalate or stop;
+- if tool calls repeat without progress, stop or ask for human direction;
+- if a simple local change triggers unnecessary planning, reduce depth;
+- if a concise answer risks quality, escalate;
+- if a de-escalation signal appears while quality floor is at risk, do not de-escalate.
+
+## Examples
+
+See [runtime-effort-contract-example.md](../../examples/resource-aware-operations/runtime-effort-contract-example.md).
+
+## Relationship to other contracts
+
+- [effort-escalation-signals.md](../reference/effort-escalation-signals.md) — the catalog of escalation, de-escalation, stop, waste, and risk signals this contract reacts to, plus their priority order.
+- [planning-depth-profiles.md](../reference/planning-depth-profiles.md) — the Lite / Standard / High-Assurance vocabulary this contract starts, escalates, and de-escalates across.
+- [waste-heuristics.md](../reference/waste-heuristics.md) — detects inefficient behavior; this contract defines the operational response to it.
+- [token-policy.md](../reference/token-policy.md) — token discipline rules; this contract keeps token saving subordinate to the quality floor.
+- [runtime-adapter-contract.md](runtime-adapter-contract.md) — what any adapter must honor when translating this contract into local runtime behavior.
+- [readiness-gates-spec.md](readiness-gates-spec.md) — whether a slice is ready to continue; this contract uses gates to separate execution problems from authority problems.
+- [slice-telemetry-model.md](slice-telemetry-model.md) — the minimal slice-level telemetry model the effort telemetry output extends.

--- a/docs/contracts/runtime-effort-governance-contract.md
+++ b/docs/contracts/runtime-effort-governance-contract.md
@@ -175,6 +175,7 @@ escalation_triggers:
   - "low_confidence"
   - "security_privacy_or_compliance_risk"
   - "irreversible_or_external_action"
+  - "risk_exceeds_authority"
   - "quality_floor_at_risk"
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,8 @@ Reading map organized by intent. Each entry links to the most useful starting po
 3. [Readiness gates spec](contracts/readiness-gates-spec.md)
 4. [Work slice spec bundle](contracts/work-slice-spec-bundle.md)
 5. [Slice telemetry model](contracts/slice-telemetry-model.md)
-6. [All contracts →](contracts/README.md)
+6. [Runtime effort governance contract](contracts/runtime-effort-governance-contract.md) — how an agent decides effort: start, escalate, de-escalate, stop, checkpoint
+7. [All contracts →](contracts/README.md)
 
 ---
 
@@ -93,6 +94,7 @@ Reading map organized by intent. Each entry links to the most useful starting po
 
 1. [Token policy](reference/token-policy.md)
 2. [Waste heuristics](reference/waste-heuristics.md)
-3. [Planning depth profiles](reference/planning-depth-profiles.md)
+3. [Effort escalation signals](reference/effort-escalation-signals.md)
+4. [Planning depth profiles](reference/planning-depth-profiles.md)
 4. [Launch kit](reference/launch-kit.md) — public-facing descriptions and taglines
 5. [All reference →](reference/README.md)

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -11,6 +11,7 @@ Consultable material: catalogs, checklists, policies, examples, adapter guides, 
 | [canonical-vocabulary.md](../concepts/canonical-vocabulary.md) | → see concepts/ (canonical vocabulary is a concept doc) |
 | [token-policy.md](token-policy.md) | Token discipline rules |
 | [waste-heuristics.md](waste-heuristics.md) | Heuristics for identifying operational waste |
+| [effort-escalation-signals.md](effort-escalation-signals.md) | Signals to escalate, de-escalate, or stop effort, and their priority order |
 | [planning-depth-profiles.md](planning-depth-profiles.md) | Lite / Standard / High-Assurance planning depth |
 | [launch-kit.md](launch-kit.md) | Public-facing descriptions, taglines, one-pager |
 | [learnings.md](learnings.md) | Durable lessons from AI-assisted work |

--- a/docs/reference/effort-escalation-signals.md
+++ b/docs/reference/effort-escalation-signals.md
@@ -1,0 +1,164 @@
+# Effort Escalation Signals
+
+## Goal
+
+Catalog the observable signals an AletheIA-governed runtime uses to decide whether to
+**escalate**, **de-escalate**, or **stop** within a work slice, and define which signal wins
+when several appear at once.
+
+This reference is consumed by the
+[Runtime Effort Governance Contract](../contracts/runtime-effort-governance-contract.md),
+which defines the operational response to each signal. This document lists the signals; the
+contract decides what to do with them.
+
+Effort is never escalated by habit. It is escalated only when at least one observable signal
+below is present, and only as far as the signal justifies.
+
+---
+
+## Escalation signals
+
+A reason to spend more effort, expand context, or raise planning depth.
+
+| Signal | Meaning |
+|---|---|
+| `missing_required_context` | Context required for a correct, safe, or complete answer is absent. |
+| `conflicting_requirements` | Two or more requirements cannot both be satisfied as stated. |
+| `multi_file_dependency_detected` | The change reaches beyond the local artifact into linked files. |
+| `test_or_validation_failure` | A check, test, or validation did not pass. |
+| `low_confidence` | The agent's confidence in the current answer is materially low. |
+| `security_privacy_or_compliance_risk` | The slice touches security, privacy, or compliance surface. |
+| `irreversible_or_external_action` | The next step is hard to undo or causes an external side effect. |
+| `quality_floor_at_risk` | Continuing at current effort would breach the required quality floor. |
+
+---
+
+## De-escalation signals
+
+A reason to reduce effort, stop expanding context, or lower planning depth — valid only when
+no blocking escalation signal is active.
+
+| Signal | Meaning |
+|---|---|
+| `scope_became_local` | The task turned out to be narrow and locally contained. |
+| `required_context_found` | The context the slice needed has been located. |
+| `risk_confirmed_low` | Investigation confirmed the risk of error is low. |
+| `answer_sufficient_without_more_tools` | The current answer meets the requested output without further tool use. |
+
+---
+
+## Stop signals
+
+A reason to stop the slice — either because more effort adds cost without quality, or because
+the next step requires human authority.
+
+| Signal | Meaning |
+|---|---|
+| `sufficient_quality_reached` | The output already satisfies the quality floor and the request. |
+| `budget_exhausted` | The effort, tool, or revision budget is spent. |
+| `human_decision_required` | The next step is a human decision, not more reasoning. |
+| `risk_exceeds_authority` | The risk is above what the agent is authorized to take. |
+| `next_action_is_not_reversible` | Proceeding would cross an irreversibility boundary. |
+
+---
+
+## Waste signals and operational response
+
+Waste signals come from [waste-heuristics.md](waste-heuristics.md). The contract maps each to
+a response.
+
+| Waste signal | Response |
+|---|---|
+| broad context read with no relevant gain | de-escalate or stop expanding context |
+| tool calls repeating without progress | stop or ask for human direction |
+| heavy planning for a simple local change | reduce depth toward Lite |
+| concise answer that risks quality | escalate |
+| repeated validation failure | stop or request a handoff |
+
+---
+
+## Risk signals
+
+Risk signals always bias toward escalation or a human checkpoint, never toward de-escalation:
+
+- `security_privacy_or_compliance_risk`
+- `irreversible_or_external_action`
+- `risk_exceeds_authority`
+- `quality_floor_at_risk`
+
+---
+
+## Signal priority
+
+When escalation and de-escalation signals appear simultaneously, resolve with this order.
+Escalation signals override de-escalation signals when quality, safety, reversibility, or
+authority is at risk.
+
+```yaml
+signal_priority:
+  rule: "Escalation signals override de-escalation signals when quality, safety, reversibility, or authority is at risk."
+
+  always_escalate:
+    - "security_privacy_or_compliance_risk"
+    - "irreversible_or_external_action"
+    - "risk_exceeds_authority"
+    - "quality_floor_at_risk"
+
+  escalate_before_deescalate:
+    - "test_or_validation_failure"
+    - "conflicting_requirements"
+    - "low_confidence"
+
+  conditional_escalation:
+    - "multi_file_dependency_detected"
+    - "missing_required_context"
+
+  deescalate_only_when_no_blocking_risk:
+    - "answer_sufficient_without_more_tools"
+    - "scope_became_local"
+    - "risk_confirmed_low"
+    - "required_context_found"
+```
+
+Read the tiers top-down:
+
+1. **always_escalate** — a single one of these forces escalation or a human checkpoint, no
+   matter what de-escalation signals are also present.
+2. **escalate_before_deescalate** — resolve these toward more effort before considering any
+   reduction.
+3. **conditional_escalation** — escalate only if the signal actually blocks quality, safety,
+   or correctness; otherwise it does not force escalation.
+4. **deescalate_only_when_no_blocking_risk** — reduce effort only when no signal from the
+   higher tiers is active.
+
+---
+
+## Examples by task type
+
+- **Lite edit** (`task_type: edit`, reversible, local): typically no escalation signal fires;
+  the slice stays Lite and stops on `sufficient_quality_reached`.
+- **Standard plan** (`task_type: plan`, multi-file, read-only): `multi_file_dependency_detected`
+  is present but conditional — escalate only if a linked file actually changes the answer.
+- **High-Assurance code change** (`task_type: code_change`, systemic, low reversibility):
+  `irreversible_or_external_action` and `risk_exceeds_authority` force escalation and a human
+  checkpoint.
+
+---
+
+## Conflict examples
+
+- `missing_required_context` + `answer_sufficient_without_more_tools` → escalate if the missing
+  context is required for quality; de-escalate only if it is not required for the requested
+  output. See example 4 in
+  [runtime-effort-contract-example.md](../../examples/resource-aware-operations/runtime-effort-contract-example.md).
+- `scope_became_local` + `risk_confirmed_low` + `answer_sufficient_without_more_tools` with no
+  blocking risk → de-escalate to Lite. See example 7 in the same file.
+
+---
+
+## Suggested next reading
+
+- [runtime-effort-governance-contract.md](../contracts/runtime-effort-governance-contract.md)
+- [planning-depth-profiles.md](planning-depth-profiles.md)
+- [waste-heuristics.md](waste-heuristics.md)
+- [runtime-effort-contract-example.md](../../examples/resource-aware-operations/runtime-effort-contract-example.md)

--- a/docs/reference/effort-escalation-signals.md
+++ b/docs/reference/effort-escalation-signals.md
@@ -29,6 +29,7 @@ A reason to spend more effort, expand context, or raise planning depth.
 | `low_confidence` | The agent's confidence in the current answer is materially low. |
 | `security_privacy_or_compliance_risk` | The slice touches security, privacy, or compliance surface. |
 | `irreversible_or_external_action` | The next step is hard to undo or causes an external side effect. |
+| `risk_exceeds_authority` | The risk is above what the agent is authorized to take; escalate toward a human checkpoint. |
 | `quality_floor_at_risk` | Continuing at current effort would breach the required quality floor. |
 
 ---

--- a/docs/roadmaps/resource-aware-operations-roadmap.md
+++ b/docs/roadmaps/resource-aware-operations-roadmap.md
@@ -321,3 +321,12 @@ This track now begins with:
 - `examples/resource-aware-operations/agent-runtime-decision-example.md`
 
 These are meant to establish the first observability spine, the first advisory signal layer, a minimal runtime contract, and an advisory fit layer before any benchmark or learning-layer work is attempted.
+
+Building on Phase E (planning-depth profiles and readiness gates), the track now adds an explicit effort-governance layer that decides when to start, escalate, de-escalate, and stop across those profiles:
+
+- `docs/contracts/runtime-effort-governance-contract.md`
+- `docs/reference/effort-escalation-signals.md`
+- `starter-pack/templates/runtime-effort-policy-template.md`
+- `examples/resource-aware-operations/runtime-effort-contract-example.md`
+
+This layer stays docs-first, advisory-first, and provider-agnostic. It does not select models, does not claim auto-routing, and keeps token saving subordinate to the quality floor.

--- a/examples/resource-aware-operations/README.md
+++ b/examples/resource-aware-operations/README.md
@@ -15,6 +15,7 @@ The first examples stay docs-first and intentionally small.
 - `bounded-pilot-conversion-loop.md`
 - `slice-finalization-reference.md`
 - `clean-restart-command-adapter-example.md`
+- `runtime-effort-contract-example.md`
 
 ## Related pilot support
 

--- a/examples/resource-aware-operations/runtime-effort-contract-example.md
+++ b/examples/resource-aware-operations/runtime-effort-contract-example.md
@@ -1,0 +1,293 @@
+# Runtime Effort Contract — Operational Examples and Edge Cases
+
+Concrete examples that exercise the
+[Runtime Effort Governance Contract](../../docs/contracts/runtime-effort-governance-contract.md).
+They show how an AletheIA-governed runtime decides effort, escalates, de-escalates,
+stops, and asks for a human checkpoint — without naming any specific model.
+
+## 1. Lite slice — Local, reversible edit
+
+### Scenario
+
+A user asks: "Adjust this paragraph for clarity."
+
+### Classification
+
+```yaml
+task_type: "edit"
+reversibility: "high"
+blast_radius: "local"
+uncertainty: "low"
+risk_of_error: "low"
+context_need: "none"
+tool_need: "none"
+initial_depth: "lite"
+max_depth: "lite"
+```
+
+### Expected behavior
+
+- Do not expand project context.
+- Do not create a heavy plan.
+- Produce the edited paragraph.
+- Stop when quality is sufficient.
+
+### Telemetry expectation
+
+```yaml
+initial_effort: "lite"
+final_effort: "lite"
+escalation_count: 0
+deescalation_count: 0
+stop_reason: "sufficient_quality_reached"
+quality_floor_maintained: true
+```
+
+---
+
+## 2. Standard slice — Bounded project document update
+
+### Scenario
+
+A user asks: "Update the governance guide to mention runtime effort and telemetry."
+
+### Classification
+
+```yaml
+task_type: "plan"
+reversibility: "medium"
+blast_radius: "multi_file"
+uncertainty: "medium"
+risk_of_error: "medium"
+context_need: "project"
+tool_need: "read_only"
+initial_depth: "standard"
+max_depth: "standard"
+```
+
+### Expected behavior
+
+- Inspect related governance docs.
+- Create a short plan.
+- Apply bounded changes.
+- Validate internal consistency.
+- Avoid broad repository exploration unless a trigger appears.
+
+### Telemetry expectation
+
+```yaml
+initial_effort: "standard"
+final_effort: "standard"
+escalation_count: 0
+deescalation_count: 0
+context_expansion_level: "targeted"
+stop_reason: "sufficient_quality_reached"
+quality_floor_maintained: true
+```
+
+---
+
+## 3. High-Assurance slice — Systemic governance change
+
+### Scenario
+
+A user asks: "Change the runtime adapter contract so all consumers follow the new effort governance policy."
+
+### Classification
+
+```yaml
+task_type: "code_change"
+reversibility: "low"
+blast_radius: "systemic"
+uncertainty: "high"
+risk_of_error: "high"
+context_need: "project"
+tool_need: "write"
+initial_depth: "standard"
+max_depth: "high_assurance"
+```
+
+### Expected behavior
+
+- Start in Standard if the initial task is clear.
+- Escalate to High-Assurance when systemic impact is confirmed.
+- Map affected contracts and examples.
+- Produce explicit plan before changes.
+- Request human checkpoint before high-impact or irreversible changes.
+- Record escalation reason.
+
+### Telemetry expectation
+
+```yaml
+initial_effort: "standard"
+final_effort: "high_assurance"
+escalation_count: 1
+escalation_reasons:
+  - "systemic_blast_radius_detected"
+human_checkpoint_triggered: true
+stop_reason: "human_decision_required"
+quality_floor_maintained: true
+```
+
+---
+
+## 4. Edge case — Escalation vs. de-escalation conflict
+
+### Scenario
+
+The agent detects:
+
+```yaml
+signals_detected:
+  - "missing_required_context"
+  - "answer_sufficient_without_more_tools"
+```
+
+### Conflict
+
+One signal suggests escalation. Another suggests de-escalation.
+
+### Resolution
+
+`missing_required_context` wins if the missing context is required to preserve quality, safety, evidence, or correctness.
+
+`answer_sufficient_without_more_tools` wins only when the missing context is not required for the user's requested output.
+
+### Expected decision
+
+```yaml
+decision:
+  action: "escalate_or_ask_for_context"
+  reason: "missing_required_context blocks quality_floor"
+```
+
+### Alternative decision
+
+```yaml
+decision:
+  action: "deescalate_and_stop"
+  reason: "missing context not required for sufficient answer"
+```
+
+### Rule validated
+
+De-escalation only happens when no blocking risk exists.
+
+---
+
+## 5. Edge case — User intent conflict
+
+### Scenario
+
+The user asks:
+
+"Be fast, precise and save tokens."
+
+### Conflict
+
+Speed, precision and cost saving can conflict.
+
+### Resolution
+
+```yaml
+intent_resolution:
+  applied_order:
+    - "precision"
+    - "speed"
+    - "cost_saving"
+  rule_applied:
+    - "precision overrides speed when risk_of_error is medium or high"
+    - "cost_saving never overrides quality_floor"
+```
+
+### Expected behavior
+
+- Reduce verbosity where possible.
+- Do not skip required validation.
+- Avoid broad context expansion unless triggered.
+- Explain limitations if answering without full certainty.
+
+### Expected decision
+
+```yaml
+decision:
+  initial_effort: "standard"
+  max_effort: "standard"
+  verbosity: "concise"
+  validation: "required"
+  token_saving: "secondary"
+```
+
+---
+
+## 6. Edge case — Human checkpoint
+
+### Scenario
+
+The agent is asked to alter a file that changes behavior across multiple consumers.
+
+Detected signals:
+
+```yaml
+signals_detected:
+  - "irreversible_or_external_action"
+  - "risk_exceeds_authority"
+```
+
+### Expected behavior
+
+The agent must stop and ask for human confirmation.
+
+### Expected decision
+
+```yaml
+decision:
+  action: "stop_for_human_checkpoint"
+  reason:
+    - "risk_exceeds_authority"
+    - "irreversible_or_external_action"
+  human_checkpoint_triggered: true
+```
+
+### Rule validated
+
+More reasoning must not replace human authority.
+
+---
+
+## 7. Edge case — Economy justified
+
+### Scenario
+
+The agent starts in Standard, but discovers the task is a local typo fix in one Markdown file.
+
+Detected signals:
+
+```yaml
+signals_detected:
+  - "scope_became_local"
+  - "risk_confirmed_low"
+  - "answer_sufficient_without_more_tools"
+```
+
+### Expected behavior
+
+The agent de-escalates to Lite and avoids broad context expansion.
+
+### Expected decision
+
+```yaml
+decision:
+  action: "deescalate"
+  initial_effort: "standard"
+  final_effort: "lite"
+  reason:
+    - "scope_became_local"
+    - "risk_confirmed_low"
+    - "answer_sufficient_without_more_tools"
+  token_saving: "allowed_without_quality_loss"
+```
+
+### Rule validated
+
+Token saving is allowed when quality floor is preserved.

--- a/examples/resource-aware-operations/runtime-effort-contract-example.md
+++ b/examples/resource-aware-operations/runtime-effort-contract-example.md
@@ -123,7 +123,7 @@ initial_effort: "standard"
 final_effort: "high_assurance"
 escalation_count: 1
 escalation_reasons:
-  - "systemic_blast_radius_detected"
+  - "irreversible_or_external_action"
 human_checkpoint_triggered: true
 stop_reason: "human_decision_required"
 quality_floor_maintained: true

--- a/starter-pack/templates/runtime-effort-policy-template.md
+++ b/starter-pack/templates/runtime-effort-policy-template.md
@@ -1,0 +1,124 @@
+# Runtime Effort Policy Template
+
+## Goal
+
+Instantiate the [Runtime Effort Governance Contract](../../docs/contracts/runtime-effort-governance-contract.md)
+for a consumer project: a short, local policy that says how this project starts, escalates,
+de-escalates, and stops effort — without rebuilding the contract.
+
+Keep this file small. It is a local override layer, not a second contract.
+
+> Quality is the floor. Token saving stays secondary to quality, evidence, safety, and clarity.
+
+---
+
+## Local effort policy
+
+### Default start mode
+
+Examples:
+- `minimal_sufficient_effort` (recommended)
+- `standard_by_default` (only if this project's slices are rarely trivial)
+
+### Default planning depth per slice type
+
+Map this project's common slice types to Lite / Standard / High-Assurance.
+
+| Slice type | Default depth | Notes |
+|---|---|---|
+| | | |
+| | | |
+
+---
+
+## Default intent priority
+
+State the local priority order when user intents conflict. Must not let `cost_saving`
+override the quality floor.
+
+Examples:
+- `safety > precision > autonomy > speed > cost_saving` (contract default)
+- project-specific order, with justification
+
+---
+
+## Limits per slice type
+
+Set local budgets. Leave blank to inherit the contract defaults
+(`max_tool_iterations: 3`, `max_revision_loops: 2`).
+
+| Slice type | max_context_expansion | max_tool_iterations | max_revision_loops |
+|---|---|---|---|
+| | | | |
+
+---
+
+## Local conflict resolution
+
+Describe any project-specific rule for resolving escalation vs. de-escalation signals.
+
+The contract's `signal_priority` always applies. Local rules may only **tighten** it (escalate
+sooner), never loosen it (skip a required escalation).
+
+### When to ask for approval
+
+List the local actions that always require a human checkpoint, on top of the contract's
+`human_checkpoint_required_for` list.
+
+Examples:
+- deploy to production
+- schema or data migration
+- changes to a shared contract or public surface
+
+### When to execute directly
+
+List the local actions safe to perform without a checkpoint.
+
+Examples:
+- local doc edits
+- reversible config changes behind a flag
+
+---
+
+## Local telemetry
+
+### When to record telemetry
+
+Examples:
+- on every escalation, de-escalation, and stop (recommended)
+- on High-Assurance slices only
+
+### Where telemetry is written
+
+Examples:
+- slice record
+- project log
+- handoff package
+
+### Minimum fields kept
+
+Inherit the contract's `telemetry_output.minimum_fields` unless this project has a reason to
+extend them. Always keep `quality_floor_maintained` and `human_checkpoint_triggered`.
+
+---
+
+## Local mapping of Lite / Standard / High-Assurance
+
+Describe what each depth means as concrete behavior in this project.
+
+### Lite
+
+### Standard
+
+### High-Assurance
+
+---
+
+## Review checkpoint
+
+After the first slices using this policy, answer:
+
+- Did effort start too high or too low by default?
+- Were any escalations missing a recorded reason?
+- Did any de-escalation breach the quality floor?
+- Should any local rule become a contract-level proposal?


### PR DESCRIPTION
## What

Adds a **docs-first, advisory-first, provider-agnostic** contract for how an AletheIA-governed agent decides runtime effort per work slice: start at minimal sufficient effort, escalate only on observable signals, de-escalate when the task is bounded, and stop when the next step requires human authority — not more reasoning.

Core invariant: **quality is the floor, token saving is secondary**. `cost_saving` never overrides `quality_floor`. No model selection, no auto-routing claims, no heavy engine.

## Deliverables

- `docs/contracts/runtime-effort-governance-contract.md` — the contract (23 sections incl. signal priority order, intent conflict resolution, telemetry output format, versioning)
- `docs/reference/effort-escalation-signals.md` — escalation / de-escalation / stop / waste / risk signals + priority tiers
- `starter-pack/templates/runtime-effort-policy-template.md` — local policy template for consumer projects
- `examples/resource-aware-operations/runtime-effort-contract-example.md` — 7 cases (Lite, Standard, High-Assurance, escalation-vs-de-escalation conflict, intent conflict, human checkpoint, justified economy)

## Registered in

`docs/index.md` (contract + reference sections), `docs/contracts/README.md`, `docs/reference/README.md`, `examples/resource-aware-operations/README.md`, and the 1.2 resource-aware roadmap.

## Verification

- `scripts/check-governance.sh` — passes
- No vendor names (Codex/Claude/GPT/Opus/Qwen) in any deliverable
- "auto-routing" appears only as a negation in Non-goals
- Quality-floor invariants present (`token_saving_priority: secondary`, `cost_saving never overrides quality_floor`, `quality_floor_at_risk` in escalation + always_escalate)
- `signal_priority` present in both contract and signals reference
- 18/18 relative links resolve
- Acceptance checklist (package `04`) §1–§12 mapped green

## Non-goals / deferred

- No `schemas/*.schema.json` (PRD Phase 2)
- ADR-010 deferred (repo convention, optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)