### PR TITLE
feat(governance): REGC phase 2 — record schema + ADR-010

### DIFF
--- a/docs/adr/ADR-010-runtime-effort-governance-contract.md
+++ b/docs/adr/ADR-010-runtime-effort-governance-contract.md
@@ -1,0 +1,124 @@
+# ADR 010 — Runtime Effort Governance Contract
+
+| Field | Value |
+|---|---|
+| Status | Accepted |
+| Date | 2026-06-03 |
+| Author | Neviton Santana |
+| Deciders | Neviton Santana |
+| Related | ADR-004 (AletheIA as operating overlay), ADR-006 (Domain agnosticism) |
+| Supersedes | — |
+
+## 1. Context
+
+AletheIA already had the substrate for resource-aware operations in the 1.2 track: a
+[token policy](../reference/token-policy.md), [waste heuristics](../reference/waste-heuristics.md),
+[planning-depth profiles](../reference/planning-depth-profiles.md) (Lite / Standard /
+High-Assurance), [readiness gates](../contracts/readiness-gates-spec.md), a
+[slice telemetry model](../contracts/slice-telemetry-model.md), and a provider-agnostic
+[runtime adapter contract](../contracts/runtime-adapter-contract.md).
+
+What it lacked was an explicit contract for **how an agent decides how much effort to
+spend** on a work slice: when to start small, when to escalate, when to reduce effort, when
+to stop, and when to hand the decision to a human. Without it, a runtime can fail in two
+opposite directions — under-spend on a complex slice (weak, unsafe, incomplete output) or
+over-spend on a trivial one (wasted tokens, tools, and context). Two gaps made this acute:
+contradictory **signals** (one says escalate, another says de-escalate) and contradictory
+**user intents** (e.g. "be fast, precise, and cheap"). The guiding principle: **quality is
+the floor; token saving is secondary** — economy must never justify lost clarity, evidence,
+safety, or completeness.
+
+The contract, signal reference, template, and examples shipped first as docs-first in
+PR #177. This ADR records the decision and the follow-on choice to formalize the per-slice
+record as an optional schema once the semantics had stabilized.
+
+## 2. Decision
+
+1. **Add a governance layer, not an engine.** Ship the
+   [Runtime Effort Governance Contract](../contracts/runtime-effort-governance-contract.md) as
+   a docs-first, advisory-first, provider-agnostic contract that sits *between* the existing
+   resource-aware pieces and the runtime. It defines operational intent; runtime adapters
+   translate it. It replaces none of token policy, planning-depth profiles, readiness gates,
+   or the adapter contract.
+2. **Quality floor is a hard invariant.** `quality_floor` is required and
+   `token_saving_priority` is secondary. `cost_saving` can never override `quality_floor`,
+   and `quality_floor_at_risk` is an always-escalate signal — economy is never silent.
+3. **Escalation is evidence-based.** Effort rises only on a defined, observable trigger.
+   The signal set is canonical and shared by the contract and the
+   [signal reference](../reference/effort-escalation-signals.md); a record may not cite an
+   undefined signal. Every signal in `always_escalate` is also a defined `escalation_trigger`.
+4. **Conflicts have a fixed resolution order.** A `signal_priority` order (always_escalate →
+   escalate_before_deescalate → conditional_escalation → deescalate_only_when_no_blocking_risk)
+   and an `intent_resolution` order (safety → precision → autonomy → speed → cost_saving)
+   prevent decision loops.
+5. **Human authority is a stop, not more reasoning.** Irreversible actions, external side
+   effects, high-cost changes, ambiguous trade-offs, and `risk_exceeds_authority` force a
+   human checkpoint. More reasoning must not substitute for human authority.
+6. **Formalize the per-slice record as an optional schema (this ADR's added decision).**
+   Once the semantics stabilized, ship
+   [`runtime-effort-governance-contract.schema.json`](../../schemas/runtime-effort-governance-contract.schema.json)
+   validating the **telemetry record an agent emits per slice** — not the prose contract.
+   The schema enforces the guardrails structurally: signal names are constrained to the
+   defined catalog; escalation/de-escalation counts must match recorded reasons (no silent
+   moves); a breached quality floor must coincide with a human checkpoint or an
+   authority/budget stop; a triggered checkpoint must stop for an authority or
+   irreversibility reason. A vitest suite exercises each guardrail.
+
+## 3. Consequences
+
+**Positive**
+- Effort decisions become auditable: every escalation, de-escalation, and stop carries a
+  recorded, defined reason, and the quality floor can never be breached silently.
+- The schema makes the "never silent" obligations executable, mirroring the Feature Value
+  pack (ADR-009): a non-conforming record fails validation in CI.
+- The layer stays vendor-neutral and additive — no existing contract changes; runtimes opt
+  in through their adapter.
+
+**Negative / accepted tradeoffs**
+- The schema validates the *record* a caller produces, not the prose contract; the runtime
+  must map its decision into the record shape. Accepted — same posture as the generic
+  engine fact model.
+- Some invariants remain semantic (e.g. "precision overrides speed when risk is medium or
+  high") and cannot be expressed structurally; they live in the contract prose and examples.
+- Phase 5 (runtime validation on real tasks) and adapter-mapping examples are deliberately
+  out of scope here; the layer ships and tunes against evidence later.
+
+## 4. Alternatives considered
+
+- **A model router / auto-routing layer.** Rejected: out of scope and against the
+  advisory-first posture; the contract defines behavior, never selects a vendor or model.
+- **A heavy policy engine for effort.** Rejected: duplicates the existing governance-pack
+  engine and inflates the core; docs + an optional record schema are proportional.
+- **Ship the schema in the first PR.** Rejected: the package (and SDD §3.5) deferred it on
+  purpose — stabilize the semantics in review before validating structure.
+- **Validate the prose contract object instead of the per-slice record.** Rejected: the
+  record is the artifact runtimes actually emit and the one worth enforcing in CI.
+- **No ADR (docs only).** Rejected: this draws a durable boundary (effort governance vs.
+  routing vs. existing contracts) that will be cited across PRs — repo convention writes one.
+
+## 5. Relationship
+
+- Builds on Phase E of the
+  [resource-aware operations roadmap](../roadmaps/resource-aware-operations-roadmap.md)
+  (planning-depth profiles + readiness gates).
+- Contract, reference, template, and example:
+  [`runtime-effort-governance-contract.md`](../contracts/runtime-effort-governance-contract.md),
+  [`effort-escalation-signals.md`](../reference/effort-escalation-signals.md),
+  [`runtime-effort-policy-template.md`](../../starter-pack/templates/runtime-effort-policy-template.md),
+  [`runtime-effort-contract-example.md`](../../examples/resource-aware-operations/runtime-effort-contract-example.md).
+- Schema + fixture + test:
+  [`schemas/runtime-effort-governance-contract.schema.json`](../../schemas/runtime-effort-governance-contract.schema.json),
+  `examples/resource-aware-operations/fixtures/standard-slice.json`,
+  `tests/contracts/test-runtime-effort-governance.test.ts`.
+- Adds schema/test/docs only; modifies no existing contract.
+
+## 6. Review
+
+Revisit this ADR when any of the following becomes true:
+
+- Phase 5 runtime validation reveals the trigger set, signal priority, or intent order needs
+  to change.
+- Adapter-mapping examples or a project overlay need record fields the schema does not model.
+- A second resource-aware governance surface appears and reveals shared structure worth
+  extracting.
+- The per-slice record proves too heavy or too thin for real telemetry consumers.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -71,3 +71,4 @@ Do *not* write one for:
 | [ADR-007](ADR-007-apm-packaging-strategy.md) | APM packaging strategy | Accepted |
 | [ADR-008](ADR-008-knowledge-governance-layer.md) | Knowledge Governance Layer | Accepted |
 | [ADR-009](ADR-009-feature-value-governance-pack.md) | Feature Value Governance Pack | Accepted |
+| [ADR-010](ADR-010-runtime-effort-governance-contract.md) | Runtime Effort Governance Contract | Accepted |

--- a/docs/contracts/runtime-effort-governance-contract.md
+++ b/docs/contracts/runtime-effort-governance-contract.md
@@ -370,6 +370,20 @@ Examples:
 
 See [runtime-effort-contract-example.md](../../examples/resource-aware-operations/runtime-effort-contract-example.md).
 
+## Schema
+
+The prose above is the contract. The per-slice **record** an agent emits — its
+classification, intent, effort decision, escalation/de-escalation reasons, stop reason, and
+minimum telemetry — is formalized as an optional JSON Schema:
+[`runtime-effort-governance-contract.schema.json`](../../schemas/runtime-effort-governance-contract.schema.json).
+
+The schema validates the record, not the prose. It constrains signal names to the defined
+catalog and enforces the "never silent" guardrails: escalation/de-escalation counts must
+match recorded reasons, a breached quality floor must coincide with a human checkpoint or an
+authority/budget stop, and a triggered checkpoint must stop for an authority or
+irreversibility reason. See `examples/resource-aware-operations/fixtures/standard-slice.json`
+for a conforming record.
+
 ## Relationship to other contracts
 
 - [effort-escalation-signals.md](../reference/effort-escalation-signals.md) — the catalog of escalation, de-escalation, stop, waste, and risk signals this contract reacts to, plus their priority order.

--- a/docs/roadmaps/resource-aware-operations-roadmap.md
+++ b/docs/roadmaps/resource-aware-operations-roadmap.md
@@ -330,3 +330,10 @@ Building on Phase E (planning-depth profiles and readiness gates), the track now
 - `examples/resource-aware-operations/runtime-effort-contract-example.md`
 
 This layer stays docs-first, advisory-first, and provider-agnostic. It does not select models, does not claim auto-routing, and keeps token saving subordinate to the quality floor.
+
+The semantics are now formalized by an optional schema for the per-slice record, with a vitest guardrail suite and an Architecture Decision Record:
+
+- `schemas/runtime-effort-governance-contract.schema.json`
+- `examples/resource-aware-operations/fixtures/standard-slice.json`
+- `tests/contracts/test-runtime-effort-governance.test.ts`
+- `docs/adr/ADR-010-runtime-effort-governance-contract.md`

--- a/engine/validation.ts
+++ b/engine/validation.ts
@@ -13,7 +13,7 @@ export class SchemaValidationError extends Error {
   }
 }
 
-const ajv = new Ajv2020({ allErrors: true, strict: false });
+const ajv = new Ajv2020({ allErrors: true, strict: false, $data: true });
 addFormats(ajv);
 
 const validatorCache = new Map<string, ReturnType<typeof ajv.compile>>();

--- a/examples/resource-aware-operations/fixtures/standard-slice.json
+++ b/examples/resource-aware-operations/fixtures/standard-slice.json
@@ -1,0 +1,28 @@
+{
+  "slice_id": "slice-2026-06-02-001",
+  "task_type": "code_change",
+  "classification": {
+    "reversibility": "medium",
+    "blast_radius": "multi_file",
+    "uncertainty": "medium",
+    "risk_of_error": "medium",
+    "context_need": "project",
+    "tool_need": "write"
+  },
+  "user_intent": {
+    "priority": ["precision", "cost_saving"],
+    "confirmation_style": "ask_on_risk"
+  },
+  "initial_effort": "standard",
+  "final_effort": "high_assurance",
+  "escalation_count": 1,
+  "escalation_reasons": ["multi_file_dependency_detected"],
+  "deescalation_count": 0,
+  "deescalation_reasons": [],
+  "stop_reason": "human_decision_required",
+  "human_checkpoint_triggered": true,
+  "quality_floor_maintained": true,
+  "context_expansion_level": "targeted",
+  "tool_iterations": 2,
+  "timestamp": "2026-06-02T00:00:00Z"
+}

--- a/schemas/runtime-effort-governance-contract.schema.json
+++ b/schemas/runtime-effort-governance-contract.schema.json
@@ -95,12 +95,18 @@
     "escalation_reasons": {
       "type": "array",
       "items": { "$ref": "#/$defs/escalation_signal" },
-      "description": "Observable triggers that justified raising effort. Must be defined escalation signals; a record cannot cite an undefined signal."
+      "minItems": { "$data": "1/escalation_count" },
+      "maxItems": { "$data": "1/escalation_count" },
+      "$comment": "Reasons are the source of truth: the array length must equal escalation_count exactly, so a record can never misreport how many effort moves occurred. minItems/maxItems use the JSON Schema $data extension (enabled in this repo's validator).",
+      "description": "Observable triggers that justified raising effort. Must be defined escalation signals, and exactly escalation_count of them; a record cannot cite an undefined signal or misreport the move total."
     },
     "deescalation_count": { "type": "integer", "minimum": 0 },
     "deescalation_reasons": {
       "type": "array",
-      "items": { "$ref": "#/$defs/deescalation_signal" }
+      "items": { "$ref": "#/$defs/deescalation_signal" },
+      "minItems": { "$data": "1/deescalation_count" },
+      "maxItems": { "$data": "1/deescalation_count" },
+      "$comment": "Same accounting rule: the array length must equal deescalation_count exactly."
     },
     "stop_reason": {
       "type": "string",
@@ -119,32 +125,6 @@
     "timestamp": { "type": "string", "format": "date-time" }
   },
   "allOf": [
-    {
-      "$comment": "Escalation honesty: a zero escalation_count must carry no escalation reasons, and any escalation must record at least one reason. Effort never moves silently.",
-      "if": {
-        "properties": { "escalation_count": { "const": 0 } },
-        "required": ["escalation_count"]
-      },
-      "then": {
-        "properties": { "escalation_reasons": { "maxItems": 0 } }
-      },
-      "else": {
-        "properties": { "escalation_reasons": { "minItems": 1 } }
-      }
-    },
-    {
-      "$comment": "De-escalation honesty: same accounting rule for de-escalation.",
-      "if": {
-        "properties": { "deescalation_count": { "const": 0 } },
-        "required": ["deescalation_count"]
-      },
-      "then": {
-        "properties": { "deescalation_reasons": { "maxItems": 0 } }
-      },
-      "else": {
-        "properties": { "deescalation_reasons": { "minItems": 1 } }
-      }
-    },
     {
       "$comment": "Quality floor is never silently breached: if it was not maintained, the slice must have stopped for human authority or an exhausted budget, or raised a human checkpoint. cost_saving alone can never breach it.",
       "if": {

--- a/schemas/runtime-effort-governance-contract.schema.json
+++ b/schemas/runtime-effort-governance-contract.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia.local/schemas/runtime-effort-governance-contract.schema.json",
+  "title": "Runtime Effort Governance Record",
+  "description": "Minimum structured record an AletheIA-governed runtime emits for a work slice under the Runtime Effort Governance Contract (docs/contracts/runtime-effort-governance-contract.md). It captures how the slice was classified, the user's operational intent, the effort decision, the escalation/de-escalation reasons, the stop reason, and the minimum telemetry. The schema does not decide effort; it forces the decision to be explicit, traceable, and reconcilable with the signal catalog. Signal names are constrained to the contract's defined triggers so a record can never cite an undefined signal.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "slice_id",
+    "task_type",
+    "classification",
+    "user_intent",
+    "initial_effort",
+    "final_effort",
+    "escalation_count",
+    "escalation_reasons",
+    "deescalation_count",
+    "deescalation_reasons",
+    "stop_reason",
+    "human_checkpoint_triggered",
+    "quality_floor_maintained",
+    "context_expansion_level",
+    "tool_iterations",
+    "timestamp"
+  ],
+  "$defs": {
+    "effort_level": { "type": "string", "enum": ["lite", "standard", "high_assurance"] },
+    "escalation_signal": {
+      "type": "string",
+      "enum": [
+        "missing_required_context",
+        "conflicting_requirements",
+        "multi_file_dependency_detected",
+        "test_or_validation_failure",
+        "low_confidence",
+        "security_privacy_or_compliance_risk",
+        "irreversible_or_external_action",
+        "risk_exceeds_authority",
+        "quality_floor_at_risk"
+      ]
+    },
+    "deescalation_signal": {
+      "type": "string",
+      "enum": [
+        "scope_became_local",
+        "required_context_found",
+        "risk_confirmed_low",
+        "answer_sufficient_without_more_tools"
+      ]
+    },
+    "intent": {
+      "type": "string",
+      "enum": ["speed", "precision", "safety", "autonomy", "cost_saving"]
+    }
+  },
+  "properties": {
+    "slice_id": { "type": "string", "minLength": 1 },
+    "task_type": {
+      "type": "string",
+      "enum": ["answer", "edit", "plan", "code_change", "review", "research", "automation"]
+    },
+    "classification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reversibility", "blast_radius", "uncertainty", "risk_of_error", "context_need", "tool_need"],
+      "properties": {
+        "reversibility": { "type": "string", "enum": ["high", "medium", "low"] },
+        "blast_radius": { "type": "string", "enum": ["local", "multi_file", "systemic", "external_system"] },
+        "uncertainty": { "type": "string", "enum": ["low", "medium", "high"] },
+        "risk_of_error": { "type": "string", "enum": ["low", "medium", "high"] },
+        "context_need": { "type": "string", "enum": ["none", "local", "project", "external"] },
+        "tool_need": { "type": "string", "enum": ["none", "read_only", "write", "execute"] }
+      }
+    },
+    "user_intent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["priority"],
+      "properties": {
+        "priority": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/intent" },
+          "description": "User-expressed operational intent, ordered. Resolved against the contract's intent_resolution priority; cost_saving never overrides the quality floor."
+        },
+        "confirmation_style": {
+          "type": "string",
+          "enum": ["ask_before_write", "ask_on_risk", "autonomous_with_summary"]
+        }
+      }
+    },
+    "initial_effort": { "$ref": "#/$defs/effort_level" },
+    "final_effort": { "$ref": "#/$defs/effort_level" },
+    "escalation_count": { "type": "integer", "minimum": 0 },
+    "escalation_reasons": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/escalation_signal" },
+      "description": "Observable triggers that justified raising effort. Must be defined escalation signals; a record cannot cite an undefined signal."
+    },
+    "deescalation_count": { "type": "integer", "minimum": 0 },
+    "deescalation_reasons": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/deescalation_signal" }
+    },
+    "stop_reason": {
+      "type": "string",
+      "enum": [
+        "sufficient_quality_reached",
+        "budget_exhausted",
+        "human_decision_required",
+        "risk_exceeds_authority",
+        "next_action_is_not_reversible"
+      ]
+    },
+    "human_checkpoint_triggered": { "type": "boolean" },
+    "quality_floor_maintained": { "type": "boolean" },
+    "context_expansion_level": { "type": "string", "enum": ["none", "targeted", "broad"] },
+    "tool_iterations": { "type": "integer", "minimum": 0 },
+    "timestamp": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "$comment": "Escalation honesty: a zero escalation_count must carry no escalation reasons, and any escalation must record at least one reason. Effort never moves silently.",
+      "if": {
+        "properties": { "escalation_count": { "const": 0 } },
+        "required": ["escalation_count"]
+      },
+      "then": {
+        "properties": { "escalation_reasons": { "maxItems": 0 } }
+      },
+      "else": {
+        "properties": { "escalation_reasons": { "minItems": 1 } }
+      }
+    },
+    {
+      "$comment": "De-escalation honesty: same accounting rule for de-escalation.",
+      "if": {
+        "properties": { "deescalation_count": { "const": 0 } },
+        "required": ["deescalation_count"]
+      },
+      "then": {
+        "properties": { "deescalation_reasons": { "maxItems": 0 } }
+      },
+      "else": {
+        "properties": { "deescalation_reasons": { "minItems": 1 } }
+      }
+    },
+    {
+      "$comment": "Quality floor is never silently breached: if it was not maintained, the slice must have stopped for human authority or an exhausted budget, or raised a human checkpoint. cost_saving alone can never breach it.",
+      "if": {
+        "properties": { "quality_floor_maintained": { "const": false } },
+        "required": ["quality_floor_maintained"]
+      },
+      "then": {
+        "anyOf": [
+          { "properties": { "human_checkpoint_triggered": { "const": true } }, "required": ["human_checkpoint_triggered"] },
+          { "properties": { "stop_reason": { "enum": ["human_decision_required", "risk_exceeds_authority", "budget_exhausted"] } }, "required": ["stop_reason"] }
+        ]
+      }
+    },
+    {
+      "$comment": "Checkpoint coherence: a triggered human checkpoint must stop for an authority/irreversibility reason, not for ordinary sufficiency.",
+      "if": {
+        "properties": { "human_checkpoint_triggered": { "const": true } },
+        "required": ["human_checkpoint_triggered"]
+      },
+      "then": {
+        "properties": {
+          "stop_reason": { "enum": ["human_decision_required", "risk_exceeds_authority", "next_action_is_not_reversible"] }
+        },
+        "required": ["stop_reason"]
+      }
+    }
+  ]
+}

