### PR TITLE
docs(governance): resource-aware next-signals validation checklist

### DIFF
--- a/docs/adr/ADR-012-resource-aware-signal-validation.md
+++ b/docs/adr/ADR-012-resource-aware-signal-validation.md
@@ -1,0 +1,112 @@
+# ADR 012 — Resource-Aware Signal Validation Layer
+
+| Field | Value |
+|---|---|
+| Status | Accepted |
+| Date | 2026-06-04 |
+| Author | Neviton Santana |
+| Deciders | Neviton Santana |
+| Related | ADR-010 (Runtime Effort Governance Contract), ADR-011 (Agent Harness Governance Extension), ADR-006 (Domain agnosticism) |
+| Supersedes | — |
+
+## 1. Context
+
+The AletheIA 1.2 resource-aware track closed its build phases (A–F) and then drew an explicit
+discipline doc, [resource-aware-next-signals.md](../roadmaps/resource-aware-next-signals.md), to
+answer one question: *what real evidence would justify reopening the track toward 1.3+ comparative
+evaluation?* Its core rule is restraint — "do not reopen the track because the framework feels
+incomplete" — and its thesis is that **evidence is an input, not an authority**: only cross-slice
+or cross-project repetition counts, never an anecdote.
+
+But that doc shipped as a *passive* watch-list. Its two sibling contracts in the same track each
+shipped with more: the [Runtime Effort Governance Contract](../contracts/runtime-effort-governance-contract.md)
+(REGC, ADR-010) and the [Agent Harness Governance Extension](../contracts/agent-harness-governance-extension.md)
+(AHGE, ADR-011) each have a phase-5 validation routine and an optional record schema with a vitest
+guardrail. The next-signals discipline had neither. There was no repeatable way to take accumulated
+real slice evidence and decide, traceably, whether the reopen threshold had been met — the decision
+risked being made by intuition, which is precisely the inertia the doc warns against.
+
+## 2. Decision
+
+1. **Operationalize the watch-list as a validation routine, not a trigger.** Ship a docs-first
+   [Resource-Aware Next-Signals Validation Checklist](../reference/resource-aware-next-signals-validation-checklist.md),
+   the sibling of the [AHGE validation checklist](../reference/agent-harness-governance-validation-checklist.md):
+   gather ≥2 real per-slice records, map them to the four healthy signals, apply the
+   cross-slice/cross-project threshold, record findings, and decide with restraint. The reopen
+   decision remains a **human** judgement.
+2. **Formalize the evidence-review event as an optional schema.** Ship
+   [`resource-aware-signal-evidence.schema.json`](../../schemas/resource-aware-signal-evidence.schema.json)
+   validating the **record produced by one evidence review** — not the prose discipline. It
+   aggregates the per-slice REGC records, names which of the four signals fired, and captures the
+   decision and its rationale.
+3. **Encode the anecdote rule structurally.** The schema makes the core restraint non-bypassable:
+   `slice_ids` requires at least two distinct entries, and a `recommend_reopen_1_3` decision is
+   only valid when `signal_is_cross_project` is true and `project_count` is at least two. A reopen
+   recommendation can therefore never rest on a single slice or a single project. A vitest suite
+   exercises each guardrail.
+4. **The schema constrains the decision; it never produces it.** Nothing in this layer reopens the
+   track automatically. The record forces the human decision to be explicit, traceable, and
+   reconcilable with the four-signal catalog.
+5. **Keep the deferrals intact.** Vendor ranking, auto-routing, learning-layer behavior,
+   orchestration machinery, and benchmark packaging stay deferred to 1.3/1.4, exactly as the
+   roadmap and next-signals doc already state.
+
+## 3. Consequences
+
+**Positive**
+- Reopening the 1.2 track becomes reviewable rather than inertia-driven: the threshold is now a
+  repeatable routine plus a record that fails validation if it tries to reopen on an anecdote.
+- The schema makes the "not anecdotal" and "cross-project required" obligations executable,
+  mirroring the per-slice record discipline of ADR-010 and ADR-011.
+- The track now has phase-5 parity across all three of its governance surfaces (REGC, AHGE,
+  next-signals).
+
+**Negative / accepted tradeoffs**
+- The schema validates the *record* a review produces, not the prose discipline or a live process;
+  a reviewer must map their findings into the record shape. Accepted — same posture as the REGC and
+  AHGE per-record schemas.
+- Some judgement remains semantic ("comparable review language", "important local differences")
+  and cannot be expressed structurally; it lives in the checklist prose.
+- The record is optional. A checklist-only outcome is valid, consistent with the next-signals
+  thesis that restraint, not machinery, is the point.
+
+## 4. Alternatives considered
+
+- **Leave next-signals passive (docs only).** Rejected: it left no repeatable proof path and made
+  the reopen decision vulnerable to intuition — the exact inertia the doc warns against.
+- **Build an auto-trigger or scheduler that reopens the track when signals fire.** Rejected:
+  directly violates "do not grow by inertia" and the human-decision posture; the layer defines when
+  reopening is *justified*, it does not perform it.
+- **Add benchmark or learning-layer fields now.** Rejected: explicitly deferred to 1.3/1.4 by the
+  roadmap; adding them here would prejudge the very decision this layer is meant to govern.
+- **Validate the prose discipline instead of the review record.** Rejected: the review record is
+  the artifact a reviewer actually emits and the one worth enforcing in CI.
+- **No ADR (docs only).** Rejected: this draws a durable boundary — evidence validation vs. effort
+  governance vs. execution governance — that will be cited across PRs; repo convention writes one.
+
+## 5. Relationship
+
+- Builds on ADR-010: the per-slice [REGC records](../../schemas/runtime-effort-governance-contract.schema.json)
+  are the raw material this layer aggregates into one evidence-review record.
+- Mirrors ADR-011: the [AHGE validation checklist](../reference/agent-harness-governance-validation-checklist.md)
+  is the template this routine copies, giving the 1.2 track phase-5 parity across its three surfaces.
+- Checklist, schema, fixture, and test:
+  [`resource-aware-next-signals-validation-checklist.md`](../reference/resource-aware-next-signals-validation-checklist.md),
+  [`schemas/resource-aware-signal-evidence.schema.json`](../../schemas/resource-aware-signal-evidence.schema.json),
+  `examples/resource-aware-operations/fixtures/signal-evidence-review.json`,
+  `tests/contracts/test-resource-aware-signal-evidence.test.ts`.
+- Operationalizes [resource-aware-next-signals.md](../roadmaps/resource-aware-next-signals.md);
+  adds schema/test/docs only and modifies no existing contract.
+
+## 6. Review
+
+Revisit this ADR when any of the following becomes true. The
+[validation checklist](../reference/resource-aware-next-signals-validation-checklist.md) is the
+routine that turns accumulated real slices into the evidence these triggers need.
+
+- More than one cross-project signal recurs and a reopen toward 1.3 is actually recommended.
+- The four-signal taxonomy proves too strict or too loose against real reviews (a mapping gap
+  recorded in Step 4 of the checklist, seen in more than one review).
+- The evidence-review record proves too heavy or too thin for real reviewers.
+- A fourth resource-aware governance surface appears and reveals shared structure worth extracting
+  alongside the REGC and AHGE records.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -73,3 +73,4 @@ Do *not* write one for:
 | [ADR-009](ADR-009-feature-value-governance-pack.md) | Feature Value Governance Pack | Accepted |
 | [ADR-010](ADR-010-runtime-effort-governance-contract.md) | Runtime Effort Governance Contract | Accepted |
 | [ADR-011](ADR-011-agent-harness-governance-extension.md) | Agent Harness Governance Extension | Accepted |
