### PR TITLE
docs(governance): Agent Harness Contract (AHC) + ADR-013

### DIFF
--- a/docs/adr/ADR-013-agent-harness-contract.md
+++ b/docs/adr/ADR-013-agent-harness-contract.md
@@ -1,0 +1,121 @@
+# ADR 013 — Agent Harness Contract (per-task declaration)
+
+| Field | Value |
+|---|---|
+| Status | Accepted |
+| Date | 2026-06-05 |
+| Author | Neviton Santana |
+| Deciders | Neviton Santana |
+| Related | ADR-010 (Runtime Effort Governance Contract), ADR-011 (Agent Harness Governance Extension), ADR-008 (Knowledge Governance Layer) |
+| Supersedes | — |
+
+## 1. Context
+
+The repository already governs three distinct questions about agent work:
+
+- **REGC** (ADR-010) governs *how much effort* a slice deserves — when to start small, escalate,
+  de-escalate, and stop, under a quality floor.
+- **AHGE** (ADR-011) governs *execution per action* — tool permission decisions, the draft/commit
+  split, planning mode, runtime budgets, and the structured per-action record.
+- **Knowledge Governance** (ADR-008) governs *which context is authorized* — sources, authority,
+  sensitivity, precedence, restrictions.
+
+The Agent Harness Improvement Pack (an external docs-first proposal) raised a question none of
+these answer directly: **before a task starts, what is the declared envelope the agent operates
+within?** Its proposed "Agent Harness Contract" declares the autonomy level, allowed tools and
+skills, blocked actions, required gates, expected sensors, rollback strategy, human-review
+requirement, and the context policy — *up front*, as a per-task declaration.
+
+This is upstream of AHGE. AHGE records what actually happened per action; it does not declare, in
+advance, the envelope those actions must stay within. The pack also explicitly cautions (PRD §15)
+against creating a new "Harness Governance Layer" — the term *layer* should stay reserved.
+
+## 2. Decision
+
+1. **Add an Agent Harness Contract (AHC) as a per-task declaration, not a new layer.** AHC is a
+   docs-first, advisory-first, provider-agnostic *contract* declaring the operating envelope for a
+   task before it runs. It is not a runtime, orchestrator, policy engine, or permission automation.
+2. **AHC composes the existing surfaces; it does not restate them.** The three artifacts form a
+   chain, each at its own granularity:
+
+   ```
+   REGC (how much effort, per-slice)
+     → AHC (the declared envelope, per-task)
+       → AHGE (execution + record, per-action)
+         → Knowledge Governance (authorized context)
+   ```
+
+   AHC references each through an explicit mapping block and never re-decides their concerns:
+   it does not set effort (REGC), does not authorize individual actions (AHGE), and does not decide
+   source authority or sensitivity (Knowledge Governance).
+3. **AHGE's per-action record *is* AHC's observability trace.** AHC declares `observability`
+   requirements (`trace_required`, etc.); the trace itself is the
+   [AHGE per-action record](../../schemas/agent-harness-governance-record.schema.json). Therefore
+   **no new harness-observability concept document is created** — RF5 of the pack is satisfied by
+   reference.
+4. **Autonomy is a declared taxonomy mapped onto AHGE semantics.** The four levels — `observe`,
+   `advise`, `act_with_approval`, `autonomous_within_bounds` — map onto AHGE's planning/execution
+   mode and `decision_authority` rather than introducing a parallel permission model.
+5. **Formalize the declaration as an optional schema.** Ship
+   [`agent-harness-contract.schema.json`](../../schemas/agent-harness-contract.schema.json)
+   validating the **declaration** (distinct from the per-action record). It enforces the pack's
+   safety invariants structurally: a write/execute tool above low risk requires a write gate; a
+   hard-to-reverse task requires rollback and human review; `autonomous_within_bounds` requires
+   blocked actions and rollback. A vitest suite exercises each guardrail.
+
+## 3. Consequences
+
+**Positive**
+- The pre-task envelope becomes explicit and reviewable, closing the gap between effort (REGC) and
+  per-action execution (AHGE).
+- Safety obligations (no unguarded write above low risk, no irreversible action without rollback +
+  human review) become executable in CI, mirroring REGC/AHGE.
+- The framework stays additive and vendor-neutral: no existing contract changes; AHC references them.
+
+**Negative / accepted tradeoffs**
+- One more artifact to keep aligned with REGC/AHGE/KGL. Mitigated by the mapping block and a shared
+  vocabulary; drift is caught by the cross-phase consistency checks.
+- The schema validates the *declaration*, not a runtime; a harness must still honor it. Accepted —
+  same posture as the REGC and AHGE record schemas.
+- Some fields (sensors, ACI design quality) remain advisory prose; they are not mechanically
+  enforced here.
+
+## 4. Alternatives considered
+
+- **Implement the pack as specified, standalone.** Rejected: it would duplicate AHGE's contract,
+  schema, and observability, contradicting the anti-duplication discipline.
+- **Create a new "Harness Governance Layer".** Rejected: the pack itself (PRD §15) cautions against
+  the term; AHC is a contract, not a layer.
+- **Fold AHC fields into AHGE.** Rejected: AHGE is per-action execution; AHC is a per-task
+  declaration. Conflating them would blur a boundary worth keeping (declaration vs. execution).
+- **A new observability document.** Rejected: the AHGE per-action record already is the trace.
+- **A real validator/runtime now (`validate_harness_contracts.py`).** Rejected: out of scope and
+  deferred by the pack (Fase 5); the JSON Schema + vitest is the structural validator for this phase.
+
+## 5. Relationship
+
+- Sits between ADR-010 (REGC, effort) and ADR-011 (AHGE, per-action execution); references both and
+  ADR-008 (Knowledge Governance) for the context policy.
+- Concept, contract, references, examples:
+  [`agent-harness-contract.md`](../concepts/agent-harness-contract.md) (concept),
+  [`agent-harness-contract.md`](../contracts/agent-harness-contract.md) (contract),
+  [`agent-computer-interface.md`](../concepts/agent-computer-interface.md),
+  [`context-rot-controls.md`](../concepts/context-rot-controls.md),
+  [`harness-expiration-review-checklist.md`](../reference/harness-expiration-review-checklist.md),
+  `examples/harness/codex-debugging-harness.md`, `examples/harness/codex-testing-harness.md`.
+- Schema + fixture + test:
+  [`schemas/agent-harness-contract.schema.json`](../../schemas/agent-harness-contract.schema.json),
+  `examples/resource-aware-operations/fixtures/agent-harness-contract-debugging.json`,
+  `tests/contracts/test-agent-harness-contract.test.ts`.
+- A complementary template set lives in the Adaptative Skills repo (`templates/`).
+- Adds docs + an optional declaration schema only; modifies no existing contract.
+
+## 6. Review
+
+Revisit this ADR when any of the following becomes true:
+
+- A real Codex (or other) task trace shows the declaration is too heavy or too thin for practical use.
+- The autonomy taxonomy, gate set, or sensor fields need to change once validated on real tasks.
+- The mapping between AHC, REGC, and AHGE drifts and needs a shared field instead of a reference.
+- Repeated real evidence justifies the pack's deferred Fase 5 (a real structural validator beyond
+  the JSON Schema). Until then, evidence is an input, not an authority.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -74,3 +74,4 @@ Do *not* write one for:
 | [ADR-010](ADR-010-runtime-effort-governance-contract.md) | Runtime Effort Governance Contract | Accepted |
 | [ADR-011](ADR-011-agent-harness-governance-extension.md) | Agent Harness Governance Extension | Accepted |
 | [ADR-012](ADR-012-resource-aware-signal-validation.md) | Resource-Aware Signal Validation Layer | Accepted |