--- a/tests/contracts/test-runtime-effort-governance.test.ts
+++ b/tests/contracts/test-runtime-effort-governance.test.ts
@@ -66,6 +66,27 @@ describe("Runtime Effort Governance Record", () => {
     expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
   });
 
+  it("rejects a count higher than the number of recorded reasons (exact match)", () => {
+    const data = loadFixture();
+    data.escalation_count = 2;
+    data.escalation_reasons = ["multi_file_dependency_detected"];
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a count lower than the number of recorded reasons (exact match)", () => {
+    const data = loadFixture();
+    data.escalation_count = 1;
+    data.escalation_reasons = ["multi_file_dependency_detected", "low_confidence"];
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a record where escalation_count equals the reason total", () => {
+    const data = loadFixture();
+    data.escalation_count = 2;
+    data.escalation_reasons = ["multi_file_dependency_detected", "low_confidence"];
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
   it("rejects a breached quality floor that stops for ordinary sufficiency (never silent)", () => {
     const data = loadFixture();
     data.quality_floor_maintained = false;

--- a/tests/contracts/test-runtime-effort-governance.test.ts
+++ b/tests/contracts/test-runtime-effort-governance.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { validateAgainstSchema, SchemaValidationError } from "../../engine";
+
+const schemasDir = path.resolve(process.cwd(), "schemas");
+const schemaPath = path.join(schemasDir, "runtime-effort-governance-contract.schema.json");
+const fixturePath = path.resolve(
+  process.cwd(),
+  "examples/resource-aware-operations/fixtures/standard-slice.json",
+);
+
+function loadFixture(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(fixturePath, "utf-8")) as Record<string, unknown>;
+}
+
+describe("Runtime Effort Governance Record", () => {
+  it("validates a realistic Standard -> High-Assurance record against the schema", () => {
+    const data = loadFixture();
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("accepts a minimal Lite record with no escalation and a sufficiency stop", () => {
+    const data = loadFixture();
+    data.task_type = "edit";
+    data.classification = {
+      reversibility: "high",
+      blast_radius: "local",
+      uncertainty: "low",
+      risk_of_error: "low",
+      context_need: "none",
+      tool_need: "none",
+    };
+    data.initial_effort = "lite";
+    data.final_effort = "lite";
+    data.escalation_count = 0;
+    data.escalation_reasons = [];
+    data.stop_reason = "sufficient_quality_reached";
+    data.human_checkpoint_triggered = false;
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects an escalation reason outside the defined signal catalog", () => {
+    const data = loadFixture();
+    data.escalation_reasons = ["systemic_blast_radius_detected"];
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a task_type outside the contract vocabulary", () => {
+    const data = loadFixture();
+    data.task_type = "deploy";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a zero escalation_count that still lists reasons (escalation honesty)", () => {
+    const data = loadFixture();
+    data.escalation_count = 0;
+    // escalation_reasons still carries one entry
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects an escalation with a non-zero count but no recorded reason", () => {
+    const data = loadFixture();
+    data.escalation_count = 1;
+    data.escalation_reasons = [];
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a breached quality floor that stops for ordinary sufficiency (never silent)", () => {
+    const data = loadFixture();
+    data.quality_floor_maintained = false;
+    data.human_checkpoint_triggered = false;
+    data.stop_reason = "sufficient_quality_reached";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a breached quality floor when the slice stops for human authority", () => {
+    const data = loadFixture();
+    data.quality_floor_maintained = false;
+    data.human_checkpoint_triggered = true;
+    data.stop_reason = "human_decision_required";
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a triggered human checkpoint that stops for sufficiency (checkpoint coherence)", () => {
+    const data = loadFixture();
+    data.human_checkpoint_triggered = true;
+    data.stop_reason = "sufficient_quality_reached";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects an intent outside the canonical intent set", () => {
+    const data = loadFixture();
+    (data.user_intent as Record<string, unknown>).priority = ["accuracy"];
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a record missing quality_floor_maintained", () => {
+    const data = loadFixture();
+    delete data.quality_floor_maintained;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+});


### PR DESCRIPTION
Follow-up to #177 (Runtime Effort Governance Contract, docs-first). Now that the contract semantics stabilized in review, this PR formalizes the structure and records the decision.

## What

- **`schemas/runtime-effort-governance-contract.schema.json`** — validates the per-work-slice **record** an agent emits (classification, intent, effort decision, escalation/de-escalation reasons, stop reason, telemetry). It validates the record, not the prose contract. Guardrails enforced structurally:
  - signal names constrained to the defined catalog (a record can't cite an undefined signal)
  - escalation/de-escalation counts must match recorded reasons (no silent moves)
  - a breached quality floor must coincide with a human checkpoint or an authority/budget stop
  - a triggered human checkpoint must stop for an authority or irreversibility reason
- **`examples/resource-aware-operations/fixtures/standard-slice.json`** — conforming fixture (the contract's own telemetry example)
- **`tests/contracts/test-runtime-effort-governance.test.ts`** — 11 vitest cases exercising each guardrail (mirrors the Feature Value schema test)
- **`docs/adr/ADR-010-runtime-effort-governance-contract.md`** — decision record (mirrors ADR-008/009)
- Links the schema from the contract, registers ADR-010, updates the 1.2 roadmap

## Verification

- `tests/contracts/` — **44 passed** (11 new)
- `scripts/check-governance.sh` — passes
- Schema is valid JSON; ADR-010's 15 relative links resolve

## Posture (unchanged)

Docs-first, advisory-first, provider-agnostic. No model selection, no auto-routing, token saving stays subordinate to the quality floor. Adds schema/test/docs only; modifies no existing contract.

## Deferred

Phase 5 (runtime validation on real tasks) and adapter-mapping examples remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)