### PR TITLE
feat(governance): resource-aware signal-evidence record + ADR-012

### DIFF
--- a/docs/adr/ADR-012-resource-aware-signal-validation.md
+++ b/docs/adr/ADR-012-resource-aware-signal-validation.md
@@ -1,0 +1,112 @@
+# ADR 012 — Resource-Aware Signal Validation Layer
+
+| Field | Value |
+|---|---|
+| Status | Accepted |
+| Date | 2026-06-04 |
+| Author | Neviton Santana |
+| Deciders | Neviton Santana |
+| Related | ADR-010 (Runtime Effort Governance Contract), ADR-011 (Agent Harness Governance Extension), ADR-006 (Domain agnosticism) |
+| Supersedes | — |
+
+## 1. Context
+
+The AletheIA 1.2 resource-aware track closed its build phases (A–F) and then drew an explicit
+discipline doc, [resource-aware-next-signals.md](../roadmaps/resource-aware-next-signals.md), to
+answer one question: *what real evidence would justify reopening the track toward 1.3+ comparative
+evaluation?* Its core rule is restraint — "do not reopen the track because the framework feels
+incomplete" — and its thesis is that **evidence is an input, not an authority**: only cross-slice
+or cross-project repetition counts, never an anecdote.
+
+But that doc shipped as a *passive* watch-list. Its two sibling contracts in the same track each
+shipped with more: the [Runtime Effort Governance Contract](../contracts/runtime-effort-governance-contract.md)
+(REGC, ADR-010) and the [Agent Harness Governance Extension](../contracts/agent-harness-governance-extension.md)
+(AHGE, ADR-011) each have a phase-5 validation routine and an optional record schema with a vitest
+guardrail. The next-signals discipline had neither. There was no repeatable way to take accumulated
+real slice evidence and decide, traceably, whether the reopen threshold had been met — the decision
+risked being made by intuition, which is precisely the inertia the doc warns against.
+
+## 2. Decision
+
+1. **Operationalize the watch-list as a validation routine, not a trigger.** Ship a docs-first
+   [Resource-Aware Next-Signals Validation Checklist](../reference/resource-aware-next-signals-validation-checklist.md),
+   the sibling of the [AHGE validation checklist](../reference/agent-harness-governance-validation-checklist.md):
+   gather ≥2 real per-slice records, map them to the four healthy signals, apply the
+   cross-slice/cross-project threshold, record findings, and decide with restraint. The reopen
+   decision remains a **human** judgement.
+2. **Formalize the evidence-review event as an optional schema.** Ship
+   [`resource-aware-signal-evidence.schema.json`](../../schemas/resource-aware-signal-evidence.schema.json)
+   validating the **record produced by one evidence review** — not the prose discipline. It
+   aggregates the per-slice REGC records, names which of the four signals fired, and captures the
+   decision and its rationale.
+3. **Encode the anecdote rule structurally.** The schema makes the core restraint non-bypassable:
+   `slice_ids` requires at least two distinct entries, and a `recommend_reopen_1_3` decision is
+   only valid when `signal_is_cross_project` is true and `project_count` is at least two. A reopen
+   recommendation can therefore never rest on a single slice or a single project. A vitest suite
+   exercises each guardrail.
+4. **The schema constrains the decision; it never produces it.** Nothing in this layer reopens the
+   track automatically. The record forces the human decision to be explicit, traceable, and
+   reconcilable with the four-signal catalog.
+5. **Keep the deferrals intact.** Vendor ranking, auto-routing, learning-layer behavior,
+   orchestration machinery, and benchmark packaging stay deferred to 1.3/1.4, exactly as the
+   roadmap and next-signals doc already state.
+
+## 3. Consequences
+
+**Positive**
+- Reopening the 1.2 track becomes reviewable rather than inertia-driven: the threshold is now a
+  repeatable routine plus a record that fails validation if it tries to reopen on an anecdote.
+- The schema makes the "not anecdotal" and "cross-project required" obligations executable,
+  mirroring the per-slice record discipline of ADR-010 and ADR-011.
+- The track now has phase-5 parity across all three of its governance surfaces (REGC, AHGE,
+  next-signals).
+
+**Negative / accepted tradeoffs**
+- The schema validates the *record* a review produces, not the prose discipline or a live process;
+  a reviewer must map their findings into the record shape. Accepted — same posture as the REGC and
+  AHGE per-record schemas.
+- Some judgement remains semantic ("comparable review language", "important local differences")
+  and cannot be expressed structurally; it lives in the checklist prose.
+- The record is optional. A checklist-only outcome is valid, consistent with the next-signals
+  thesis that restraint, not machinery, is the point.
+
+## 4. Alternatives considered
+
+- **Leave next-signals passive (docs only).** Rejected: it left no repeatable proof path and made
+  the reopen decision vulnerable to intuition — the exact inertia the doc warns against.
+- **Build an auto-trigger or scheduler that reopens the track when signals fire.** Rejected:
+  directly violates "do not grow by inertia" and the human-decision posture; the layer defines when
+  reopening is *justified*, it does not perform it.
+- **Add benchmark or learning-layer fields now.** Rejected: explicitly deferred to 1.3/1.4 by the
+  roadmap; adding them here would prejudge the very decision this layer is meant to govern.
+- **Validate the prose discipline instead of the review record.** Rejected: the review record is
+  the artifact a reviewer actually emits and the one worth enforcing in CI.
+- **No ADR (docs only).** Rejected: this draws a durable boundary — evidence validation vs. effort
+  governance vs. execution governance — that will be cited across PRs; repo convention writes one.
+
+## 5. Relationship
+
+- Builds on ADR-010: the per-slice [REGC records](../../schemas/runtime-effort-governance-contract.schema.json)
+  are the raw material this layer aggregates into one evidence-review record.
+- Mirrors ADR-011: the [AHGE validation checklist](../reference/agent-harness-governance-validation-checklist.md)
+  is the template this routine copies, giving the 1.2 track phase-5 parity across its three surfaces.
+- Checklist, schema, fixture, and test:
+  [`resource-aware-next-signals-validation-checklist.md`](../reference/resource-aware-next-signals-validation-checklist.md),
+  [`schemas/resource-aware-signal-evidence.schema.json`](../../schemas/resource-aware-signal-evidence.schema.json),
+  `examples/resource-aware-operations/fixtures/signal-evidence-review.json`,
+  `tests/contracts/test-resource-aware-signal-evidence.test.ts`.
+- Operationalizes [resource-aware-next-signals.md](../roadmaps/resource-aware-next-signals.md);
+  adds schema/test/docs only and modifies no existing contract.
+
+## 6. Review
+
+Revisit this ADR when any of the following becomes true. The
+[validation checklist](../reference/resource-aware-next-signals-validation-checklist.md) is the
+routine that turns accumulated real slices into the evidence these triggers need.
+
+- More than one cross-project signal recurs and a reopen toward 1.3 is actually recommended.
+- The four-signal taxonomy proves too strict or too loose against real reviews (a mapping gap
+  recorded in Step 4 of the checklist, seen in more than one review).
+- The evidence-review record proves too heavy or too thin for real reviewers.
+- A fourth resource-aware governance surface appears and reveals shared structure worth extracting
+  alongside the REGC and AHGE records.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -73,3 +73,4 @@ Do *not* write one for:
 | [ADR-009](ADR-009-feature-value-governance-pack.md) | Feature Value Governance Pack | Accepted |
 | [ADR-010](ADR-010-runtime-effort-governance-contract.md) | Runtime Effort Governance Contract | Accepted |
 | [ADR-011](ADR-011-agent-harness-governance-extension.md) | Agent Harness Governance Extension | Accepted |