+| [ADR-013](ADR-013-agent-harness-contract.md) | Agent Harness Contract (per-task declaration) | Accepted |

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -21,6 +21,9 @@ If you need a step-by-step guide, see [`guides/`](../guides/README.md). If you n
 | [agent-handoffs.md](agent-handoffs.md) | Cross-agent and cross-session transitions |
 | [handoff-capture-pattern.md](handoff-capture-pattern.md) | How to capture handoff signals from completed work |
 | [slice-finalization-and-restart.md](../guides/slice-finalization-and-restart.md) | → see guides/ |
+| [agent-harness-contract.md](agent-harness-contract.md) | The declared per-task operating envelope (autonomy, tools, gates, sensors, rollback) |
+| [agent-computer-interface.md](agent-computer-interface.md) | How to design tools agents consume (ACI), complementing the permission matrix |
+| [context-rot-controls.md](context-rot-controls.md) | Signals of long-session degradation and the minimal controls + checkpoint |
 | [self-application.md](self-application.md) | How AletheIA governs its own evolution |
 | [structured-risk-inference.md](structured-risk-inference.md) | Experimental risk inference layer |
 | [project-extension-pattern.md](project-extension-pattern.md) | How projects extend the overlay without distorting it |

--- a/docs/concepts/agent-computer-interface.md
+++ b/docs/concepts/agent-computer-interface.md
@@ -1,0 +1,49 @@
+# Agent-Computer Interface (ACI)
+
+## What this is
+
+ACI is the discipline of **designing tools for AI agents** with the same seriousness UX brings to
+designing interfaces for people. A well-designed tool lets an agent act predictably, recover from
+errors, and stay within scope.
+
+ACI is about tool **design**. It complements — does not replace — the
+[tool permission matrix](../reference/tool-permission-matrix.md), which classifies a tool's *risk
+and permission*. ACI asks *is this a good tool to expose to an agent at all?*; the matrix asks
+*what permission does this action require?*
+
+## Rules for tools
+
+A good agent tool has:
+
+- an explicit name that reveals its consequence;
+- a short, unambiguous description;
+- a restricted input schema;
+- a predictable output schema;
+- actionable error messages (what to do next, not just what failed);
+- usage examples;
+- explicit states;
+- idempotent behavior where possible;
+- scope limits;
+- confirmation for irreversible actions.
+
+## Anti-patterns
+
+- A tool that is too generic.
+- Free-text output where a schema would do.
+- An error with no recommended action.
+- A name that hides the consequence.
+- A tool that mixes read and write.
+- A tool that performs an irreversible action without a gate.
+- A tool that returns too much context.
+
+## Relationship to the harness contract
+
+The [Agent Harness Contract](../contracts/agent-harness-contract.md) lists `allowed_tools` with a
+`permission` and `constraints`. ACI is the design quality bar those tools should meet before they
+are listed. A template for documenting a single tool against this bar lives in the Adaptative Skills
+repo (`templates/aci-tool-guideline.md`).
+
+## Related
+
+- [Agent Harness Contract](../contracts/agent-harness-contract.md)
+- [Tool permission matrix](../reference/tool-permission-matrix.md)

