### PR TITLE
docs(governance): Agent Harness Governance Extension (AHGE)

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -29,6 +29,7 @@ If you need conceptual background, see [`concepts/`](../concepts/README.md). If 
 | [sensitivity-vocabulary-mapping.md](sensitivity-vocabulary-mapping.md) | Canonical sensitivity taxonomy and how project extensions map local labels to it |
 | [skill-evolution-validation-contract.md](skill-evolution-validation-contract.md) | What a skill evolution experiment and its validation evidence must satisfy to be governed |
 | [runtime-effort-governance-contract.md](runtime-effort-governance-contract.md) | How an agent decides runtime effort for a work slice: start, escalate, de-escalate, stop, and human checkpoint |
+| [agent-harness-governance-extension.md](agent-harness-governance-extension.md) | How the harness validates, authorizes, executes, budgets, and returns structured observations for model-proposed actions |
 
 ### Operationalized by security checklists
 

--- a/docs/contracts/agent-harness-governance-extension.md
+++ b/docs/contracts/agent-harness-governance-extension.md
@@ -1,0 +1,409 @@
+# Agent Harness Governance Extension
+
+## Purpose
+
+This contract defines how an AletheIA-compatible harness validates, authorizes, executes, records, and returns observations for actions proposed by a model.
+
+The Runtime Effort Governance Contract governs *how much effort* an agent spends on a work slice. This extension governs *how the runtime harness controls execution* once effort is decided: tool exposure, argument validation, permission decisions, runtime budgets, planning mode, the draft/commit split, structured observations, context and cache architecture, and audit traces.
+
+The goal is a provider-agnostic control plane around the model. Good effort decisions are not enough: an agent can decide well and still operate badly if the harness does not control tools, permissions, budgets, retries, and side effects.
+
+## Scope
+
+This contract applies to any AletheIA-compatible runtime, project overlay, or harness that executes model-proposed tool calls.
+
+It is posture `docs_first` and `advisory_first`. It describes required behavior; it does not implement a runtime, a permission engine, or any tool. It can be honored by any model, coding agent, chat assistant, or runtime adapter without binding to a specific provider.
+
+It complements, and does not replace, the [Runtime Effort Governance Contract](runtime-effort-governance-contract.md) and the [Runtime Adapter Contract](runtime-adapter-contract.md).
+
+## Non-goals
+
+This contract does not:
+
+- replace the Runtime Effort Governance Contract;
+- implement a runtime or a permission engine in code;
+- create real tools or schemas in this phase;
+- choose or name a provider;
+- promise automatic model or tool routing;
+- treat the prompt as a sufficient security control;
+- allow the model to approve its own actions;
+- claim the model executes side effects directly.
+
+## Core rule
+
+The model proposes actions. The harness validates arguments, authorizes against policy, executes or denies or pauses for approval, records traces, and returns structured observations.
+
+```yaml
+core_rule: "The model proposes actions; the harness validates, authorizes, executes, records, and returns structured observations."
+```
+
+## Principles
+
+- The model does not execute; it proposes.
+- The harness validates, authorizes, executes, denies, or asks for approval.
+- Side effects require a policy external to the model.
+- Draft and commit are different actions.
+- Planning mode blocks mutation.
+- Budgets are hard limits.
+- Context must be sufficient, not maximal.
+- Cost savings come from context architecture, not blind quality reduction.
+
+## Harness boundary
+
+```yaml
+harness_boundary:
+  model_may:
+    - "interpret_user_task"
+    - "ask_clarifying_questions"
+    - "draft_plan"
+    - "request_tool_call"
+    - "summarize_observations"
+    - "produce_final_answer_from_observations"
+  harness_must:
+    - "build_context"
+    - "expose_scoped_tools"
+    - "validate_tool_arguments"
+    - "evaluate_permission_policy"
+    - "enforce_budgets"
+    - "execute_or_deny_tool_calls"
+    - "pause_for_human_approval"
+    - "sandbox_when_required"
+    - "record_traces"
+    - "return_structured_observations"
+```
+
+## Canonical loop
+
+```txt
+user/task
+  ↓
+instruction + context builder
+  ↓
+model call
+  ↓
+tool/action proposal
+  ↓
+schema validation
+  ↓
+permission decision
+  ↓
+execution | denial | approval pause | sandbox
+  ↓
+structured observation
+  ↓
+context update / compaction
+  ↓
+repeat within budget or finish
+```
+
+## Loop invariants
+
+```yaml
+loop_invariants:
+  - "Every tool call receives exactly one result."
+  - "Tool arguments are parsed and validated before execution."
+  - "A permission decision precedes every side effect."
+  - "Tool results are bounded, structured, and traceable."
+  - "The loop has hard step, time, token, cost, and tool-call budgets."
+  - "The final answer is based on observations, not assumed tool success."
+  - "Errors, denials, cancellations, and timeouts become structured observations."
+```
+
+## Tool registry contract
+
+Each tool exposed to the model must declare a contract. The harness rejects calls whose arguments do not match the input schema and bounds every result.
+
+```yaml
+tool_contract:
+  name: "string"
+  purpose: "when to use and when not to use"
+  input_schema: "strict_json_schema"
+  output_schema: "structured_result_schema"
+  risk_class:
+    - "read_only"
+    - "search_only"
+    - "compute_only"
+    - "draft_only"
+    - "write_local"
+    - "write_internal"
+    - "write_external"
+    - "communication"
+    - "financial"
+    - "identity_access"
+    - "security_sensitive"
+    - "process_execution"
+    - "network_open_world"
+    - "destructive"
+    - "privileged_admin"
+  side_effect_class:
+    - "none"
+    - "local_artifact"
+    - "internal_state_change"
+    - "external_commitment"
+    - "financial_transfer"
+    - "identity_or_access_change"
+    - "destructive_change"
+    - "process_or_network_execution"
+  resource_scope: "user | session | project | organization | external"
+  permission_policy: "allow | deny | approval_required | stronger_auth | sandbox | draft_only"
+  timeout_seconds: 30
+  result_size_limit_chars: 8000
+  retry_policy: "safe_retry | no_auto_retry | idempotent_only"
+  audit_policy: "none | metadata_only | full_structured_event"
+  error_format: "structured_observation"
+```
+
+The full risk taxonomy and default policies live in [tool-permission-matrix.md](../reference/tool-permission-matrix.md).
+
+## Permission decision object
+
+The harness evaluates permission outside the model and records the decision.
+
+```yaml
+permission_decision:
+  tool_name: "send_email"
+  risk_class: "communication"
+  side_effect_class: "external_commitment"
+  resource_scope: "external"
+  decision: "approval_required"
+  policy_rule: "external_communication_requires_approval"
+  reason: "Sending an email creates an external side effect."
+  approver: null
+  timestamp: "ISO-8601"
+```
+
+Decision values: `allow`, `deny`, `ask_user`, `approval_required`, `require_stronger_auth`, `run_in_sandbox`, `run_as_draft_only`.
+
+## Draft vs commit policy
+
+Preparation and execution are separate actions. A draft can run automatically when scoped; the commit that creates a side effect requires approval unless an explicit allowlist applies.
+
+```yaml
+draft_commit_policy:
+  - draft_tool: "draft_email"
+    commit_tool: "send_email"
+    commit_policy: "approval_required"
+  - draft_tool: "prepare_refund"
+    commit_tool: "issue_refund"
+    commit_policy: "approval_plus_strong_auth"
+  - draft_tool: "propose_record_update"
+    commit_tool: "apply_record_update"
+    commit_policy: "approval_or_allowlist"
+  - draft_tool: "stage_workflow_change"
+    commit_tool: "commit_workflow_change"
+    commit_policy: "approval_required"
+```
+
+## Planning mode
+
+Planning mode lets the model read, search, ask, compare, and plan. It blocks every mutation.
+
+```yaml
+planning_mode:
+  allowed:
+    - "read"
+    - "search"
+    - "ask_clarifying_question"
+    - "compare_approaches"
+    - "draft_plan"
+    - "estimate_risk"
+    - "define_validation_steps"
+  blocked:
+    - "write"
+    - "send"
+    - "delete"
+    - "payment"
+    - "permission_change"
+    - "deployment"
+    - "external_commitment"
+    - "irreversible_side_effect"
+```
+
+Execution after planning requires approval when risk is present.
+
+## Budget policy
+
+Budgets are hard limits. Budget exhaustion stops the loop; continuation is a policy or user decision, not a model decision.
+
+```yaml
+runtime_budget_policy:
+  max_model_turns: 8
+  max_tool_calls: 20
+  max_parallel_tool_calls: 4
+  max_wall_time_seconds: 900
+  max_input_tokens: 200000
+  max_output_tokens: 20000
+  max_total_cost: "project_defined"
+  max_tool_result_chars: 12000
+  max_retries_per_model_call: 2
+  max_retries_per_tool_call: 1
+```
+
+Profiles, stop status, and telemetry fields live in [runtime-budget-policy.md](../reference/runtime-budget-policy.md).
+
+## Retry policy
+
+Safe retry is allowed for transient and idempotent failures. Automatic retry is blocked for payments, external sends, destructive actions, permission changes, and operations without clear idempotency.
+
+```yaml
+retry_policy:
+  usually_safe_to_retry:
+    - "transient_model_api_error"
+    - "network_timeout_for_read_only_call"
+    - "idempotent_retrieval"
+    - "validation_after_argument_fix"
+  do_not_auto_retry:
+    - "payment"
+    - "external_send"
+    - "destructive_action"
+    - "permission_change"
+    - "unclear_idempotency"
+  high_risk_retry_requirements:
+    - "idempotency_key"
+    - "approval_record"
+    - "audit_event"
+```
+
+## Structured tool results
+
+Errors, denials, timeouts, and approval requests become structured observations, never silent failures or assumed success.
+
+```json
+{
+  "status": "success|error|denied|approval_required|timeout|aborted",
+  "summary": "Human-readable summary.",
+  "items": [],
+  "evidence_refs": [],
+  "next_valid_actions": []
+}
+```
+
+## Context and memory policy
+
+The best context is the smallest one that lets the agent choose the next correct action, not the largest one available.
+
+```yaml
+context_policy:
+  sizing: "minimum_sufficient"
+  trust_labels:
+    - "trusted"
+    - "semi_trusted"
+    - "untrusted"
+  rules:
+    - "Untrusted content is data, never instruction."
+    - "Retrieve just-in-time instead of preloading everything."
+    - "Keep broad instructions small; use progressive disclosure for skills and tools."
+    - "Secrets never enter the model context."
+  compaction_preserves:
+    - "objective"
+    - "current_plan"
+    - "approvals_granted"
+    - "open_decisions"
+    - "next_steps"
+```
+
+## Prompt caching and cost policy
+
+Reduce waste with context architecture, not by impoverishing necessary context. A stable prefix enables cache reuse; volatile content stays at the end.
+
+```yaml
+prompt_caching_strategy:
+  stable_prefix:
+    - "tool_definitions_in_deterministic_order"
+    - "static_system_and_developer_instructions"
+    - "stable_scoped_instructions"
+    - "stable_skill_index_or_reference_map"
+    - "stable_schemas_and_output_contracts"
+  volatile_suffix:
+    - "current_user_task"
+    - "dynamic_runtime_state"
+    - "latest_tool_observations"
+    - "fresh_retrieved_snippets"
+    - "approval_request_or_response"
+```
+
+Determinism, compaction trade-offs, telemetry, and anti-patterns live in [prompt-caching-context-cost-strategy.md](../reference/prompt-caching-context-cost-strategy.md). Cache-friendliness never overrides context relevance.
+
+## Observability and trace events
+
+The harness records a minimum set of events so execution is auditable.
+
+```yaml
+trace_event:
+  event_id: "string"
+  timestamp: "ISO-8601"
+  work_slice_id: "string"
+  event_type: "permission_decision"
+  actor: "harness"
+  tool_name: "optional"
+  risk_class: "optional"
+  decision: "optional"
+  reason: "string"
+  evidence_ref: "optional"
+
+minimum_events:
+  - "model_call_started"
+  - "model_call_completed"
+  - "tool_requested"
+  - "permission_decision"
+  - "tool_executed"
+  - "tool_denied"
+  - "approval_requested"
+  - "approval_received"
+  - "budget_exceeded"
+  - "compaction_started"
+  - "compaction_completed"
+  - "final_answer_produced"
+```
+
+## Relationship with REGC
+
+REGC decides effort; this extension translates effort into permissions, budgets, tool visibility, and execution limits.
+
+```yaml
+relationship:
+  REGC:
+    governs:
+      - "effort"
+      - "escalation"
+      - "deescalation"
+      - "quality_floor"
+      - "stop_conditions"
+  AHGE:
+    governs:
+      - "tool_visibility"
+      - "permission_decision"
+      - "runtime_budgets"
+      - "planning_mode"
+      - "draft_commit_split"
+      - "context_cache_architecture"
+      - "structured_observations"
+
+regc_to_harness_mapping:
+  lite:
+    context_expansion: "none_or_targeted"
+    tool_visibility: "minimal"
+    permission_policy: "allow_low_risk_only"
+    telemetry: "minimal"
+  standard:
+    context_expansion: "targeted"
+    tool_visibility: "scoped"
+    permission_policy: "risk_based"
+    telemetry: "standard"
+  high_assurance:
+    context_expansion: "targeted_or_broad_with_justification"
+    tool_visibility: "least_privilege"
+    permission_policy: "approval_gated_for_side_effects"
+    planning_mode: "required"
+    telemetry: "complete"
+```
+
+## Versioning
+
+```yaml
+versioning:
+  current: "0.1"
+  compatibility: "backward_compatible_within_minor"
+  breaking_changes: "require_major_version_bump"
+  deprecation_policy: "deprecated fields remain documented for at least one minor version"
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,8 @@ Reading map organized by intent. Each entry links to the most useful starting po
 4. [Work slice spec bundle](contracts/work-slice-spec-bundle.md)
 5. [Slice telemetry model](contracts/slice-telemetry-model.md)
 6. [Runtime effort governance contract](contracts/runtime-effort-governance-contract.md) — how an agent decides effort: start, escalate, de-escalate, stop, checkpoint
-7. [All contracts →](contracts/README.md)
+7. [Agent harness governance extension](contracts/agent-harness-governance-extension.md) — how the harness authorizes, budgets, and bounds execution of model-proposed actions
+8. [All contracts →](contracts/README.md)
 
 ---
 
@@ -96,5 +97,8 @@ Reading map organized by intent. Each entry links to the most useful starting po
 2. [Waste heuristics](reference/waste-heuristics.md)
 3. [Effort escalation signals](reference/effort-escalation-signals.md)
 4. [Planning depth profiles](reference/planning-depth-profiles.md)
-4. [Launch kit](reference/launch-kit.md) — public-facing descriptions and taglines
-5. [All reference →](reference/README.md)
+5. [Tool permission matrix](reference/tool-permission-matrix.md) — risk taxonomy and permission decisions for model-requested tools
+6. [Runtime budget policy](reference/runtime-budget-policy.md) — hard runtime limits and budget profiles
+7. [Prompt caching and context cost strategy](reference/prompt-caching-context-cost-strategy.md) — cache-aware context architecture
+8. [Launch kit](reference/launch-kit.md) — public-facing descriptions and taglines
+9. [All reference →](reference/README.md)

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -12,6 +12,9 @@ Consultable material: catalogs, checklists, policies, examples, adapter guides, 
 | [token-policy.md](token-policy.md) | Token discipline rules |
 | [waste-heuristics.md](waste-heuristics.md) | Heuristics for identifying operational waste |
 | [effort-escalation-signals.md](effort-escalation-signals.md) | Signals to escalate, de-escalate, or stop effort, and their priority order |
+| [tool-permission-matrix.md](tool-permission-matrix.md) | Risk taxonomy, permission decisions, and draft/commit split for model-requested tools |
+| [runtime-budget-policy.md](runtime-budget-policy.md) | Hard limits for turns, tool calls, time, tokens, cost, and retries, with budget profiles |
+| [prompt-caching-context-cost-strategy.md](prompt-caching-context-cost-strategy.md) | Stable/volatile context architecture for cache reuse without losing relevance |
 | [planning-depth-profiles.md](planning-depth-profiles.md) | Lite / Standard / High-Assurance planning depth |
 | [launch-kit.md](launch-kit.md) | Public-facing descriptions, taglines, one-pager |
 | [learnings.md](learnings.md) | Durable lessons from AI-assisted work |

--- a/docs/reference/prompt-caching-context-cost-strategy.md
+++ b/docs/reference/prompt-caching-context-cost-strategy.md
@@ -1,0 +1,112 @@
+# Prompt Caching and Context Cost Strategy
+
+## Purpose
+
+Reduce cost and latency without reducing quality. The rule is: reduce waste through context architecture, not by impoverishing necessary context.
+
+This reference details the stable/volatile split, deterministic serialization, the compaction trade-off, telemetry, and anti-patterns referenced by the [Agent Harness Governance Extension](../contracts/agent-harness-governance-extension.md).
+
+## Stable prefix and volatile suffix
+
+```yaml
+prompt_caching_strategy:
+  stable_prefix:
+    - "tool_definitions_in_deterministic_order"
+    - "static_system_and_developer_instructions"
+    - "stable_scoped_instructions"
+    - "stable_skill_index_or_reference_map"
+    - "stable_schemas_and_output_contracts"
+    - "stable_reusable_context_when_relevant"
+  volatile_suffix:
+    - "current_user_task"
+    - "dynamic_runtime_state"
+    - "latest_tool_observations"
+    - "fresh_retrieved_snippets"
+    - "approval_request_or_response"
+    - "timestamps_request_ids_session_ids_when_needed"
+```
+
+## Ordering rule
+
+Bad:
+
+```txt
+timestamp + request_id + fresh search result + system instructions + tools + task
+```
+
+Better:
+
+```txt
+stable tools + stable instructions + stable schemas + stable reference map + dynamic state + current task
+```
+
+## Deterministic serialization
+
+```yaml
+deterministic_serialization:
+  required:
+    - "stable_tool_order"
+    - "stable_json_key_order"
+    - "stable_schema_formatting"
+    - "stable_instruction_block_order"
+    - "stable_skill_listing_order"
+    - "versioned_prompt_bundles"
+    - "versioned_tool_bundles"
+```
+
+## Context relevance still wins
+
+Cache-friendly does not mean loading everything. Rules:
+
+- include stable content only when relevant;
+- use progressive disclosure for skills and tools;
+- retrieve just-in-time;
+- keep broad instructions small;
+- keep volatile snippets near the end.
+
+## Compaction trade-off
+
+Compaction can reduce context but can also break cache reuse. Use it at explicit boundaries: approaching the context window, large outputs, the planning→execution transition, a pause for approval, resuming long work, or a workflow milestone.
+
+Avoid rewriting the summary constantly, reordering tools or schemas, changing stable instructions mid-run, or placing timestamps in the stable prefix.
+
+## Cache telemetry
+
+```yaml
+cache_telemetry:
+  fields:
+    - "request_id"
+    - "session_id"
+    - "provider"
+    - "model"
+    - "prompt_bundle_version"
+    - "tool_bundle_version"
+    - "system_prompt_hash"
+    - "tools_hash"
+    - "input_tokens_new"
+    - "cache_read_tokens"
+    - "cache_write_tokens"
+    - "cached_tokens"
+    - "output_tokens"
+    - "time_to_first_token_ms"
+    - "total_latency_ms"
+    - "estimated_cost"
+```
+
+## Cache-killing anti-patterns
+
+Avoid:
+
+- a timestamp at the start of the system prompt;
+- a request ID in the stable prefix;
+- random tool order;
+- random JSON key order;
+- volatile retrieval before stable instructions;
+- secrets in the prefix;
+- rewriting history every turn;
+- changing schemas without versioning;
+- loading all tools and skills up front.
+
+## Relationship to AletheIA
+
+This strategy complements the Runtime Effort Governance Contract, the Knowledge Governance Layer, the Runtime Adapter Contract, and Resource-Aware Operations.

--- a/docs/reference/runtime-budget-policy.md
+++ b/docs/reference/runtime-budget-policy.md
@@ -1,0 +1,138 @@
+# Runtime Budget Policy
+
+## Purpose
+
+Budgets define hard limits for turns, tool calls, time, tokens, cost, retries, and result size.
+
+This reference details the budget profiles, stop status, retry policy, parallelization rules, and telemetry referenced by the [Agent Harness Governance Extension](../contracts/agent-harness-governance-extension.md).
+
+## Core policy
+
+```yaml
+runtime_budget_policy:
+  version: "0.1"
+  default_limits:
+    max_model_turns: 8
+    max_tool_calls: 20
+    max_parallel_tool_calls: 4
+    max_wall_time_seconds: 900
+    max_input_tokens: 200000
+    max_output_tokens: 20000
+    max_total_cost: "project_defined"
+    max_tool_result_chars: 12000
+    max_retries_per_model_call: 2
+    max_retries_per_tool_call: 1
+  enforcement:
+    budget_limits_are_hard: true
+    budget_exceeded_requires_stop: true
+    continuation_requires_user_or_policy_approval: true
+```
+
+## Budget profiles
+
+```yaml
+budget_profiles:
+  lite:
+    max_model_turns: 2
+    max_tool_calls: 3
+    max_parallel_tool_calls: 2
+    max_wall_time_seconds: 120
+    max_context_expansion: "none_or_targeted"
+    max_retries_per_tool_call: 0
+  standard:
+    max_model_turns: 6
+    max_tool_calls: 12
+    max_parallel_tool_calls: 4
+    max_wall_time_seconds: 600
+    max_context_expansion: "targeted"
+    max_retries_per_tool_call: 1
+  high_assurance:
+    max_model_turns: 10
+    max_tool_calls: 30
+    max_parallel_tool_calls: 4
+    max_wall_time_seconds: 1800
+    max_context_expansion: "targeted_or_broad_with_justification"
+    max_retries_per_tool_call: 1
+```
+
+## Stop status
+
+```json
+{
+  "status": "stopped",
+  "reason": "budget_exceeded",
+  "completed": false,
+  "budget_exceeded": "max_tool_calls",
+  "next_safe_action": "Ask the user whether to continue with a larger budget."
+}
+```
+
+## Retry policy
+
+```yaml
+retry_policy:
+  usually_safe_to_retry:
+    - "transient_model_api_error"
+    - "network_timeout_for_read_only_call"
+    - "idempotent_retrieval"
+    - "validation_after_argument_fix"
+  do_not_auto_retry:
+    - "payment"
+    - "external_send"
+    - "destructive_action"
+    - "permission_change"
+    - "unclear_idempotency"
+  high_risk_retry_requirements:
+    - "idempotency_key"
+    - "approval_record"
+    - "audit_event"
+```
+
+## Parallelization policy
+
+```yaml
+parallelization:
+  safe_candidates:
+    - "search"
+    - "read"
+    - "retrieve_metadata"
+    - "classify_independent_records"
+    - "summarize_independent_documents"
+  serialize:
+    - "writes"
+    - "sends"
+    - "deletes"
+    - "financial_actions"
+    - "permission_changes"
+    - "shell_or_process_execution"
+    - "multi_step_external_workflow_commits"
+```
+
+## Budget telemetry
+
+```yaml
+budget_telemetry:
+  fields:
+    - "session_id"
+    - "work_slice_id"
+    - "budget_profile"
+    - "model_turns_used"
+    - "tool_calls_used"
+    - "parallel_tool_calls_peak"
+    - "wall_time_seconds"
+    - "input_tokens_used"
+    - "output_tokens_used"
+    - "estimated_cost"
+    - "tool_result_chars_peak"
+    - "retries_used"
+    - "stop_reason"
+    - "budget_exceeded"
+```
+
+## Non-negotiables
+
+- Budgets are explicit before long loops.
+- Budget exhaustion stops the loop.
+- The agent does not continue silently beyond budget.
+- High-risk retry requires idempotency and approval records.
+- More budget is a policy decision, not a model decision.

--- a/docs/reference/tool-permission-matrix.md
+++ b/docs/reference/tool-permission-matrix.md
@@ -1,0 +1,138 @@
+# Tool Permission Matrix
+
+## Purpose
+
+The model can request tools. The harness decides whether each request is allowed, denied, sandboxed, converted to draft-only, or paused for approval.
+
+This reference details the tool contract, the risk taxonomy, the permission decision object, and the draft/commit split referenced by the [Agent Harness Governance Extension](../contracts/agent-harness-governance-extension.md).
+
+## Tool contract
+
+```yaml
+tool:
+  name: "string"
+  purpose: "when to use and when not to use"
+  input_schema: "strict_json_schema"
+  output_schema: "structured_result_schema"
+  risk_class: "read_only"
+  side_effect_class: "none"
+  resource_scope: "user | session | project | organization | external"
+  permission_policy: "allow | deny | approval_required | stronger_auth | sandbox | draft_only"
+  timeout_seconds: 30
+  result_size_limit_chars: 8000
+  retry_policy: "safe_retry | no_auto_retry | idempotent_only"
+  audit_policy: "metadata_only"
+  error_format: "structured_observation"
+```
+
+## Risk taxonomy
+
+```yaml
+risk_classes:
+  read_only:
+    default_policy: "allow_when_scoped"
+  search_only:
+    default_policy: "allow_or_policy_restricted"
+  compute_only:
+    default_policy: "allow_in_bounded_environment"
+  draft_only:
+    default_policy: "allow_when_scoped"
+  write_local:
+    default_policy: "allow_when_scoped_or_ask_on_risk"
+  write_internal:
+    default_policy: "approval_or_allowlist"
+  write_external:
+    default_policy: "approval_required"
+  communication:
+    default_policy: "draft_first_approval_to_send"
+  financial:
+    default_policy: "approval_plus_strong_auth"
+  identity_access:
+    default_policy: "approval_plus_strong_auth"
+  security_sensitive:
+    default_policy: "approval_or_deny_by_default"
+  process_execution:
+    default_policy: "sandbox_plus_allowlist_plus_timeout"
+  network_open_world:
+    default_policy: "sandbox_or_policy_restricted"
+  destructive:
+    default_policy: "deny_by_default_or_approval_with_recovery_plan"
+  privileged_admin:
+    default_policy: "approval_plus_strong_auth"
+```
+
+## Permission decision object
+
+```yaml
+permission_decision:
+  tool_name: "send_email"
+  risk_class: "communication"
+  side_effect_class: "external_commitment"
+  resource_scope: "external"
+  decision: "approval_required"
+  policy_rule: "external_communication_requires_approval"
+  reason: "Sending an email creates an external side effect."
+  approver: null
+  timestamp: "ISO-8601"
+```
+
+## Decision values
+
+- `allow`: execute within scope.
+- `deny`: do not execute; return a structured denial.
+- `ask_user`: ask for clarification before deciding.
+- `approval_required`: pause for scoped approval.
+- `require_stronger_auth`: require stronger authentication.
+- `run_in_sandbox`: execute only in a restricted environment.
+- `run_as_draft_only`: prepare an artifact without committing a side effect.
+
+## Draft vs commit
+
+```yaml
+draft_commit_examples:
+  - draft_tool: "draft_email"
+    commit_tool: "send_email"
+    commit_policy: "approval_required"
+  - draft_tool: "prepare_refund"
+    commit_tool: "issue_refund"
+    commit_policy: "approval_plus_strong_auth"
+  - draft_tool: "propose_record_update"
+    commit_tool: "apply_record_update"
+    commit_policy: "approval_or_allowlist"
+  - draft_tool: "stage_workflow_change"
+    commit_tool: "commit_workflow_change"
+    commit_policy: "approval_required"
+```
+
+## Structured tool result
+
+### Success
+
+```json
+{
+  "status": "success",
+  "summary": "Draft created.",
+  "items": [{"id": "draft_123", "title": "Customer response draft", "evidence_ref": "artifact://drafts/draft_123"}],
+  "next_valid_actions": ["review_draft", "request_send_approval"]
+}
+```
+
+### Error
+
+```json
+{
+  "status": "error",
+  "type": "permission_denied",
+  "message": "Sending external email requires approval.",
+  "next_valid_actions": ["draft_email", "request_approval"]
+}
+```
+
+## Non-negotiables
+
+- The model does not approve its own actions.
+- Side effects require permission evaluation outside the model.
+- Broad tools are avoided or encapsulated.
+- Unknown arguments are rejected.
+- Tool results are bounded.
+- Secrets never enter the model context.

--- a/docs/roadmaps/resource-aware-operations-roadmap.md
+++ b/docs/roadmaps/resource-aware-operations-roadmap.md
@@ -337,3 +337,13 @@ The semantics are now formalized by an optional schema for the per-slice record,
 - `examples/resource-aware-operations/fixtures/standard-slice.json`
 - `tests/contracts/test-runtime-effort-governance.test.ts`
 - `docs/adr/ADR-010-runtime-effort-governance-contract.md`
+
+Complementing the effort layer, an Agent Harness Governance Extension now governs how the harness authorizes and bounds execution once effort is decided — tool permissions, runtime budgets, planning mode, the draft/commit split, structured observations, and cache-aware context:
+
+- `docs/contracts/agent-harness-governance-extension.md`
+- `docs/reference/tool-permission-matrix.md`
+- `docs/reference/runtime-budget-policy.md`
+- `docs/reference/prompt-caching-context-cost-strategy.md`
+- `examples/resource-aware-operations/harness-governance-example.md`
+
+This extension stays docs-first, advisory-first, and provider-agnostic. The model proposes; the harness validates, authorizes, executes, and records. It does not implement a runtime or permission engine, and a record schema, guardrail tests, and an ADR are deferred to a later phase.

--- a/examples/resource-aware-operations/README.md
+++ b/examples/resource-aware-operations/README.md
@@ -16,6 +16,7 @@ The first examples stay docs-first and intentionally small.
 - `slice-finalization-reference.md`
 - `clean-restart-command-adapter-example.md`
 - `runtime-effort-contract-example.md`
+- `harness-governance-example.md`
 
 ## Related pilot support
 

--- a/examples/resource-aware-operations/harness-governance-example.md
+++ b/examples/resource-aware-operations/harness-governance-example.md
@@ -1,0 +1,261 @@
+# Agent Harness Governance — Operational Examples
+
+Concrete examples that exercise the
+[Agent Harness Governance Extension](../../docs/contracts/agent-harness-governance-extension.md).
+They show how an AletheIA-compatible harness validates, authorizes, executes, budgets,
+and returns structured observations for model-proposed actions — without naming any
+specific model or provider.
+
+In every scenario the model **proposes**; the harness **decides and executes**.
+
+## 1. Read-only task — allowed
+
+### Scenario
+
+A user asks: "Find the current owner of service `billing-api`."
+
+### Classification
+
+```yaml
+tool_requested: "search_service_registry"
+risk_class: "read_only"
+side_effect_class: "none"
+resource_scope: "project"
+```
+
+### Harness decision
+
+```yaml
+permission_decision:
+  tool_name: "search_service_registry"
+  decision: "allow"
+  policy_rule: "read_only_allow_when_scoped"
+  reason: "Read-only, no side effect, within project scope."
+```
+
+### Structured observation
+
+```json
+{
+  "status": "success",
+  "summary": "Owner found.",
+  "items": [{"id": "svc_billing_api", "owner": "team-payments", "evidence_ref": "registry://services/billing-api"}],
+  "next_valid_actions": ["produce_final_answer"]
+}
+```
+
+## 2. Draft-only task — allowed
+
+### Scenario
+
+A user asks: "Prepare a reply to the customer's refund question."
+
+### Classification
+
+```yaml
+tool_requested: "draft_email"
+risk_class: "draft_only"
+side_effect_class: "local_artifact"
+resource_scope: "session"
+```
+
+### Harness decision
+
+```yaml
+permission_decision:
+  tool_name: "draft_email"
+  decision: "run_as_draft_only"
+  policy_rule: "draft_only_allow_when_scoped"
+  reason: "Preparing an artifact creates no external commitment."
+```
+
+### Structured observation
+
+```json
+{
+  "status": "success",
+  "summary": "Draft created.",
+  "items": [{"id": "draft_123", "title": "Customer response draft", "evidence_ref": "artifact://drafts/draft_123"}],
+  "next_valid_actions": ["review_draft", "request_send_approval"]
+}
+```
+
+## 3. Commit — approval-gated
+
+### Scenario
+
+After the draft is reviewed, the model proposes sending it.
+
+### Classification
+
+```yaml
+tool_requested: "send_email"
+risk_class: "communication"
+side_effect_class: "external_commitment"
+resource_scope: "external"
+```
+
+### Harness decision
+
+```yaml
+permission_decision:
+  tool_name: "send_email"
+  decision: "approval_required"
+  policy_rule: "external_communication_requires_approval"
+  reason: "Sending an email creates an external side effect."
+  approver: null
+```
+
+### Structured observation
+
+```json
+{
+  "status": "approval_required",
+  "summary": "Sending the email requires human approval.",
+  "items": [{"id": "draft_123", "evidence_ref": "artifact://drafts/draft_123"}],
+  "next_valid_actions": ["request_approval", "edit_draft"]
+}
+```
+
+The model does not approve its own send. The harness pauses for a human approver.
+
+## 4. Planning mode — blocks mutation
+
+### Scenario
+
+In planning mode, the model proposes deleting a stale database record while drafting a cleanup plan.
+
+### Classification
+
+```yaml
+mode: "planning"
+tool_requested: "delete_record"
+risk_class: "destructive"
+side_effect_class: "destructive_change"
+```
+
+### Harness decision
+
+```yaml
+permission_decision:
+  tool_name: "delete_record"
+  decision: "deny"
+  policy_rule: "planning_mode_blocks_mutation"
+  reason: "Planning mode allows read, search, ask, compare, and plan; it blocks delete and other mutations."
+```
+
+### Structured observation
+
+```json
+{
+  "status": "denied",
+  "summary": "Deletion is blocked in planning mode.",
+  "items": [],
+  "next_valid_actions": ["draft_plan", "estimate_risk", "request_execution_mode_with_approval"]
+}
+```
+
+## 5. Budget exceeded
+
+### Scenario
+
+A long retrieval loop reaches the standard profile tool-call limit before finishing.
+
+### Classification
+
+```yaml
+budget_profile: "standard"
+max_tool_calls: 12
+tool_calls_used: 12
+```
+
+### Harness decision
+
+```yaml
+enforcement:
+  budget_limits_are_hard: true
+  budget_exceeded_requires_stop: true
+  continuation_requires_user_or_policy_approval: true
+```
+
+### Stop status
+
+```json
+{
+  "status": "stopped",
+  "reason": "budget_exceeded",
+  "completed": false,
+  "budget_exceeded": "max_tool_calls",
+  "next_safe_action": "Ask the user whether to continue with a larger budget."
+}
+```
+
+The agent does not continue silently. More budget is a policy decision.
+
+## 6. Structured success result
+
+### Scenario
+
+A compute-only tool classifies an independent batch of records.
+
+### Structured observation
+
+```json
+{
+  "status": "success",
+  "summary": "Classified 20 records.",
+  "items": [{"id": "batch_001", "classified": 20, "evidence_ref": "artifact://batches/batch_001"}],
+  "evidence_refs": ["artifact://batches/batch_001"],
+  "next_valid_actions": ["summarize_results", "produce_final_answer"]
+}
+```
+
+## 7. Structured error result
+
+### Scenario
+
+A write-external tool is requested without the required approval.
+
+### Structured observation
+
+```json
+{
+  "status": "error",
+  "type": "permission_denied",
+  "message": "Sending external email requires approval.",
+  "next_valid_actions": ["draft_email", "request_approval"]
+}
+```
+
+The error is a structured observation, not a silent failure or an assumed success.
+
+## 8. Prompt-cache-aware context assembly
+
+### Scenario
+
+The harness assembles the request to maximize cache reuse without sacrificing relevance.
+
+### Assembly order
+
+```yaml
+stable_prefix:
+  - "tool_definitions_in_deterministic_order"
+  - "static_system_and_developer_instructions"
+  - "stable_scoped_instructions"
+  - "stable_skill_index_or_reference_map"
+  - "stable_schemas_and_output_contracts"
+volatile_suffix:
+  - "current_user_task"
+  - "dynamic_runtime_state"
+  - "latest_tool_observations"
+  - "fresh_retrieved_snippets"
+```
+
+### Anti-pattern avoided
+
+```txt
+Bad:    timestamp + request_id + fresh search result + system instructions + tools + task
+Better: stable tools + stable instructions + stable schemas + reference map + dynamic state + current task
+```
+
+Cache-friendliness never overrides context relevance: stable content is included only when relevant, and snippets are retrieved just-in-time.


### PR DESCRIPTION
## Summary

Adds a docs-first, provider-agnostic **Agent Harness Governance Extension (AHGE)** that complements the Runtime Effort Governance Contract (REGC). REGC governs *how much effort* an agent spends; AHGE governs *how the harness validates, authorizes, executes, budgets, and records* model-proposed actions.

Core posture: **the model proposes; the harness authorizes and bounds execution.**

## Deliverables

- `docs/contracts/agent-harness-governance-extension.md` — main contract (boundary, canonical loop, loop invariants, tool registry, permission decisions, draft/commit, planning mode, budgets, retries, structured results, context/memory, prompt caching, observability, REGC relationship, versioning)
- `docs/reference/tool-permission-matrix.md` — risk taxonomy, permission decisions, draft/commit split
- `docs/reference/runtime-budget-policy.md` — hard limits + lite/standard/high-assurance profiles
- `docs/reference/prompt-caching-context-cost-strategy.md` — stable/volatile context architecture
- `examples/resource-aware-operations/harness-governance-example.md` — 8 scenarios (read-only allow, draft-only allow, approval-gated commit, planning blocks mutation, budget exceeded, structured success, structured error, cache-aware assembly)

Wired into `docs/contracts/README`, `docs/reference/README`, `docs/index`, examples README, and the resource-aware-operations roadmap (mirrors the REGC PR #177 pattern).

## Scope guards

- Docs-first / advisory-first / provider-agnostic — no provider names in normative text.
- No runtime, permission engine, schemas, tests, or ADR this phase (deferred).
- Complements, does not replace, REGC. No auto-routing claims.

## Verification

- `pnpm run check:governance` ✅ passes
- All 5 deliverables present; intra-repo relative links resolve
- Provider-name grep across all new files → 0 matches
- No placeholder tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)