+| [ADR-012](ADR-012-resource-aware-signal-validation.md) | Resource-Aware Signal Validation Layer | Accepted |

--- a/examples/resource-aware-operations/fixtures/signal-evidence-review.json
+++ b/examples/resource-aware-operations/fixtures/signal-evidence-review.json
@@ -1,0 +1,19 @@
+{
+  "review_id": "rans-review-2026-06-04-001",
+  "slice_ids": [
+    "slice-2026-06-02-001",
+    "slice-2026-06-03-004",
+    "slice-2026-06-03-009"
+  ],
+  "project_count": 2,
+  "signal": "repeated_comparable_slices",
+  "signal_is_cross_project": true,
+  "outcome_distribution": {
+    "reinforced": 2,
+    "no_change": 1,
+    "other": 0
+  },
+  "decision": "record_and_wait",
+  "decision_rationale": "Three comparable code-change slices across two projects showed similar resource-aware pressure and reinforced outcomes, but the review language is not yet comparable enough to reopen the track. Recording the signal and waiting for a second cross-project occurrence.",
+  "timestamp": "2026-06-04T00:00:00Z"
+}

--- a/schemas/resource-aware-signal-evidence.schema.json
+++ b/schemas/resource-aware-signal-evidence.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia.local/schemas/resource-aware-signal-evidence.schema.json",
+  "title": "Resource-Aware Signal Evidence Record",
+  "description": "Optional structured record for one evidence-review event under the Resource-Aware Next-Signals validation routine (docs/reference/resource-aware-next-signals-validation-checklist.md). It aggregates the per-slice Runtime Effort Governance records (schemas/runtime-effort-governance-contract.schema.json) gathered for a review, names which of the four healthy signals fired, and captures the human decision. The schema does not decide whether to reopen the 1.2 track; it forces that decision to be explicit, traceable, and bounded by the next-signals threshold rule. A reopen recommendation can never rest on a single slice or a single project. Signal names are constrained to the four defined in resource-aware-next-signals.md so a record can never cite an undefined signal.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "review_id",
+    "slice_ids",
+    "project_count",
+    "signal",
+    "signal_is_cross_project",
+    "outcome_distribution",
+    "decision",
+    "decision_rationale",
+    "timestamp"
+  ],
+  "$defs": {
+    "healthy_signal": {
+      "type": "string",
+      "enum": [
+        "repeated_comparable_slices",
+        "repeated_late_stage_waste",
+        "repeated_local_translations",
+        "stable_reinforced_outcomes"
+      ]
+    },
+    "decision": {
+      "type": "string",
+      "enum": ["keep_1_2_stable", "record_and_wait", "recommend_reopen_1_3"]
+    }
+  },
+  "properties": {
+    "review_id": { "type": "string", "minLength": 1 },
+    "slice_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 2,
+      "uniqueItems": true,
+      "$comment": "minItems is 2 by design: the next-signals doc forbids reopening on a single slice. One slice is an input, not a threshold. A review that has only one slice cannot be recorded — gather more first.",
+      "description": "The per-slice runtime-effort-governance records aggregated for this review. At least two, because anecdote is never a threshold."
+    },
+    "project_count": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "How many distinct projects the gathered slices span. Cross-project repetition (project_count > 1) is the strongest believable signal; required for a reopen recommendation."
+    },
+    "signal": {
+      "$ref": "#/$defs/healthy_signal",
+      "description": "Which of the four healthy signals fired across the gathered slices. Must be one of the four defined in resource-aware-next-signals.md; a record cannot cite an undefined signal."
+    },
+    "signal_is_cross_project": {
+      "type": "boolean",
+      "description": "True only when the firing signal appears across more than one project, not confined to one."
+    },
+    "outcome_distribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reinforced", "no_change", "other"],
+      "properties": {
+        "reinforced": { "type": "integer", "minimum": 0 },
+        "no_change": { "type": "integer", "minimum": 0 },
+        "other": { "type": "integer", "minimum": 0 }
+      },
+      "description": "Counts of slice review outcomes across the gathered set. Stable reinforced / no-change outcomes are themselves useful evidence."
+    },
+    "decision": {
+      "$ref": "#/$defs/decision",
+      "description": "The human judgement recorded for this review. The schema constrains this value but never produces it; nothing here reopens the track automatically."
+    },
+    "decision_rationale": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Why the decision was made, in plain language, reconcilable with the threshold rule in resource-aware-next-signals.md."
+    },
+    "timestamp": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "$comment": "Reopen restraint, encoded structurally: a recommendation to reopen 1.2 toward 1.3 can never rest on a single project. It requires cross-project signal AND project_count > 1. Combined with slice_ids minItems:2, a reopen recommendation can never be anecdotal. This is the core rule of resource-aware-next-signals.md made non-bypassable.",
+      "if": {
+        "properties": { "decision": { "const": "recommend_reopen_1_3" } },
+        "required": ["decision"]
+      },
+      "then": {
+        "properties": {
+          "signal_is_cross_project": { "const": true },
+          "project_count": { "minimum": 2 }
+        },
+        "required": ["signal_is_cross_project", "project_count"]
+      }
+    },
+    {
+      "$comment": "Coherence: a signal cannot be flagged cross-project while the slices span only one project.",
+      "if": {
+        "properties": { "signal_is_cross_project": { "const": true } },
+        "required": ["signal_is_cross_project"]
+      },
+      "then": {
+        "properties": { "project_count": { "minimum": 2 } },
+        "required": ["project_count"]
+      }
+    }
+  ]
+}

