### PR TITLE
fix(governance): land AHGE record schema + ADR-011 on main

### DIFF
--- a/docs/adr/ADR-011-agent-harness-governance-extension.md
+++ b/docs/adr/ADR-011-agent-harness-governance-extension.md
@@ -1,0 +1,127 @@
+# ADR 011 — Agent Harness Governance Extension
+
+| Field | Value |
+|---|---|
+| Status | Accepted |
+| Date | 2026-06-04 |
+| Author | Neviton Santana |
+| Deciders | Neviton Santana |
+| Related | ADR-010 (Runtime Effort Governance Contract), ADR-004 (AletheIA as operating overlay), ADR-006 (Domain agnosticism) |
+| Supersedes | — |
+
+## 1. Context
+
+The [Runtime Effort Governance Contract](../contracts/runtime-effort-governance-contract.md)
+(REGC, ADR-010) governs **how much effort** an agent spends on a work slice: when to start
+small, escalate, de-escalate, and stop. But effort decisions alone do not control execution.
+An agent can decide effort well and still operate badly if the harness does not control which
+tools are exposed, whether a tool call is permitted, how side effects are authorized, what the
+runtime budgets are, and how observations are returned. Without this layer AletheIA had strong
+decision contracts but little clarity over **real execution**.
+
+The gap is the boundary between the model and the harness. The model proposes actions; it must
+not be the thing that authorizes its own side effects, treats the prompt as a security control,
+or silently exceeds a budget. That control belongs to a harness/runtime layer that is
+provider-agnostic and advisory-first.
+
+The extension shipped first as docs-first in the prior PR: the
+[contract](../contracts/agent-harness-governance-extension.md), the
+[tool permission matrix](../reference/tool-permission-matrix.md), the
+[runtime budget policy](../reference/runtime-budget-policy.md), the
+[prompt caching and context cost strategy](../reference/prompt-caching-context-cost-strategy.md),
+and an [operational example](../../examples/resource-aware-operations/harness-governance-example.md).
+This ADR records the decision and the follow-on choice to formalize the per-action harness
+record as an optional schema once the semantics had stabilized.
+
+## 2. Decision
+
+1. **Add a harness control-plane contract, not a runtime.** Ship the Agent Harness Governance
+   Extension (AHGE) as a docs-first, advisory-first, provider-agnostic contract that governs
+   execution *after* REGC has decided effort. It implements no runtime, no permission engine,
+   and no real tools. It replaces neither REGC nor the runtime adapter contract.
+2. **The model proposes; the harness authorizes.** The core rule is structural: the model may
+   interpret, plan, and request tool calls, but the harness validates arguments, evaluates
+   permissions, executes or denies or pauses for approval, enforces budgets, and returns
+   structured observations. The model never authorizes its own actions.
+3. **Permission lives outside the model.** Every tool carries a risk class, side-effect class,
+   and permission policy. The prompt is never a sufficient security control. External
+   communication is draft-first; financial, identity/access, destructive, and privileged-admin
+   actions require human authority.
+4. **Planning mode blocks mutation.** Planning allows read, search, ask, compare, and plan; it
+   blocks write, send, delete, payment, permission change, deployment, and any irreversible
+   side effect.
+5. **Budgets are hard limits.** Turns, tool calls, time, tokens, cost, retries, and result size
+   are bounded. Budget exhaustion stops the loop; continuation is a policy or user decision, not
+   a model decision.
+6. **Formalize the per-action record as an optional schema (this ADR's added decision).** Once
+   the semantics stabilized, ship
+   [`agent-harness-governance-record.schema.json`](../../schemas/agent-harness-governance-record.schema.json)
+   validating the **record a harness emits per model-proposed action** — not the prose contract.
+   The schema enforces the invariants structurally: the model never appears as the deciding
+   authority; planning mode never commits a mutation; a side effect is never committed without
+   an authorizing decision; denied or pending decisions never commit; high-risk commitments
+   require a human authority; and a budget stop must name the exhausted budget. A vitest suite
+   exercises each guardrail.
+
+## 3. Consequences
+
+**Positive**
+- Execution becomes auditable: every permission decision, denial, approval pause, and budget
+  stop carries a recorded, defined reason, and a non-conforming record fails validation in CI.
+- The schema makes the "model never self-approves" and "no commit without authorization"
+  obligations executable, mirroring ADR-009 and ADR-010.
+- The layer stays vendor-neutral and additive — no existing contract changes; runtimes opt in
+  through their adapter and map their decision into the record shape.
+
+**Negative / accepted tradeoffs**
+- The schema validates the *record* a harness produces, not the prose contract or a live
+  runtime; the harness must map its decision into the record shape. Accepted — same posture as
+  REGC's per-slice record.
+- Some invariants remain semantic (e.g. "broad tools should be encapsulated", "secrets never
+  enter the context", cache-relevance rules) and cannot be expressed structurally; they live in
+  the contract prose, the permission matrix, and the caching strategy.
+- A real permission engine, runtime, and adapter-mapping examples are deliberately out of scope
+  here; the layer ships docs + an optional record schema and tunes against evidence later.
+
+## 4. Alternatives considered
+
+- **A real permission/runtime engine.** Rejected: out of scope and against the advisory-first
+  posture; AHGE defines behavior, it does not execute it. Docs + an optional record schema are
+  proportional.
+- **Fold AHGE into REGC.** Rejected: REGC governs effort; AHGE governs execution authorization
+  and budgets. Conflating them would blur a boundary worth keeping distinct.
+- **Ship the schema in the first PR.** Rejected: the package deferred it on purpose — stabilize
+  the harness-record semantics in review before validating structure.
+- **Validate the prose contract object instead of the per-action record.** Rejected: the record
+  is the artifact a harness actually emits and the one worth enforcing in CI.
+- **No ADR (docs only).** Rejected: this draws a durable boundary (execution governance vs.
+  effort governance vs. runtime adapters) that will be cited across PRs — repo convention writes
+  one.
+
+## 5. Relationship
+
+- Complements ADR-010: REGC decides effort; AHGE translates effort into tool visibility,
+  permissions, budgets, planning mode, the draft/commit split, and structured observations
+  (see the `regc_to_harness_mapping` in the contract).
+- Contract, references, and example:
+  [`agent-harness-governance-extension.md`](../contracts/agent-harness-governance-extension.md),
+  [`tool-permission-matrix.md`](../reference/tool-permission-matrix.md),
+  [`runtime-budget-policy.md`](../reference/runtime-budget-policy.md),
+  [`prompt-caching-context-cost-strategy.md`](../reference/prompt-caching-context-cost-strategy.md),
+  [`harness-governance-example.md`](../../examples/resource-aware-operations/harness-governance-example.md).
+- Schema + fixture + test:
+  [`schemas/agent-harness-governance-record.schema.json`](../../schemas/agent-harness-governance-record.schema.json),
+  `examples/resource-aware-operations/fixtures/harness-action.json`,
+  `tests/contracts/test-agent-harness-governance.test.ts`.
+- Adds schema/test/docs only; modifies no existing contract.
+
+## 6. Review
+
+Revisit this ADR when any of the following becomes true:
+
+- A real runtime or adapter mapping needs record fields the schema does not model.
+- The risk taxonomy, decision set, or budget fields change as the contract is validated on real
+  tasks.
+- A third resource-aware governance surface appears and reveals shared structure worth
+  extracting alongside the REGC record.
+- The per-action record proves too heavy or too thin for real harness telemetry consumers.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -72,3 +72,4 @@ Do *not* write one for:
 | [ADR-008](ADR-008-knowledge-governance-layer.md) | Knowledge Governance Layer | Accepted |
 | [ADR-009](ADR-009-feature-value-governance-pack.md) | Feature Value Governance Pack | Accepted |
 | [ADR-010](ADR-010-runtime-effort-governance-contract.md) | Runtime Effort Governance Contract | Accepted |
+| [ADR-011](ADR-011-agent-harness-governance-extension.md) | Agent Harness Governance Extension | Accepted |

--- a/docs/contracts/agent-harness-governance-extension.md
+++ b/docs/contracts/agent-harness-governance-extension.md
@@ -398,6 +398,21 @@ regc_to_harness_mapping:
     telemetry: "complete"
 ```
 
+## Schema
+
+The prose above is the contract. The per-action **record** a harness emits — its mode, the
+requested tool's risk and side-effect class, the permission decision and who made it, whether a
+side effect was committed, the observation status, and the budget snapshot — is formalized as an
+optional JSON Schema:
+[`agent-harness-governance-record.schema.json`](../../schemas/agent-harness-governance-record.schema.json).
+
+The schema validates the record, not the prose. It enforces the AHGE invariants structurally:
+the model never appears as the deciding authority, planning mode never commits a mutation, a side
+effect is never committed without an authorizing decision, denied or pending decisions never
+commit, high-risk commitments require a human authority, and a budget stop must name the
+exhausted budget. See `examples/resource-aware-operations/fixtures/harness-action.json` for a
+conforming record.
+
 ## Versioning
 
 ```yaml

--- a/docs/roadmaps/resource-aware-operations-roadmap.md
+++ b/docs/roadmaps/resource-aware-operations-roadmap.md
@@ -346,4 +346,11 @@ Complementing the effort layer, an Agent Harness Governance Extension now govern
 - `docs/reference/prompt-caching-context-cost-strategy.md`
 - `examples/resource-aware-operations/harness-governance-example.md`
 
-This extension stays docs-first, advisory-first, and provider-agnostic. The model proposes; the harness validates, authorizes, executes, and records. It does not implement a runtime or permission engine, and a record schema, guardrail tests, and an ADR are deferred to a later phase.
+This extension stays docs-first, advisory-first, and provider-agnostic. The model proposes; the harness validates, authorizes, executes, and records. It does not implement a runtime or permission engine.
+
+The per-action harness record is now formalized by an optional schema, with a vitest guardrail suite and an Architecture Decision Record:
+
+- `schemas/agent-harness-governance-record.schema.json`
+- `examples/resource-aware-operations/fixtures/harness-action.json`
+- `tests/contracts/test-agent-harness-governance.test.ts`
+- `docs/adr/ADR-011-agent-harness-governance-extension.md`

--- a/examples/resource-aware-operations/fixtures/harness-action.json
+++ b/examples/resource-aware-operations/fixtures/harness-action.json
@@ -1,0 +1,17 @@
+{
+  "action_id": "action-2026-06-04-001",
+  "mode": "execution",
+  "tool_name": "send_email",
+  "risk_class": "communication",
+  "side_effect_class": "external_commitment",
+  "resource_scope": "external",
+  "permission_decision": "allow",
+  "decision_authority": "human",
+  "side_effect_committed": true,
+  "observation_status": "success",
+  "budget_profile": "standard",
+  "stop_reason": "completed",
+  "retries_used": 0,
+  "result_chars": 412,
+  "timestamp": "2026-06-04T00:00:00Z"
+}

--- a/schemas/agent-harness-governance-record.schema.json
+++ b/schemas/agent-harness-governance-record.schema.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia.local/schemas/agent-harness-governance-record.schema.json",
+  "title": "Agent Harness Governance Record",
+  "description": "Minimum structured record an AletheIA-compatible harness emits for a single model-proposed action under the Agent Harness Governance Extension (docs/contracts/agent-harness-governance-extension.md). It captures the operating mode, the requested tool's risk and side-effect class, the permission decision and who made it, whether a side effect was committed, the resulting observation status, and the budget snapshot. The schema does not authorize actions; it forces the harness decision to be explicit, traceable, and reconcilable with the permission matrix. It enforces the AHGE invariants structurally: the model never authorizes its own actions, planning mode never commits a mutation, a side effect is never committed without an authorizing decision, denied or pending decisions never commit, high-risk commitments require a human authority, and a budget stop must name the exhausted budget.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "action_id",
+    "mode",
+    "tool_name",
+    "risk_class",
+    "side_effect_class",
+    "resource_scope",
+    "permission_decision",
+    "decision_authority",
+    "side_effect_committed",
+    "observation_status",
+    "budget_profile",
+    "retries_used",
+    "result_chars",
+    "timestamp"
+  ],
+  "$defs": {
+    "mutating_side_effect": {
+      "type": "string",
+      "enum": [
+        "internal_state_change",
+        "external_commitment",
+        "financial_transfer",
+        "identity_or_access_change",
+        "destructive_change",
+        "process_or_network_execution"
+      ]
+    },
+    "authorizing_decision": {
+      "type": "string",
+      "enum": ["allow", "run_in_sandbox"]
+    }
+  },
+  "properties": {
+    "action_id": { "type": "string", "minLength": 1 },
+    "mode": { "type": "string", "enum": ["planning", "execution"] },
+    "tool_name": { "type": "string", "minLength": 1 },
+    "risk_class": {
+      "type": "string",
+      "enum": [
+        "read_only",
+        "search_only",
+        "compute_only",
+        "draft_only",
+        "write_local",
+        "write_internal",
+        "write_external",
+        "communication",
+        "financial",
+        "identity_access",
+        "security_sensitive",
+        "process_execution",
+        "network_open_world",
+        "destructive",
+        "privileged_admin"
+      ]
+    },
+    "side_effect_class": {
+      "type": "string",
+      "enum": [
+        "none",
+        "local_artifact",
+        "internal_state_change",
+        "external_commitment",
+        "financial_transfer",
+        "identity_or_access_change",
+        "destructive_change",
+        "process_or_network_execution"
+      ]
+    },
+    "resource_scope": {
+      "type": "string",
+      "enum": ["user", "session", "project", "organization", "external"]
+    },
+    "permission_decision": {
+      "type": "string",
+      "enum": [
+        "allow",
+        "deny",
+        "ask_user",
+        "approval_required",
+        "require_stronger_auth",
+        "run_in_sandbox",
+        "run_as_draft_only"
+      ]
+    },
+    "decision_authority": {
+      "type": "string",
+      "enum": ["harness", "human"],
+      "description": "Who made the permission decision. The model never appears here: the model proposes, it does not authorize its own actions."
+    },
+    "side_effect_committed": { "type": "boolean" },
+    "observation_status": {
+      "type": "string",
+      "enum": ["success", "error", "denied", "approval_required", "timeout", "aborted"]
+    },
+    "budget_profile": { "type": "string", "enum": ["lite", "standard", "high_assurance"] },
+    "stop_reason": {
+      "type": "string",
+      "enum": [
+        "completed",
+        "budget_exceeded",
+        "approval_pending",
+        "denied_by_policy",
+        "error",
+        "timeout"
+      ]
+    },
+    "budget_exceeded": {
+      "type": "string",
+      "enum": [
+        "max_model_turns",
+        "max_tool_calls",
+        "max_parallel_tool_calls",
+        "max_wall_time_seconds",
+        "max_input_tokens",
+        "max_output_tokens",
+        "max_total_cost",
+        "max_tool_result_chars",
+        "max_retries_per_model_call",
+        "max_retries_per_tool_call"
+      ]
+    },
+    "retries_used": { "type": "integer", "minimum": 0 },
+    "result_chars": { "type": "integer", "minimum": 0 },
+    "timestamp": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "$comment": "Planning mode blocks mutation: in planning mode a mutating side-effect class must be denied and must not be committed.",
+      "if": {
+        "properties": {
+          "mode": { "const": "planning" },
+          "side_effect_class": { "$ref": "#/$defs/mutating_side_effect" }
+        },
+        "required": ["mode", "side_effect_class"]
+      },
+      "then": {
+        "properties": {
+          "permission_decision": { "const": "deny" },
+          "side_effect_committed": { "const": false }
+        },
+        "required": ["permission_decision", "side_effect_committed"]
+      }
+    },
+    {
+      "$comment": "No commit without authorization: a committed side effect must carry an authorizing decision (allow or run_in_sandbox). Denied, pending, draft-only, or stronger-auth requests never commit.",
+      "if": {
+        "properties": { "side_effect_committed": { "const": true } },
+        "required": ["side_effect_committed"]
+      },
+      "then": {
+        "properties": { "permission_decision": { "$ref": "#/$defs/authorizing_decision" } },
+        "required": ["permission_decision"]
+      }
+    },
+    {
+      "$comment": "Denied or pending decisions never commit a side effect.",
+      "if": {
+        "properties": {
+          "permission_decision": {
+            "enum": ["deny", "ask_user", "approval_required", "require_stronger_auth", "run_as_draft_only"]
+          }
+        },
+        "required": ["permission_decision"]
+      },
+      "then": {
+        "properties": { "side_effect_committed": { "const": false } },
+        "required": ["side_effect_committed"]
+      }
+    },
+    {
+      "$comment": "High-risk commitments require a human authority: a committed financial, identity/access, destructive, or privileged-admin action must be authorized by a human, never by the harness alone.",
+      "if": {
+        "properties": {
+          "risk_class": { "enum": ["financial", "identity_access", "destructive", "privileged_admin"] },
+          "side_effect_committed": { "const": true }
+        },
+        "required": ["risk_class", "side_effect_committed"]
+      },
+      "then": {
+        "properties": { "decision_authority": { "const": "human" } },
+        "required": ["decision_authority"]
+      }
+    },
+    {
+      "$comment": "Status coherence: a denied observation must carry a deny decision; an approval_required observation must carry an approval_required decision.",
+      "if": {
+        "properties": { "observation_status": { "const": "denied" } },
+        "required": ["observation_status"]
+      },
+      "then": {
+        "properties": { "permission_decision": { "const": "deny" } },
+        "required": ["permission_decision"]
+      }
+    },
+    {
+      "$comment": "Approval coherence: an approval_required observation must not have committed a side effect and must carry the approval_required decision.",
+      "if": {
+        "properties": { "observation_status": { "const": "approval_required" } },
+        "required": ["observation_status"]
+      },
+      "then": {
+        "properties": {
+          "permission_decision": { "const": "approval_required" },
+          "side_effect_committed": { "const": false }
+        },
+        "required": ["permission_decision", "side_effect_committed"]
+      }
+    },
+    {
+      "$comment": "Budget stop coherence: if a budget was exceeded the stop_reason must say so, and an aborted observation that stops for budget must name the exhausted budget.",
+      "if": {
+        "properties": { "budget_exceeded": { "type": "string" } },
+        "required": ["budget_exceeded"]
+      },
+      "then": {
+        "properties": { "stop_reason": { "const": "budget_exceeded" } },
+        "required": ["stop_reason"]
+      }
+    }
+  ]
+}