--- a/docs/concepts/agent-harness-contract.md
+++ b/docs/concepts/agent-harness-contract.md
@@ -1,0 +1,73 @@
+# Agent Harness Contract
+
+## What this is
+
+An **Agent Harness Contract (AHC)** is the *declared operating envelope* for a task, written before
+the task runs. A skill says *how* to think; a knowledge pack says *what* content is authorized; an
+AHC says *in what environment the agent may act* — with which tools, autonomy, gates, sensors,
+logs, and rollback.
+
+It is a **contract**, not a runtime, orchestrator, or policy engine, and deliberately **not** a new
+"layer". It is docs-first and provider-agnostic.
+
+## Where it sits
+
+The AHC composes three governance surfaces the framework already has. Each governs a distinct
+question at its own granularity:
+
+```
+User / Request
+  → AletheIA task contract
+    → Knowledge Governance (authorized context)
+      → Agent Harness Contract  ← the declared envelope (this document)
+        → Adaptive skill selection
+          → Runtime (Codex / Claude Code / …)
+            → Tools + Sensors + Logs
+              → Evidence + Decision Record + Handoff
+```
+
+```
+REGC (how much effort, per-slice)
+  → AHC (the declared envelope, per-task)
+    → AHGE (execution + record, per-action)
+      → Knowledge Governance (authorized context)
+```
+
+**AHC declares the envelope; [AHGE](../contracts/agent-harness-governance-extension.md) records each
+action within it; [REGC](../contracts/runtime-effort-governance-contract.md) sets the effort;
+[Knowledge Governance](../contracts/knowledge-source-contract.md) decides what context is
+authorized.** The normative field-by-field spec and the mapping to these surfaces live in the
+[Agent Harness Contract spec](../contracts/agent-harness-contract.md).
+
+## Boundary table
+
+| Surface | Decides | AHC's relationship |
+|---|---|---|
+| Skill | how to execute a capability | AHC lists `allowed_skills` / `blocked_skills`; it does not define skill behavior |
+| Knowledge Governance | source authority, sensitivity, precedence | AHC references `allowed_knowledge_packs` and `retrieval_mode`; it never decides authority |
+| REGC | effort level, escalation, stop, quality floor | AHC inherits the effort; it does not re-decide it |
+| AHGE | per-action permission, draft/commit, budgets, trace | AHC declares the envelope AHGE enforces and records per action |
+
+## Principles
+
+1. **Harness is not skill.** Skill orients behavior; harness defines environment, tools, sensors,
+   gates, and limits.
+2. **Harness is not Knowledge Governance.** Knowledge Governance controls authorized context; the
+   harness controls execution conditions.
+3. **Control proportional to risk.** Reversible, local tasks may use a light harness; structural,
+   sensitive, or irreversible tasks require more gates.
+4. **Sensor before judgment.** Before asking another model for a semantic opinion, use
+   computational sensors when available: tests, linters, type checkers, scripts, structural
+   validation.
+5. **Context needs hygiene.** Long sessions require offloading, checkpoints, recorded decisions, and
+   re-anchoring — see [context-rot-controls.md](context-rot-controls.md).
+6. **A harness expires.** Controls, guides, prompts, scripts, and sensors must be reviewed. A
+   control that never fires may be excellent or useless; it needs evaluation — see
+   [harness-expiration-review-checklist.md](../reference/harness-expiration-review-checklist.md).
+
+## Related
+
+- [Agent Harness Contract spec](../contracts/agent-harness-contract.md) — normative fields + mapping
+- [Agent-Computer Interface](agent-computer-interface.md) — how to design tools agents consume
+- [Context-Rot Controls](context-rot-controls.md) — long-session hygiene
+- [ADR-013](../adr/ADR-013-agent-harness-contract.md) — the reconciliation decision

--- a/docs/concepts/context-rot-controls.md
+++ b/docs/concepts/context-rot-controls.md
@@ -1,0 +1,58 @@
+# Context-Rot Controls
+
+## What this is
+
+Long agent sessions degrade. **Context rot** is the slow loss of coherence as history grows: the
+agent starts to contradict itself, forget active constraints, or drift from the goal. These
+controls keep a long session reviewable and restartable.
+
+This complements — does not duplicate — the repo's continuity surfaces:
+[agent-handoffs.md](agent-handoffs.md), [work-slice-pattern.md](work-slice-pattern.md), and
+[slice-finalization-and-restart.md](../guides/slice-finalization-and-restart.md). Those describe how
+to hand off and restart; this describes the *signals* that say it is time, and a checkpoint shape.
+
+## Signals of context rot
+
+- the agent contradicts a previous decision;
+- the agent forgets an active constraint;
+- the agent repeats a question already answered;
+- the agent mixes sources or projects;
+- the agent uses an old plan after the scope changed;
+- the agent adds complexity without new evidence;
+- the agent loses track of the main objective.
+
+## Minimal controls
+
+```txt
+Checkpoint at each milestone.
+Summarize the decision before a structural change.
+Re-anchor to the contract when context grows too far.
+Hand off when the task exceeds its original scope.
+Start a new session when history hurts more than it helps.
+```
+
+## Checkpoint template
+
+```yaml
+context_checkpoint:
+  task_id:
+  current_goal:
+  decisions_made:
+    - decision:
+      rationale:
+      source_or_evidence:
+  active_constraints:
+    -
+  open_questions:
+    -
+  next_action:
+  stop_conditions:
+    -
+```
+
+A fuller fill-in version lives in the Adaptative Skills repo (`templates/context-rot-checkpoint.md`).
+
+## Related
+
+- [Agent Harness Contract](../contracts/agent-harness-contract.md) — declares the envelope a long session must stay within
+- [agent-handoffs.md](agent-handoffs.md), [work-slice-pattern.md](work-slice-pattern.md), [slice-finalization-and-restart.md](../guides/slice-finalization-and-restart.md)

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -30,6 +30,7 @@ If you need conceptual background, see [`concepts/`](../concepts/README.md). If 
 | [skill-evolution-validation-contract.md](skill-evolution-validation-contract.md) | What a skill evolution experiment and its validation evidence must satisfy to be governed |
 | [runtime-effort-governance-contract.md](runtime-effort-governance-contract.md) | How an agent decides runtime effort for a work slice: start, escalate, de-escalate, stop, and human checkpoint |
 | [agent-harness-governance-extension.md](agent-harness-governance-extension.md) | How the harness validates, authorizes, executes, budgets, and returns structured observations for model-proposed actions |