--- a/tests/contracts/test-resource-aware-signal-evidence.test.ts
+++ b/tests/contracts/test-resource-aware-signal-evidence.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { validateAgainstSchema, SchemaValidationError } from "../../engine";
+
+const schemasDir = path.resolve(process.cwd(), "schemas");
+const schemaPath = path.join(schemasDir, "resource-aware-signal-evidence.schema.json");
+const fixturePath = path.resolve(
+  process.cwd(),
+  "examples/resource-aware-operations/fixtures/signal-evidence-review.json",
+);
+
+function loadFixture(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(fixturePath, "utf-8")) as Record<string, unknown>;
+}
+
+describe("Resource-Aware Signal Evidence Record", () => {
+  it("validates a realistic cross-project record-and-wait review against the schema", () => {
+    const data = loadFixture();
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a signal outside the four-signal catalog", () => {
+    const data = loadFixture();
+    data.signal = "context_drag_detected";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a single-slice review (anecdote is never a threshold)", () => {
+    const data = loadFixture();
+    data.slice_ids = ["slice-2026-06-02-001"];
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a decision outside the contract vocabulary", () => {
+    const data = loadFixture();
+    data.decision = "reopen_now";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a reopen recommendation that is not cross-project (reopen restraint)", () => {
+    const data = loadFixture();
+    data.decision = "recommend_reopen_1_3";
+    data.signal_is_cross_project = false;
+    data.project_count = 1;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a reopen recommendation resting on a single project (project_count must be >= 2)", () => {
+    const data = loadFixture();
+    data.decision = "recommend_reopen_1_3";
+    data.signal_is_cross_project = true;
+    data.project_count = 1;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a valid reopen recommendation with cross-project signal and >=2 projects", () => {
+    const data = loadFixture();
+    data.decision = "recommend_reopen_1_3";
+    data.signal_is_cross_project = true;
+    data.project_count = 2;
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a cross-project flag that spans only one project (coherence)", () => {
+    const data = loadFixture();
+    data.signal_is_cross_project = true;
+    data.project_count = 1;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a record missing decision_rationale", () => {
+    const data = loadFixture();
+    delete data.decision_rationale;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects duplicate slice_ids (each gathered slice must be distinct)", () => {
+    const data = loadFixture();
+    data.slice_ids = ["slice-2026-06-02-001", "slice-2026-06-02-001"];
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+});


### PR DESCRIPTION
## What

Formalizes the next-signals evidence-review event as an **optional record schema**, giving the 1.2 track phase-5 parity across all three governance surfaces (REGC, AHGE, next-signals). This is **PR-2** of the stack — **based on `feat/rans-validation-checklist` (#183)**, not `main`. Review/merge #183 first.

## The anecdote rule, encoded structurally (non-bypassable)

- `slice_ids` requires **≥2 distinct** entries
- a `recommend_reopen_1_3` decision validates **only** when `signal_is_cross_project: true` **and** `project_count ≥ 2`

A reopen recommendation can therefore never rest on a single slice or a single project. The schema **constrains** the decision; it never **produces** it.

## Changes

- **new** `schemas/resource-aware-signal-evidence.schema.json` (4-signal enum, `allOf` reopen invariants)
- **new** `examples/resource-aware-operations/fixtures/signal-evidence-review.json`
- **new** `tests/contracts/test-resource-aware-signal-evidence.test.ts` (10 cases)
- **new** `docs/adr/ADR-012-resource-aware-signal-validation.md` (6 sections, reopen triggers in §6)
- one index row in `docs/adr/README.md`

## Verification

- `pnpm test` → **139 passed** (10 new)
- `pnpm run check:governance` → baseline passed
- anti-pattern grep (auto-routing / vendor-rank / benchmark / learning-layer): hits only in out-of-scope/Rejected context

Docs-first, advisory-first, provider-agnostic. Adds schema/test/docs only; modifies no existing contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)