### PR TITLE
docs(governance): AHGE phase-5 validation checklist

### DIFF
--- a/docs/adr/ADR-011-agent-harness-governance-extension.md
+++ b/docs/adr/ADR-011-agent-harness-governance-extension.md
@@ -117,7 +117,9 @@ record as an optional schema once the semantics had stabilized.
 
 ## 6. Review
 
-Revisit this ADR when any of the following becomes true:
+Revisit this ADR when any of the following becomes true. The
+[validation checklist](../reference/agent-harness-governance-validation-checklist.md) is the
+routine that turns a real harness trace into the evidence these triggers need.
 
 - A real runtime or adapter mapping needs record fields the schema does not model.
 - The risk taxonomy, decision set, or budget fields change as the contract is validated on real

--- a/docs/contracts/agent-harness-governance-extension.md
+++ b/docs/contracts/agent-harness-governance-extension.md
@@ -413,6 +413,10 @@ commit, high-risk commitments require a human authority, and a budget stop must 
 exhausted budget. See `examples/resource-aware-operations/fixtures/harness-action.json` for a
 conforming record.
 
+To validate the contract and this schema against a **real harness trace** (the deferred phase-5
+step), follow
+[agent-harness-governance-validation-checklist.md](../reference/agent-harness-governance-validation-checklist.md).
+
 ## Versioning
 
 ```yaml

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -15,6 +15,7 @@ Consultable material: catalogs, checklists, policies, examples, adapter guides, 
 | [tool-permission-matrix.md](tool-permission-matrix.md) | Risk taxonomy, permission decisions, and draft/commit split for model-requested tools |
 | [runtime-budget-policy.md](runtime-budget-policy.md) | Hard limits for turns, tool calls, time, tokens, cost, and retries, with budget profiles |
 | [prompt-caching-context-cost-strategy.md](prompt-caching-context-cost-strategy.md) | Stable/volatile context architecture for cache reuse without losing relevance |
+| [agent-harness-governance-validation-checklist.md](agent-harness-governance-validation-checklist.md) | Deferred phase-5 routine to validate the harness contract and record schema against a real trace |
 | [planning-depth-profiles.md](planning-depth-profiles.md) | Lite / Standard / High-Assurance planning depth |
 | [launch-kit.md](launch-kit.md) | Public-facing descriptions, taglines, one-pager |
 | [learnings.md](learnings.md) | Durable lessons from AI-assisted work |

--- a/docs/reference/agent-harness-governance-validation-checklist.md
+++ b/docs/reference/agent-harness-governance-validation-checklist.md
@@ -1,0 +1,108 @@
+# Agent Harness Governance — Validation Checklist
+
+## Goal
+
+Provide a short, repeatable routine for validating the
+[Agent Harness Governance Extension](../contracts/agent-harness-governance-extension.md)
+against a **real harness trace**, once one exists.
+
+This is the deferred phase-5 step for AHGE. The contract, references, example, and the
+[record schema](../../schemas/agent-harness-governance-record.schema.json) shipped docs-first;
+this routine is how they get tuned against evidence instead of speculation.
+
+The discipline is the same as [resource-aware-next-signals.md](../roadmaps/resource-aware-next-signals.md)
+and the skill-evolution thesis: **evidence is an input, not an authority.** A single trace does
+not justify changing the schema, the risk taxonomy, or the budget fields.
+
+---
+
+## When to run this
+
+Run the routine when a real (not synthetic) trace becomes available, such as:
+
+- a runtime or adapter that already emits per-action records;
+- a pilot harness instrumented to log tool requests, permission decisions, and outcomes;
+- an existing agent log that can be mapped, after the fact, onto the per-action record shape.
+
+Do **not** run it on the shipped fixture
+(`examples/resource-aware-operations/fixtures/harness-action.json`) — that fixture only proves
+the schema accepts a conforming record. Phase 5 is about real traces.
+
+---
+
+## Step 1 — Capture the trace
+
+For each model-proposed action in the run, capture what the harness actually did:
+
+- the operating mode (planning or execution);
+- the tool name and its risk class and side-effect class;
+- the permission decision and **who** made it (harness or human);
+- whether a side effect was committed;
+- the resulting observation status;
+- the budget profile and any budget that stopped the loop;
+- retries used and result size.
+
+Keep the trace provider-agnostic. Strip secrets and any vendor identifiers before storing it.
+
+---
+
+## Step 2 — Map to the record shape
+
+Translate each captured action into the
+[`agent-harness-governance-record`](../../schemas/agent-harness-governance-record.schema.json)
+shape. Mapping gaps are themselves findings — record any field the real trace cannot fill, and
+any real signal the schema has no field for.
+
+---
+
+## Step 3 — Validate
+
+Validate each mapped record against the schema (the repo's `validateAgainstSchema` helper, the
+same path the vitest suite uses). For every failure, classify it:
+
+- **Real violation** — the harness actually breached an invariant (e.g. committed a side effect
+  without an authorizing decision, let the model self-approve, mutated in planning mode, or ran
+  past a budget without a stop). This is a genuine finding about the harness.
+- **Mapping error** — the trace was translated incorrectly. Fix the mapping, not the schema.
+- **Schema gap** — the trace is legitimate but the schema is too strict or too loose. Candidate
+  for a change, but only under Step 5's discipline.
+
+---
+
+## Step 4 — Record findings
+
+Write down, per trace:
+
+- how many actions validated cleanly;
+- each real violation and which invariant it breached;
+- each mapping gap (missing field, unmodeled signal);
+- each candidate schema gap, with the concrete example that motivated it;
+- whether the budget profiles and risk taxonomy fit the real action mix.
+
+---
+
+## Step 5 — Decide changes (with restraint)
+
+A change to the schema, risk taxonomy, or budget fields is justified only when:
+
+- more than one real trace shows the same gap, or one trace shows a clear invariant defect; and
+- the change keeps the layer provider-agnostic and advisory-first; and
+- it does not turn the docs-first contract into a runtime or permission engine.
+
+If the evidence is a single anecdote, **do not change the contract.** Record the observation and
+wait for a second comparable signal — the same posture the
+[ADR-011 review section](../adr/ADR-011-agent-harness-governance-extension.md) already names as a
+trigger to revisit.
+
+---
+
+## What stays out of scope
+
+Even with real traces, these remain deferred unless evidence becomes unusually strong:
+
+- a real permission engine or runtime in this repo;
+- vendor-specific tool policies as core truth;
+- auto-routing of tools or models;
+- benchmark packaging or a learning layer.
+
+The framework stays provider-agnostic and review-oriented.


### PR DESCRIPTION
## Summary

Adds the **deferred phase-5 routine** for the Agent Harness Governance Extension: a short, repeatable checklist for validating the contract and the per-action record schema against a **real harness trace**, once one exists.

This prepares the evidence step — it does not run it. No runtime, no schema change.

## What it adds

- `docs/reference/agent-harness-governance-validation-checklist.md` (new) — 5-step routine: capture trace → map to record shape → validate → record findings → decide changes with restraint
- Wiring: `reference/README` row, contract `## Schema` section pointer, ADR-011 review-section pointer

## Discipline baked in

Mirrors `resource-aware-next-signals.md` and the skill-evolution thesis: **evidence is an input, not an authority.** A single trace never justifies changing the schema, risk taxonomy, or budget fields — a change needs more than one comparable trace (or one clear invariant defect) and must keep the layer provider-agnostic and docs-first.

## Verification

- `pnpm run check:governance` ✅
- Provider-name grep on the new doc → 0 matches
- All internal relative links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)