+| [agent-harness-contract.md](agent-harness-contract.md) | The per-task declaration: autonomy, allowed tools/skills, gates, sensors, rollback, human review, context policy |
 
 ### Operationalized by security checklists
 

--- a/docs/contracts/agent-harness-contract.md
+++ b/docs/contracts/agent-harness-contract.md
@@ -1,0 +1,148 @@
+# Agent Harness Contract — Specification
+
+## Purpose
+
+Define the **per-task declaration** an agent operates within: autonomy, allowed tools and skills,
+blocked actions, required gates, expected sensors, observability, rollback, human review, and the
+context policy. The conceptual background and the boundary table are in
+[concepts/agent-harness-contract.md](../concepts/agent-harness-contract.md).
+
+This contract is docs-first and advisory-first. It declares an envelope; it does not execute,
+authorize, or enforce. Per-action authorization and the action trace are governed by the
+[Agent Harness Governance Extension](agent-harness-governance-extension.md) (AHGE); effort is
+governed by the [Runtime Effort Governance Contract](runtime-effort-governance-contract.md) (REGC);
+authorized context is governed by the [Knowledge Source Contract](knowledge-source-contract.md).
+
+## Non-goals
+
+- No runtime, orchestrator, policy engine, or permission automation.
+- No restating of REGC effort logic, AHGE permission logic, or Knowledge Governance authority — the
+  contract references them (see [Mapping](#mapping-to-regc-ahge-and-knowledge-governance)).
+- No new "Harness Governance Layer" — this is a contract (see [ADR-013](../adr/ADR-013-agent-harness-contract.md)).
+
+## Declaration shape
+
+```yaml
+agent_harness_contract:
+  contract_id: ahc-001
+  task_id: <task-id>
+  agent_id: <agent-or-runtime>
+  date: <YYYY-MM-DD>
+  autonomy_level: observe | advise | act_with_approval | autonomous_within_bounds
+
+  task_boundary:
+    objective: <what the agent is allowed to accomplish>
+    non_goals:
+      - <what the agent must not do>
+    risk_level: low | medium | high | critical
+    reversibility: reversible | partially_reversible | hard_to_reverse
+
+  allowed_skills:
+    - <skill-id>
+  blocked_skills:
+    - <skill-id>
+
+  allowed_tools:
+    - name: <tool-name>
+      permission: read | write | execute
+      constraints:
+        - <constraint>
+
+  blocked_actions:
+    - <action>
+
+  context_policy:
+    allowed_knowledge_packs:
+      - <pack-id@version>
+    retrieval_mode: capsule_first | excerpt_only | metadata_only | none
+    max_context_scope: task_only | project | repository | workspace
+
+  gates:
+    before_write: true
+    before_delete: true
+    before_external_call: true
+    before_structural_change: true
+    before_final_answer: true
+
+  sensors:
+    computational:
+      - test_suite
+      - linter
+      - typecheck
+      - schema_validation
+    inferential:
+      - review_skill
+      - architecture_review
+      - risk_review
+
+  observability:
+    trace_required: true
+    tool_log_required: true
+    decision_log_required: true
+    evidence_required: true
+
+  rollback:
+    required: true
+    strategy: git_diff | revert_commit | feature_flag | manual_restore
+
+  human_review:
+    required: true
+    reviewer_role: product | design | engineering | governance | security
+```
+
+## Autonomy taxonomy
+
+The four levels declare *how much authority* the agent holds. Each maps onto AHGE planning/execution
+mode and `decision_authority` — it does not introduce a parallel permission model.
+
+| `autonomy_level` | Meaning | AHGE mapping |
+|---|---|---|
+| `observe` | read and report only; no side effects | execution blocked; read-only tools; no commit |
+| `advise` | propose changes as drafts; never commit | draft-only; commit decision deferred to human |
+| `act_with_approval` | may commit, but side effects pass a gate | `approval_required` decisions on write/delete/external |
+| `autonomous_within_bounds` | acts within a declared budget and blocked-action list | harness-authorized within budget; high-risk still needs human authority |
+
+`autonomy_level` is *how much authority*; the Adaptative Skills `execution-modes` (basic / extended
+/ high-risk / multi-agent) are *how deep* the work runs. They are orthogonal axes.
+
+## Normative invariants
+
+These are the safety rules the [schema](../../schemas/agent-harness-contract.schema.json) enforces
+structurally:
+
+1. **No unguarded write above low risk.** If `risk_level` is `medium`, `high`, or `critical` and any
+   `allowed_tools[].permission` is `write` or `execute`, then `gates.before_write` must be `true`.
+2. **No irreversible action without recovery.** If `reversibility` is `hard_to_reverse`, then
+   `rollback.required` and `human_review.required` must both be `true`.
+3. **Bounded autonomy.** If `autonomy_level` is `autonomous_within_bounds`, then `blocked_actions`
+   must list at least one action and `rollback.required` must be `true`.
+
+## Mapping to REGC, AHGE, and Knowledge Governance
+
+The contract composes the existing surfaces; it does not re-decide them.
+
+```yaml
+ahc_mapping:
+  REGC:
+    provides: ["effort_level", "escalation", "stop_conditions", "quality_floor"]
+    ahc_inherits: "the slice effort; AHC does not re-decide it"
+  AHGE:
+    provides: ["permission_decision", "draft_commit_split", "planning_mode", "runtime_budgets", "per_action_record"]
+    ahc_relationship:
+      autonomy_level: "maps to planning/execution mode + decision_authority"
+      gates: "map to draft/commit policy + permission decision object"
+      allowed_tools_permission: "maps to AHGE tool registry risk/side-effect class"
+      observability: "the trace IS the AHGE per-action record"
+  knowledge_governance:
+    provides: ["source_authority", "sensitivity", "precedence", "restrictions"]
+    ahc_relationship:
+      context_policy: "references allowed_knowledge_packs + retrieval_mode; never decides authority"
+```
+
+## Related
+
+- [ADR-013 — Agent Harness Contract](../adr/ADR-013-agent-harness-contract.md)
+- [Agent-Computer Interface](../concepts/agent-computer-interface.md)
+- [Context-Rot Controls](../concepts/context-rot-controls.md)
+- [Harness Expiration Review Checklist](../reference/harness-expiration-review-checklist.md)
+- Examples: `examples/harness/codex-debugging-harness.md`, `examples/harness/codex-testing-harness.md`

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -17,6 +17,7 @@ Consultable material: catalogs, checklists, policies, examples, adapter guides, 
 | [prompt-caching-context-cost-strategy.md](prompt-caching-context-cost-strategy.md) | Stable/volatile context architecture for cache reuse without losing relevance |
 | [agent-harness-governance-validation-checklist.md](agent-harness-governance-validation-checklist.md) | Deferred phase-5 routine to validate the harness contract and record schema against a real trace |
 | [resource-aware-next-signals-validation-checklist.md](resource-aware-next-signals-validation-checklist.md) | Deferred phase-5 routine to validate the next-signals watch-list against accumulated real slice evidence |
+| [harness-expiration-review-checklist.md](harness-expiration-review-checklist.md) | Routine for deciding when a harness control should be kept, simplified, or removed |
 | [planning-depth-profiles.md](planning-depth-profiles.md) | Lite / Standard / High-Assurance planning depth |
 | [launch-kit.md](launch-kit.md) | Public-facing descriptions, taglines, one-pager |
 | [learnings.md](learnings.md) | Durable lessons from AI-assisted work |

--- a/docs/reference/harness-expiration-review-checklist.md
+++ b/docs/reference/harness-expiration-review-checklist.md
@@ -1,0 +1,74 @@
+# Harness Expiration Review — Checklist
+
+## Goal
+
+Provide a short, repeatable routine for deciding whether a harness control — a gate, sensor, guide,
+prompt, or script declared in an [Agent Harness Contract](../contracts/agent-harness-contract.md) —
+still earns its place, or should be **simplified, updated, or removed**.
+
+A harness is not permanent. A control that never fires may be excellent or useless; without review
+you cannot tell. This routine is the sibling of the
+[Agent Harness Governance validation checklist](agent-harness-governance-validation-checklist.md):
+that one validates the per-action contract against a real trace; this one decides when a *control*
+has expired.
+
+The discipline is the same as the rest of the framework: **evidence is an input, not an authority.**
+Remove a control because it stopped reducing real risk, not because it feels heavy.
+
+---
+
+## When to run this
+
+Review a harness control when any of the following changes:
+
+- the model changes capability;
+- a skill changes;
+- a tool changes its schema;
+- a sensor stops firing;
+- a sensor fires too much noise;
+- the project context changes;
+- a gate adds delay without reducing risk;
+- human review keeps finding the same errors the control was meant to catch.
+
+---
+
+## The checklist
+
+For each control under review, answer:
+
+```txt
+Does the control still prevent a real error?
+Does the sensor capture something that matters?
+Is the cost of the control still justified?
+Does the instruction contradict another rule?
+Does the current model still need this support?
+Could the gate be reduced without increasing risk?
+Is the harness creating bureaucracy without evidence?
+```
+
+A single "no" is a candidate for change, not an automatic removal. The core review question:
+
+```txt
+Does this control still reduce real risk, or does it only preserve an old fear?
+```
+
+---
+
+## Decide (with restraint)
+
+- **Keep** — the control still prevents a real, observed error class.
+- **Simplify** — the control's intent is valid but its cost is too high; reduce the gate or sensor.
+- **Remove** — the control no longer maps to a real risk, and removing it does not raise blast
+  radius, irreversibility, or quality risk.
+
+Removing a gate that guards a write, delete, external call, or irreversible action requires the same
+human authority AHGE requires for those actions — do not auto-relax a safety gate. Record the
+decision and the evidence behind it.
+
+---
+
+## What stays out of scope
+
+This routine reviews *controls*, not the contract's safety floor. It never authorizes removing
+rollback or human review from a `hard_to_reverse` task, and never turns a harness review into a way
+to bypass human review (Guardrails). The framework stays provider-agnostic and review-oriented.

--- a/examples/harness/codex-debugging-harness.md
+++ b/examples/harness/codex-debugging-harness.md
@@ -1,0 +1,54 @@
+# Example — Codex debugging harness
+
+A worked [Agent Harness Contract](../../docs/contracts/agent-harness-contract.md) for a Codex
+debugging task: reproduce, isolate, and propose a fix for a bug. Medium risk, reversible, so the
+agent may act but every write passes a gate, and a failing test must exist before an edit.
+
+```yaml
+agent_harness_contract:
+  task_id: debug-issue-001
+  agent_id: codex
+  autonomy_level: act_with_approval
+  task_boundary:
+    objective: reproduce, isolate and propose a fix for a bug
+    non_goals:
+      - large refactor
+      - dependency migration
+      - production config changes
+    risk_level: medium
+    reversibility: reversible
+  allowed_skills:
+    - debugging
+    - testing
+  allowed_tools:
+    - name: file_read
+      permission: read
+    - name: test_runner
+      permission: execute
+    - name: file_edit
+      permission: write
+      constraints:
+        - only after repro path is documented
+  gates:
+    before_write: true
+    before_structural_change: true
+  sensors:
+    computational:
+      - failing_test
+      - regression_test
+    inferential:
+      - debugging_review
+  rollback:
+    required: true
+    strategy: git_diff
+```
+
+## Why it is shaped this way
+
+- **`act_with_approval`** — the bug fix may commit, but each write passes a gate
+  (`gates.before_write: true`), satisfying the "no unguarded write above low risk" invariant.
+- **Sensor before judgment** — `failing_test` / `regression_test` (computational) run before the
+  `debugging_review` (inferential) is consulted.
+- **`file_edit` constraint** — an edit is only allowed *after* the reproduction path is documented,
+  keeping the fix evidence-led.
+- **Rollback** — `git_diff` makes the change reversible, consistent with `reversibility: reversible`.

--- a/examples/harness/codex-testing-harness.md
+++ b/examples/harness/codex-testing-harness.md
@@ -1,0 +1,40 @@
+# Example — Codex testing harness
+
+A worked [Agent Harness Contract](../../docs/contracts/agent-harness-contract.md) for a Codex
+testing task: add the minimum reliable proof for a behavior change. Low risk and reversible, so the
+harness is light — a write gate and a final-answer gate, with computational sensors.
+
+```yaml
+agent_harness_contract:
+  task_id: test-change-001
+  agent_id: codex
+  autonomy_level: act_with_approval
+  task_boundary:
+    objective: add minimum reliable proof for a behavior change
+    non_goals:
+      - rewrite test architecture
+      - add broad test suite without risk rationale
+    risk_level: low
+    reversibility: reversible
+  allowed_skills:
+    - testing
+  gates:
+    before_write: true
+    before_final_answer: true
+  sensors:
+    computational:
+      - test_suite
+      - coverage_delta
+    inferential:
+      - testing_review
+```
+
+## Why it is shaped this way
+
+- **Proportional control** — low risk and reversible, so the harness stays light: no rollback
+  section is mandated (the invariant only forces rollback for `hard_to_reverse` tasks), but writes
+  and the final answer still pass a gate.
+- **Minimum reliable proof** — the `non_goals` keep the agent from inflating the test suite without
+  a risk rationale, matching the framework's anti-overengineering posture.
+- **Sensor before judgment** — `test_suite` / `coverage_delta` (computational) precede the
+  `testing_review` (inferential).

--- a/examples/resource-aware-operations/fixtures/agent-harness-contract-debugging.json
+++ b/examples/resource-aware-operations/fixtures/agent-harness-contract-debugging.json
@@ -1,0 +1,51 @@
+{
+  "contract_id": "ahc-001",
+  "task_id": "debug-issue-001",
+  "agent_id": "codex",
+  "date": "2026-06-05",
+  "autonomy_level": "act_with_approval",
+  "task_boundary": {
+    "objective": "reproduce, isolate and propose a fix for a bug",
+    "non_goals": ["large refactor", "dependency migration", "production config changes"],
+    "risk_level": "medium",
+    "reversibility": "reversible"
+  },
+  "allowed_skills": ["debugging", "testing"],
+  "blocked_skills": [],
+  "allowed_tools": [
+    { "name": "file_read", "permission": "read" },
+    { "name": "test_runner", "permission": "execute" },
+    { "name": "file_edit", "permission": "write", "constraints": ["only after repro path is documented"] }
+  ],
+  "blocked_actions": ["change_secrets", "modify_production_config"],
+  "context_policy": {
+    "allowed_knowledge_packs": ["example-consumer@1.0.0"],
+    "retrieval_mode": "capsule_first",
+    "max_context_scope": "repository"
+  },
+  "gates": {
+    "before_write": true,
+    "before_delete": true,
+    "before_external_call": true,
+    "before_structural_change": true,
+    "before_final_answer": false
+  },
+  "sensors": {
+    "computational": ["failing_test", "regression_test"],
+    "inferential": ["debugging_review"]
+  },
+  "observability": {
+    "trace_required": true,
+    "tool_log_required": true,
+    "decision_log_required": true,
+    "evidence_required": true
+  },
+  "rollback": {
+    "required": true,
+    "strategy": "git_diff"
+  },
+  "human_review": {
+    "required": true,
+    "reviewer_role": "engineering"
+  }
+}

--- a/schemas/agent-harness-contract.schema.json
+++ b/schemas/agent-harness-contract.schema.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia.local/schemas/agent-harness-contract.schema.json",
+  "title": "Agent Harness Contract (per-task declaration)",
+  "description": "Optional structured record for the per-task Agent Harness Contract (docs/contracts/agent-harness-contract.md). It declares the operating envelope for a task before it runs: autonomy, allowed tools and skills, blocked actions, required gates, expected sensors, observability, rollback, human review, and the context policy. It is the upstream declaration that the Agent Harness Governance Extension (per-action) enforces and records, under the effort set by REGC and the context authorized by Knowledge Governance. The schema does not authorize or execute; it forces the declaration to be explicit and enforces the pack's safety invariants structurally: a write/execute tool above low risk requires a write gate; a hard-to-reverse task requires rollback and human review; autonomous_within_bounds requires blocked actions and rollback.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_id",
+    "task_id",
+    "agent_id",
+    "autonomy_level",
+    "task_boundary",
+    "allowed_tools",
+    "gates",
+    "observability",
+    "rollback",
+    "human_review"
+  ],
+  "$defs": {
+    "autonomy_level": {
+      "type": "string",
+      "enum": ["observe", "advise", "act_with_approval", "autonomous_within_bounds"]
+    },
+    "risk_level": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+    "reversibility": {
+      "type": "string",
+      "enum": ["reversible", "partially_reversible", "hard_to_reverse"]
+    },
+    "permission": { "type": "string", "enum": ["read", "write", "execute"] },
+    "retrieval_mode": {
+      "type": "string",
+      "enum": ["capsule_first", "excerpt_only", "metadata_only", "none"]
+    },
+    "max_context_scope": {
+      "type": "string",
+      "enum": ["task_only", "project", "repository", "workspace"]
+    },
+    "rollback_strategy": {
+      "type": "string",
+      "enum": ["git_diff", "revert_commit", "feature_flag", "manual_restore"]
+    },
+    "reviewer_role": {
+      "type": "string",
+      "enum": ["product", "design", "engineering", "governance", "security"]
+    }
+  },
+  "properties": {
+    "contract_id": { "type": "string", "minLength": 1 },
+    "task_id": { "type": "string", "minLength": 1 },
+    "agent_id": { "type": "string", "minLength": 1 },
+    "date": { "type": "string", "format": "date" },
+    "autonomy_level": { "$ref": "#/$defs/autonomy_level" },
+    "task_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["objective", "risk_level", "reversibility"],
+      "properties": {
+        "objective": { "type": "string", "minLength": 1 },
+        "non_goals": { "type": "array", "items": { "type": "string" } },
+        "risk_level": { "$ref": "#/$defs/risk_level" },
+        "reversibility": { "$ref": "#/$defs/reversibility" }
+      }
+    },
+    "allowed_skills": { "type": "array", "items": { "type": "string" } },
+    "blocked_skills": { "type": "array", "items": { "type": "string" } },
+    "allowed_tools": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "permission"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "permission": { "$ref": "#/$defs/permission" },
+          "constraints": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "blocked_actions": { "type": "array", "items": { "type": "string" } },
+    "context_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowed_knowledge_packs": { "type": "array", "items": { "type": "string" } },
+        "retrieval_mode": { "$ref": "#/$defs/retrieval_mode" },
+        "max_context_scope": { "$ref": "#/$defs/max_context_scope" }
+      }
+    },
+    "gates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "before_write",
+        "before_delete",
+        "before_external_call",
+        "before_structural_change",
+        "before_final_answer"
+      ],
+      "properties": {
+        "before_write": { "type": "boolean" },
+        "before_delete": { "type": "boolean" },
+        "before_external_call": { "type": "boolean" },
+        "before_structural_change": { "type": "boolean" },
+        "before_final_answer": { "type": "boolean" }
+      }
+    },
+    "sensors": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "computational": { "type": "array", "items": { "type": "string" } },
+        "inferential": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "observability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trace_required", "tool_log_required", "decision_log_required", "evidence_required"],
+      "properties": {
+        "trace_required": { "type": "boolean" },
+        "tool_log_required": { "type": "boolean" },
+        "decision_log_required": { "type": "boolean" },
+        "evidence_required": { "type": "boolean" }
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "strategy": { "$ref": "#/$defs/rollback_strategy" }
+      }
+    },
+    "human_review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "reviewer_role": { "$ref": "#/$defs/reviewer_role" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "Invariant 1 — no unguarded write above low risk: if the task is medium/high/critical risk AND any allowed tool can write or execute, a write gate must be declared. Encodes Guardrails: no write action without a gate when risk_level is medium, high, or critical.",
+      "if": {
+        "properties": {
+          "task_boundary": {
+            "properties": { "risk_level": { "enum": ["medium", "high", "critical"] } },
+            "required": ["risk_level"]
+          },
+          "allowed_tools": {
+            "contains": {
+              "properties": { "permission": { "enum": ["write", "execute"] } },
+              "required": ["permission"]
+            }
+          }
+        },
+        "required": ["task_boundary", "allowed_tools"]
+      },
+      "then": {
+        "properties": {
+          "gates": {
+            "properties": { "before_write": { "const": true } },
+            "required": ["before_write"]
+          }
+        },
+        "required": ["gates"]
+      }
+    },
+    {
+      "$comment": "Invariant 2 — no irreversible action without recovery: a hard_to_reverse task must declare rollback.required and human_review.required.",
+      "if": {
+        "properties": {
+          "task_boundary": {
+            "properties": { "reversibility": { "const": "hard_to_reverse" } },
+            "required": ["reversibility"]
+          }
+        },
+        "required": ["task_boundary"]
+      },
+      "then": {
+        "properties": {
+          "rollback": {
+            "properties": { "required": { "const": true } },
+            "required": ["required"]
+          },
+          "human_review": {
+            "properties": { "required": { "const": true } },
+            "required": ["required"]
+          }
+        },
+        "required": ["rollback", "human_review"]
+      }
+    },
+    {
+      "$comment": "Invariant 3 — bounded autonomy: autonomous_within_bounds must declare at least one blocked action and require rollback.",
+      "if": {
+        "properties": { "autonomy_level": { "const": "autonomous_within_bounds" } },
+        "required": ["autonomy_level"]
+      },
+      "then": {
+        "properties": {
+          "blocked_actions": { "type": "array", "minItems": 1 },
+          "rollback": {
+            "properties": { "required": { "const": true } },
+            "required": ["required"]
+          }
+        },
+        "required": ["blocked_actions", "rollback"]
+      }
+    }
+  ]
+}