--- a/tests/contracts/test-agent-harness-governance.test.ts
+++ b/tests/contracts/test-agent-harness-governance.test.ts
@@ -1,0 +1,152 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { validateAgainstSchema, SchemaValidationError } from "../../engine";
+
+const schemasDir = path.resolve(process.cwd(), "schemas");
+const schemaPath = path.join(schemasDir, "agent-harness-governance-record.schema.json");
+const fixturePath = path.resolve(
+  process.cwd(),
+  "examples/resource-aware-operations/fixtures/harness-action.json",
+);
+
+function loadFixture(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(fixturePath, "utf-8")) as Record<string, unknown>;
+}
+
+describe("Agent Harness Governance Record", () => {
+  it("validates a realistic approved external-commitment record against the schema", () => {
+    const data = loadFixture();
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("accepts a read-only action allowed by the harness", () => {
+    const data = loadFixture();
+    data.tool_name = "search_service_registry";
+    data.risk_class = "read_only";
+    data.side_effect_class = "none";
+    data.resource_scope = "project";
+    data.permission_decision = "allow";
+    data.decision_authority = "harness";
+    data.side_effect_committed = false;
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a permission_decision outside the defined decision set", () => {
+    const data = loadFixture();
+    data.permission_decision = "auto_approve";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects the model authorizing its own action (decision_authority must be harness or human)", () => {
+    const data = loadFixture();
+    data.decision_authority = "model";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a mutation committed in planning mode", () => {
+    const data = loadFixture();
+    data.mode = "planning";
+    data.side_effect_class = "destructive_change";
+    data.risk_class = "destructive";
+    // planning must deny + not commit; this record still commits
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a planning-mode mutation that is denied and not committed", () => {
+    const data = loadFixture();
+    data.mode = "planning";
+    data.tool_name = "delete_record";
+    data.risk_class = "destructive";
+    data.side_effect_class = "destructive_change";
+    data.permission_decision = "deny";
+    data.decision_authority = "harness";
+    data.side_effect_committed = false;
+    data.observation_status = "denied";
+    data.stop_reason = "denied_by_policy";
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a committed side effect without an authorizing decision", () => {
+    const data = loadFixture();
+    data.permission_decision = "approval_required";
+    // still committed = true
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a denied decision that still commits a side effect", () => {
+    const data = loadFixture();
+    data.permission_decision = "deny";
+    data.observation_status = "denied";
+    // side_effect_committed still true
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a committed financial action authorized by the harness alone (needs human)", () => {
+    const data = loadFixture();
+    data.tool_name = "issue_refund";
+    data.risk_class = "financial";
+    data.side_effect_class = "financial_transfer";
+    data.decision_authority = "harness";
+    // committed = true, allow
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a committed financial action authorized by a human", () => {
+    const data = loadFixture();
+    data.tool_name = "issue_refund";
+    data.risk_class = "financial";
+    data.side_effect_class = "financial_transfer";
+    data.decision_authority = "human";
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a denied observation that does not carry a deny decision", () => {
+    const data = loadFixture();
+    data.observation_status = "denied";
+    data.side_effect_committed = false;
+    data.permission_decision = "allow";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts an approval_required observation that pauses without committing", () => {
+    const data = loadFixture();
+    data.permission_decision = "approval_required";
+    data.decision_authority = "harness";
+    data.side_effect_committed = false;
+    data.observation_status = "approval_required";
+    data.stop_reason = "approval_pending";
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects an approval_required observation that committed a side effect", () => {
+    const data = loadFixture();
+    data.observation_status = "approval_required";
+    data.permission_decision = "approval_required";
+    // side_effect_committed still true
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a budget-exceeded abort that names the exhausted budget", () => {
+    const data = loadFixture();
+    data.observation_status = "aborted";
+    data.permission_decision = "allow";
+    data.side_effect_committed = false;
+    data.stop_reason = "budget_exceeded";
+    data.budget_exceeded = "max_tool_calls";
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a named exhausted budget without a budget_exceeded stop_reason", () => {
+    const data = loadFixture();
+    data.budget_exceeded = "max_tool_calls";
+    data.stop_reason = "completed";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a record missing decision_authority", () => {
+    const data = loadFixture();
+    delete data.decision_authority;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+});


### PR DESCRIPTION
## Why

PR **#180** (AHGE record schema + ADR-011) shows as MERGED, but its content **never reached `main`**. It was stacked on the #179 feature branch as its base, so when #179 merged into `main` first, GitHub then merged #180 *into the now-orphaned feature branch* (commit `cf56b82`) — not into `main`. The schema layer was stranded.

This PR re-lands the **identical** #180 content directly on `main`.

## Content (unchanged from #180)

- `schemas/agent-harness-governance-record.schema.json`
- `examples/resource-aware-operations/fixtures/harness-action.json`
- `tests/contracts/test-agent-harness-governance.test.ts` — 16 guardrail tests
- `docs/adr/ADR-011-agent-harness-governance-extension.md`
- Wiring: `adr/README`, contract `## Schema` section, roadmap (deferred → shipped)

## Verification (run against `main`)

- `pnpm run check:governance` ✅
- `npx vitest run tests/contracts/` → **63 passed / 0 failed**

## Cleanup after merge

Safe to delete the stale branches `feat/agent-harness-governance-extension` and `feat/ahge-record-schema` (both fully represented on `main` once this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)