+| [ADR-012](ADR-012-resource-aware-signal-validation.md) | Resource-Aware Signal Validation Layer | Accepted |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -16,6 +16,7 @@ Consultable material: catalogs, checklists, policies, examples, adapter guides, 
 | [runtime-budget-policy.md](runtime-budget-policy.md) | Hard limits for turns, tool calls, time, tokens, cost, and retries, with budget profiles |
 | [prompt-caching-context-cost-strategy.md](prompt-caching-context-cost-strategy.md) | Stable/volatile context architecture for cache reuse without losing relevance |
 | [agent-harness-governance-validation-checklist.md](agent-harness-governance-validation-checklist.md) | Deferred phase-5 routine to validate the harness contract and record schema against a real trace |
+| [resource-aware-next-signals-validation-checklist.md](resource-aware-next-signals-validation-checklist.md) | Deferred phase-5 routine to validate the next-signals watch-list against accumulated real slice evidence |
 | [planning-depth-profiles.md](planning-depth-profiles.md) | Lite / Standard / High-Assurance planning depth |
 | [launch-kit.md](launch-kit.md) | Public-facing descriptions, taglines, one-pager |
 | [learnings.md](learnings.md) | Durable lessons from AI-assisted work |

--- a/docs/reference/resource-aware-next-signals-validation-checklist.md
+++ b/docs/reference/resource-aware-next-signals-validation-checklist.md
@@ -1,0 +1,140 @@
+# Resource-Aware Next-Signals — Validation Checklist
+
+## Goal
+
+Provide a short, repeatable routine for validating the
+[Resource-Aware Next Signals](../roadmaps/resource-aware-next-signals.md) discipline against
+**real, accumulated slice evidence**, once it exists.
+
+This is the deferred phase-5 step for the AletheIA 1.2 resource-aware track as a whole. It is the
+sibling of the
+[Agent Harness Governance — Validation Checklist](agent-harness-governance-validation-checklist.md):
+the next-signals roadmap shipped docs-first as a *passive* watch-list; this routine is how that
+watch-list gets exercised against evidence instead of left to intuition.
+
+The discipline is the same as the next-signals doc itself and the skill-evolution thesis:
+**evidence is an input, not an authority.** A single slice — however interesting — never justifies
+reopening the 1.2 track toward 1.3. Only cross-slice or cross-project repetition does.
+
+---
+
+## When to run this
+
+Run the routine when **multiple** real (non-synthetic) slice records have accumulated, such as:
+
+- a batch of [Runtime Effort Governance](../contracts/runtime-effort-governance-contract.md)
+  per-slice records emitted by real work;
+- review notes from more than one comparable slice across one or more projects;
+- recurring local rules that several projects independently invented for the same operational
+  pressure (restart-package tightening, review-pause timing, slice stopping criteria).
+
+Do **not** run it on a single slice, a single fixture, or one unusually hard task. The next-signals
+doc is explicit that those are *inputs, not thresholds*
+([resource-aware-next-signals.md](../roadmaps/resource-aware-next-signals.md) §"Signals that are
+not enough by themselves"). Running this routine on one record proves nothing.
+
+---
+
+## Step 1 — Gather comparable slices
+
+Collect **at least two** real per-slice records in the
+[`runtime-effort-governance-contract`](../../schemas/runtime-effort-governance-contract.schema.json)
+shape, drawn from comparable work. For each, note:
+
+- the `task_type`, `classification` (reversibility, blast radius, uncertainty, risk), and `user_intent`;
+- the effort path (`initial_effort` → `final_effort`) and the `escalation_reasons` / `stop_reason`;
+- whether a `human_checkpoint_triggered` and whether `quality_floor_maintained`;
+- the originating project, kept as a coarse label only.
+
+Strip secrets and vendor identifiers before storing anything. Keep the gathered set
+provider-agnostic.
+
+---
+
+## Step 2 — Map slices to the four healthy signals
+
+For each candidate signal from
+[resource-aware-next-signals.md](../roadmaps/resource-aware-next-signals.md) §"Healthy signals to
+watch for", tally which gathered slices exhibit it:
+
+| Healthy signal | What to look for across the slices |
+|---|---|
+| **Repeated comparable slices** | similar shape, similar resource-aware pressure, similar review outcomes |
+| **Repeated late-stage waste** | context drag, retry growth, handoff inflation, or runtime-fit mismatch discovered too late, more than once |
+| **Repeated local translations** | several projects independently inventing similar local rules for the same pressure |
+| **Stable reinforced outcomes** | multiple slices ending `reinforced` or `no-change` for the same broad pattern |
+
+A signal that appears in only one slice is **not** a hit. Record it as an input and move on.
+
+---
+
+## Step 3 — Apply the threshold rule
+
+A signal counts toward reopening the track only when it is **cross-slice or cross-project**, not
+anecdotal. Resolve each tallied signal against the rule in
+[resource-aware-next-signals.md](../roadmaps/resource-aware-next-signals.md) §"What can justify
+1.3+":
+
+- one interesting example, one hard slice, one project's preference, one vendor choice → **input, not threshold**;
+- the same pattern across more than one believable slice, with comparable review language → **a real signal**.
+
+If no signal clears this bar, the routine ends at *keep 1.2 stable*. That is the expected outcome
+most of the time, and it is a healthy result, not a failure.
+
+---
+
+## Step 4 — Record findings
+
+Write down, per gathered set:
+
+- which of the four signals fired, and in how many slices / projects;
+- whether each firing signal was cross-project or confined to one project;
+- the outcome distribution (`reinforced` / `no-change` / other) across the slices;
+- which local translations recurred, if any;
+- mapping gaps — any real signal the four-signal taxonomy has no slot for. **A mapping gap is
+  itself a finding**, the same way it is in the AHGE checklist.
+
+If the optional
+[`resource-aware-signal-evidence`](../../schemas/resource-aware-signal-evidence.schema.json) record
+is in use, capture this review as one conforming record so the decision stays explicit, traceable,
+and reconcilable with the signal catalog.
+
+---
+
+## Step 5 — Decide (with restraint)
+
+Reopening the 1.2 track toward 1.3+ comparative evaluation is justified **only** when the
+combination named in
+[resource-aware-next-signals.md](../roadmaps/resource-aware-next-signals.md) §"What can justify
+1.3+" holds:
+
+- more than one believable real-world slice; **and**
+- comparable review language across those slices; **and**
+- enough structure to compare without hiding important local differences; **and**
+- no need yet for learning-layer or auto-routing claims.
+
+In order of discipline:
+
+1. **repeated evidence first**, 2. **comparative framing second**, 3. **benchmark packaging only after that.**
+
+If the evidence is a single anecdote, **do not reopen the track.** Record the observation and wait
+for a second comparable signal — the same posture
+[ADR-012](../adr/ADR-012-resource-aware-signal-validation.md) names as the trigger to revisit. The
+reopen decision is always a **human** judgement; nothing in this routine reopens the track
+automatically.
+
+---
+
+## What stays out of scope
+
+Even with stronger signals, these stay deferred unless the evidence becomes unusually strong, per
+[resource-aware-next-signals.md](../roadmaps/resource-aware-next-signals.md) §"What should still
+stay deferred":
+
+- vendor ranking as core truth;
+- auto-routing claims;
+- learning-layer behavior;
+- orchestration-heavy policy machinery;
+- benchmark packaging before repeated evidence and comparative framing exist.
+
+The framework stays provider-agnostic and review-oriented.

--- a/docs/roadmaps/resource-aware-next-signals.md
+++ b/docs/roadmaps/resource-aware-next-signals.md
@@ -142,3 +142,6 @@ The healthy posture right now is:
 - reopen only when the signals become cross-slice or cross-project rather than anecdotal
 
 That is enough discipline for this stage.
+
+The repeatable routine that operationalizes this watch-list against accumulated slice evidence is
+[resource-aware-next-signals-validation-checklist.md](../reference/resource-aware-next-signals-validation-checklist.md).

--- a/examples/resource-aware-operations/fixtures/signal-evidence-review.json
+++ b/examples/resource-aware-operations/fixtures/signal-evidence-review.json
@@ -1,0 +1,19 @@
+{
+  "review_id": "rans-review-2026-06-04-001",
+  "slice_ids": [
+    "slice-2026-06-02-001",
+    "slice-2026-06-03-004",
+    "slice-2026-06-03-009"
+  ],
+  "project_count": 2,
+  "signal": "repeated_comparable_slices",
+  "signal_is_cross_project": true,
+  "outcome_distribution": {
+    "reinforced": 2,
+    "no_change": 1,
+    "other": 0
+  },
+  "decision": "record_and_wait",
+  "decision_rationale": "Three comparable code-change slices across two projects showed similar resource-aware pressure and reinforced outcomes, but the review language is not yet comparable enough to reopen the track. Recording the signal and waiting for a second cross-project occurrence.",
+  "timestamp": "2026-06-04T00:00:00Z"
+}

--- a/schemas/resource-aware-signal-evidence.schema.json
+++ b/schemas/resource-aware-signal-evidence.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia.local/schemas/resource-aware-signal-evidence.schema.json",
+  "title": "Resource-Aware Signal Evidence Record",
+  "description": "Optional structured record for one evidence-review event under the Resource-Aware Next-Signals validation routine (docs/reference/resource-aware-next-signals-validation-checklist.md). It aggregates the per-slice Runtime Effort Governance records (schemas/runtime-effort-governance-contract.schema.json) gathered for a review, names which of the four healthy signals fired, and captures the human decision. The schema does not decide whether to reopen the 1.2 track; it forces that decision to be explicit, traceable, and bounded by the next-signals threshold rule. A reopen recommendation can never rest on a single slice or a single project. Signal names are constrained to the four defined in resource-aware-next-signals.md so a record can never cite an undefined signal.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "review_id",
+    "slice_ids",
+    "project_count",
+    "signal",
+    "signal_is_cross_project",
+    "outcome_distribution",
+    "decision",
+    "decision_rationale",
+    "timestamp"
+  ],
+  "$defs": {
+    "healthy_signal": {
+      "type": "string",
+      "enum": [
+        "repeated_comparable_slices",
+        "repeated_late_stage_waste",
+        "repeated_local_translations",
+        "stable_reinforced_outcomes"
+      ]
+    },
+    "decision": {
+      "type": "string",
+      "enum": ["keep_1_2_stable", "record_and_wait", "recommend_reopen_1_3"]
+    }
+  },
+  "properties": {
+    "review_id": { "type": "string", "minLength": 1 },
+    "slice_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 2,
+      "uniqueItems": true,
+      "$comment": "minItems is 2 by design: the next-signals doc forbids reopening on a single slice. One slice is an input, not a threshold. A review that has only one slice cannot be recorded — gather more first.",
+      "description": "The per-slice runtime-effort-governance records aggregated for this review. At least two, because anecdote is never a threshold."
+    },
+    "project_count": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "How many distinct projects the gathered slices span. Cross-project repetition (project_count > 1) is the strongest believable signal; required for a reopen recommendation."
+    },
+    "signal": {
+      "$ref": "#/$defs/healthy_signal",
+      "description": "Which of the four healthy signals fired across the gathered slices. Must be one of the four defined in resource-aware-next-signals.md; a record cannot cite an undefined signal."
+    },
+    "signal_is_cross_project": {
+      "type": "boolean",
+      "description": "True only when the firing signal appears across more than one project, not confined to one."
+    },
+    "outcome_distribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reinforced", "no_change", "other"],
+      "properties": {
+        "reinforced": { "type": "integer", "minimum": 0 },
+        "no_change": { "type": "integer", "minimum": 0 },
+        "other": { "type": "integer", "minimum": 0 }
+      },
+      "description": "Counts of slice review outcomes across the gathered set. Stable reinforced / no-change outcomes are themselves useful evidence."
+    },
+    "decision": {
+      "$ref": "#/$defs/decision",
+      "description": "The human judgement recorded for this review. The schema constrains this value but never produces it; nothing here reopens the track automatically."
+    },
+    "decision_rationale": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Why the decision was made, in plain language, reconcilable with the threshold rule in resource-aware-next-signals.md."
+    },
+    "timestamp": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "$comment": "Reopen restraint, encoded structurally: a recommendation to reopen 1.2 toward 1.3 can never rest on a single project. It requires cross-project signal AND project_count > 1. Combined with slice_ids minItems:2, a reopen recommendation can never be anecdotal. This is the core rule of resource-aware-next-signals.md made non-bypassable.",
+      "if": {
+        "properties": { "decision": { "const": "recommend_reopen_1_3" } },
+        "required": ["decision"]
+      },
+      "then": {
+        "properties": {
+          "signal_is_cross_project": { "const": true },
+          "project_count": { "minimum": 2 }
+        },
+        "required": ["signal_is_cross_project", "project_count"]
+      }
+    },
+    {
+      "$comment": "Coherence: a signal cannot be flagged cross-project while the slices span only one project.",
+      "if": {
+        "properties": { "signal_is_cross_project": { "const": true } },
+        "required": ["signal_is_cross_project"]
+      },
+      "then": {
+        "properties": { "project_count": { "minimum": 2 } },
+        "required": ["project_count"]
+      }
+    }
+  ]
+}