--- a/tests/contracts/test-agent-harness-contract.test.ts
+++ b/tests/contracts/test-agent-harness-contract.test.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { validateAgainstSchema, SchemaValidationError } from "../../engine";
+
+const schemasDir = path.resolve(process.cwd(), "schemas");
+const schemaPath = path.join(schemasDir, "agent-harness-contract.schema.json");
+const fixturePath = path.resolve(
+  process.cwd(),
+  "examples/resource-aware-operations/fixtures/agent-harness-contract-debugging.json",
+);
+
+function loadFixture(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(fixturePath, "utf-8")) as Record<string, unknown>;
+}
+
+describe("Agent Harness Contract (per-task declaration)", () => {
+  it("validates the realistic Codex debugging contract against the schema", () => {
+    const data = loadFixture();
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects an autonomy_level outside the four-value taxonomy", () => {
+    const data = loadFixture();
+    data.autonomy_level = "fully_autonomous";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a medium-risk write contract with no before_write gate (invariant 1)", () => {
+    const data = loadFixture();
+    (data.gates as Record<string, unknown>).before_write = false;
+    // task is medium risk and includes a write/execute tool -> gate is mandatory
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a low-risk write contract without a before_write gate (invariant 1 not triggered)", () => {
+    const data = loadFixture();
+    (data.task_boundary as Record<string, unknown>).risk_level = "low";
+    (data.gates as Record<string, unknown>).before_write = false;
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a hard_to_reverse task without rollback.required (invariant 2)", () => {
+    const data = loadFixture();
+    (data.task_boundary as Record<string, unknown>).reversibility = "hard_to_reverse";
+    (data.rollback as Record<string, unknown>).required = false;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a hard_to_reverse task without human_review.required (invariant 2)", () => {
+    const data = loadFixture();
+    (data.task_boundary as Record<string, unknown>).reversibility = "hard_to_reverse";
+    (data.rollback as Record<string, unknown>).required = true;
+    (data.human_review as Record<string, unknown>).required = false;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects autonomous_within_bounds with empty blocked_actions (invariant 3)", () => {
+    const data = loadFixture();
+    data.autonomy_level = "autonomous_within_bounds";
+    data.blocked_actions = [];
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts autonomous_within_bounds with blocked_actions and rollback (invariant 3 satisfied)", () => {
+    const data = loadFixture();
+    data.autonomy_level = "autonomous_within_bounds";
+    data.blocked_actions = ["delete_files"];
+    (data.rollback as Record<string, unknown>).required = true;
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a reviewer_role outside the canonical set", () => {
+    const data = loadFixture();
+    (data.human_review as Record<string, unknown>).reviewer_role = "marketing";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a retrieval_mode outside the canonical set", () => {
+    const data = loadFixture();
+    (data.context_policy as Record<string, unknown>).retrieval_mode = "full_text";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a minimal observe read-only contract with no gates fired", () => {
+    const data = loadFixture();
+    data.autonomy_level = "observe";
+    data.allowed_tools = [{ name: "file_read", permission: "read" }];
+    data.blocked_actions = [];
+    data.gates = {
+      before_write: false,
+      before_delete: false,
+      before_external_call: false,
+      before_structural_change: false,
+      before_final_answer: false,
+    };
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

Adds the per-task **Agent Harness Contract (AHC)** — the declared operating envelope before a task runs — **reconciled with the existing AHGE** (#179/#181/#182). **PR-1 (docs-first)** of a two-PR AletheIA stack; an Adaptive Skills companion PR adds the template side.

## Reconciliation thesis

AHC is **not** a competitor to AHGE. The three artifacts compose as a chain:

```
REGC (how much effort, per-slice) → AHC (declared envelope, per-task) → AHGE (execution + record, per-action) → Knowledge Governance (authorized context)
```

AHC declares the envelope; AHGE records each action within it. AHC **references** REGC/AHGE/KGL via an explicit mapping block and never restates them. It is a **contract, not a new "layer"** (per the source pack's PRD §15).

## Key reconciliation decisions (ADR-013)

- **AHGE's per-action record IS the observability trace** → no new observability doc (RF5 satisfied by reference).
- Autonomy taxonomy (`observe`/`advise`/`act_with_approval`/`autonomous_within_bounds`) maps onto AHGE planning-mode + `decision_authority` — no parallel permission model.

## Changes (docs-first)

- `docs/adr/ADR-013-agent-harness-contract.md` + index row
- `docs/concepts/agent-harness-contract.md` (concept) + `docs/contracts/agent-harness-contract.md` (normative spec with REGC/AHGE/KGL mapping)
- `docs/concepts/agent-computer-interface.md` (ACI tool-design, complements the permission matrix)
- `docs/concepts/context-rot-controls.md` + `docs/reference/harness-expiration-review-checklist.md`
- `examples/harness/codex-debugging-harness.md`, `examples/harness/codex-testing-harness.md`
- concept/contract/reference README index rows

## Verification

- `pnpm run check:governance` passes; no observability doc created; ADR has 6 sections + indexed; AHC references AHGE/REGC/KGL (not restates).

PR-2 (`feat/ahc-schema`) stacks on this branch with the declaration schema + vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)