--- a/tests/contracts/test-resource-aware-signal-evidence.test.ts
+++ b/tests/contracts/test-resource-aware-signal-evidence.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { validateAgainstSchema, SchemaValidationError } from "../../engine";
+
+const schemasDir = path.resolve(process.cwd(), "schemas");
+const schemaPath = path.join(schemasDir, "resource-aware-signal-evidence.schema.json");
+const fixturePath = path.resolve(
+  process.cwd(),
+  "examples/resource-aware-operations/fixtures/signal-evidence-review.json",
+);
+
+function loadFixture(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(fixturePath, "utf-8")) as Record<string, unknown>;
+}
+
+describe("Resource-Aware Signal Evidence Record", () => {
+  it("validates a realistic cross-project record-and-wait review against the schema", () => {
+    const data = loadFixture();
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a signal outside the four-signal catalog", () => {
+    const data = loadFixture();
+    data.signal = "context_drag_detected";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a single-slice review (anecdote is never a threshold)", () => {
+    const data = loadFixture();
+    data.slice_ids = ["slice-2026-06-02-001"];
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a decision outside the contract vocabulary", () => {
+    const data = loadFixture();
+    data.decision = "reopen_now";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a reopen recommendation that is not cross-project (reopen restraint)", () => {
+    const data = loadFixture();
+    data.decision = "recommend_reopen_1_3";
+    data.signal_is_cross_project = false;
+    data.project_count = 1;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a reopen recommendation resting on a single project (project_count must be >= 2)", () => {
+    const data = loadFixture();
+    data.decision = "recommend_reopen_1_3";
+    data.signal_is_cross_project = true;
+    data.project_count = 1;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a valid reopen recommendation with cross-project signal and >=2 projects", () => {
+    const data = loadFixture();
+    data.decision = "recommend_reopen_1_3";
+    data.signal_is_cross_project = true;
+    data.project_count = 2;
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a cross-project flag that spans only one project (coherence)", () => {
+    const data = loadFixture();
+    data.signal_is_cross_project = true;
+    data.project_count = 1;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a record missing decision_rationale", () => {
+    const data = loadFixture();
+    delete data.decision_rationale;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects duplicate slice_ids (each gathered slice must be distinct)", () => {
+    const data = loadFixture();
+    data.slice_ids = ["slice-2026-06-02-001", "slice-2026-06-02-001"];
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+});


### PR DESCRIPTION
## What

Operationalizes the passive `resource-aware-next-signals.md` watch-list into a repeatable, evidence-bounded **phase-5 validation routine** — the sibling of the AHGE validation checklist (#182). This is **PR-1 (docs-first)** of a two-PR stack.

## Why

Within the 1.2 resource-aware track, REGC (ADR-010) and AHGE (ADR-011) each shipped a phase-5 routine; next-signals had none, leaving the "reopen 1.2→1.3" decision vulnerable to intuition — the exact inertia the doc warns against.

## Routine

Gather ≥2 real per-slice records → map to the four healthy signals → apply the cross-slice/cross-project threshold → record findings → decide with restraint. The reopen decision stays **human**; nothing reopens the track automatically.

## Changes

- **new** `docs/reference/resource-aware-next-signals-validation-checklist.md` (8 sections)
- one reciprocal link in `docs/roadmaps/resource-aware-next-signals.md`
- one index row in `docs/reference/README.md`

Docs-first, advisory-first, provider-agnostic. Modifies no contract.

## Note

PR-2 (`feat/rans-evidence-schema`) stacks on this branch with the optional record schema + ADR-012 + vitest guardrail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)