### PR TITLE
feat(governance): Agent Harness Contract declaration schema + tests

### DIFF
--- a/examples/resource-aware-operations/fixtures/agent-harness-contract-debugging.json
+++ b/examples/resource-aware-operations/fixtures/agent-harness-contract-debugging.json
@@ -1,0 +1,51 @@
+{
+  "contract_id": "ahc-001",
+  "task_id": "debug-issue-001",
+  "agent_id": "codex",
+  "date": "2026-06-05",
+  "autonomy_level": "act_with_approval",
+  "task_boundary": {
+    "objective": "reproduce, isolate and propose a fix for a bug",
+    "non_goals": ["large refactor", "dependency migration", "production config changes"],
+    "risk_level": "medium",
+    "reversibility": "reversible"
+  },
+  "allowed_skills": ["debugging", "testing"],
+  "blocked_skills": [],
+  "allowed_tools": [
+    { "name": "file_read", "permission": "read" },
+    { "name": "test_runner", "permission": "execute" },
+    { "name": "file_edit", "permission": "write", "constraints": ["only after repro path is documented"] }
+  ],
+  "blocked_actions": ["change_secrets", "modify_production_config"],
+  "context_policy": {
+    "allowed_knowledge_packs": ["example-consumer@1.0.0"],
+    "retrieval_mode": "capsule_first",
+    "max_context_scope": "repository"
+  },
+  "gates": {
+    "before_write": true,
+    "before_delete": true,
+    "before_external_call": true,
+    "before_structural_change": true,
+    "before_final_answer": false
+  },
+  "sensors": {
+    "computational": ["failing_test", "regression_test"],
+    "inferential": ["debugging_review"]
+  },
+  "observability": {
+    "trace_required": true,
+    "tool_log_required": true,
+    "decision_log_required": true,
+    "evidence_required": true
+  },
+  "rollback": {
+    "required": true,
+    "strategy": "git_diff"
+  },
+  "human_review": {
+    "required": true,
+    "reviewer_role": "engineering"
+  }
+}

--- a/schemas/agent-harness-contract.schema.json
+++ b/schemas/agent-harness-contract.schema.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia.local/schemas/agent-harness-contract.schema.json",
+  "title": "Agent Harness Contract (per-task declaration)",
+  "description": "Optional structured record for the per-task Agent Harness Contract (docs/contracts/agent-harness-contract.md). It declares the operating envelope for a task before it runs: autonomy, allowed tools and skills, blocked actions, required gates, expected sensors, observability, rollback, human review, and the context policy. It is the upstream declaration that the Agent Harness Governance Extension (per-action) enforces and records, under the effort set by REGC and the context authorized by Knowledge Governance. The schema does not authorize or execute; it forces the declaration to be explicit and enforces the pack's safety invariants structurally: a write/execute tool above low risk requires a write gate; a hard-to-reverse task requires rollback and human review; autonomous_within_bounds requires blocked actions and rollback.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_id",
+    "task_id",
+    "agent_id",
+    "autonomy_level",
+    "task_boundary",
+    "allowed_tools",
+    "gates",
+    "observability",
+    "rollback",
+    "human_review"
+  ],
+  "$defs": {
+    "autonomy_level": {
+      "type": "string",
+      "enum": ["observe", "advise", "act_with_approval", "autonomous_within_bounds"]
+    },
+    "risk_level": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+    "reversibility": {
+      "type": "string",
+      "enum": ["reversible", "partially_reversible", "hard_to_reverse"]
+    },
+    "permission": { "type": "string", "enum": ["read", "write", "execute"] },
+    "retrieval_mode": {
+      "type": "string",
+      "enum": ["capsule_first", "excerpt_only", "metadata_only", "none"]
+    },
+    "max_context_scope": {
+      "type": "string",
+      "enum": ["task_only", "project", "repository", "workspace"]
+    },
+    "rollback_strategy": {
+      "type": "string",
+      "enum": ["git_diff", "revert_commit", "feature_flag", "manual_restore"]
+    },
+    "reviewer_role": {
+      "type": "string",
+      "enum": ["product", "design", "engineering", "governance", "security"]
+    }
+  },
+  "properties": {
+    "contract_id": { "type": "string", "minLength": 1 },
+    "task_id": { "type": "string", "minLength": 1 },
+    "agent_id": { "type": "string", "minLength": 1 },
+    "date": { "type": "string", "format": "date" },
+    "autonomy_level": { "$ref": "#/$defs/autonomy_level" },
+    "task_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["objective", "risk_level", "reversibility"],
+      "properties": {
+        "objective": { "type": "string", "minLength": 1 },
+        "non_goals": { "type": "array", "items": { "type": "string" } },
+        "risk_level": { "$ref": "#/$defs/risk_level" },
+        "reversibility": { "$ref": "#/$defs/reversibility" }
+      }
+    },
+    "allowed_skills": { "type": "array", "items": { "type": "string" } },
+    "blocked_skills": { "type": "array", "items": { "type": "string" } },
+    "allowed_tools": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "permission"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "permission": { "$ref": "#/$defs/permission" },
+          "constraints": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "blocked_actions": { "type": "array", "items": { "type": "string" } },
+    "context_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowed_knowledge_packs": { "type": "array", "items": { "type": "string" } },
+        "retrieval_mode": { "$ref": "#/$defs/retrieval_mode" },
+        "max_context_scope": { "$ref": "#/$defs/max_context_scope" }
+      }
+    },
+    "gates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "before_write",
+        "before_delete",
+        "before_external_call",
+        "before_structural_change",
+        "before_final_answer"
+      ],
+      "properties": {
+        "before_write": { "type": "boolean" },
+        "before_delete": { "type": "boolean" },
+        "before_external_call": { "type": "boolean" },
+        "before_structural_change": { "type": "boolean" },
+        "before_final_answer": { "type": "boolean" }
+      }
+    },
+    "sensors": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "computational": { "type": "array", "items": { "type": "string" } },
+        "inferential": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "observability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trace_required", "tool_log_required", "decision_log_required", "evidence_required"],
+      "properties": {
+        "trace_required": { "type": "boolean" },
+        "tool_log_required": { "type": "boolean" },
+        "decision_log_required": { "type": "boolean" },
+        "evidence_required": { "type": "boolean" }
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "strategy": { "$ref": "#/$defs/rollback_strategy" }
+      }
+    },
+    "human_review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "reviewer_role": { "$ref": "#/$defs/reviewer_role" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "Invariant 1 — no unguarded write above low risk: if the task is medium/high/critical risk AND any allowed tool can write or execute, a write gate must be declared. Encodes Guardrails: no write action without a gate when risk_level is medium, high, or critical.",
+      "if": {
+        "properties": {
+          "task_boundary": {
+            "properties": { "risk_level": { "enum": ["medium", "high", "critical"] } },
+            "required": ["risk_level"]
+          },
+          "allowed_tools": {
+            "contains": {
+              "properties": { "permission": { "enum": ["write", "execute"] } },
+              "required": ["permission"]
+            }
+          }
+        },
+        "required": ["task_boundary", "allowed_tools"]
+      },
+      "then": {
+        "properties": {
+          "gates": {
+            "properties": { "before_write": { "const": true } },
+            "required": ["before_write"]
+          }
+        },
+        "required": ["gates"]
+      }
+    },
+    {
+      "$comment": "Invariant 2 — no irreversible action without recovery: a hard_to_reverse task must declare rollback.required and human_review.required.",
+      "if": {
+        "properties": {
+          "task_boundary": {
+            "properties": { "reversibility": { "const": "hard_to_reverse" } },
+            "required": ["reversibility"]
+          }
+        },
+        "required": ["task_boundary"]
+      },
+      "then": {
+        "properties": {
+          "rollback": {
+            "properties": { "required": { "const": true } },
+            "required": ["required"]
+          },
+          "human_review": {
+            "properties": { "required": { "const": true } },
+            "required": ["required"]
+          }
+        },
+        "required": ["rollback", "human_review"]
+      }
+    },
+    {
+      "$comment": "Invariant 3 — bounded autonomy: autonomous_within_bounds must declare at least one blocked action and require rollback.",
+      "if": {
+        "properties": { "autonomy_level": { "const": "autonomous_within_bounds" } },
+        "required": ["autonomy_level"]
+      },
+      "then": {
+        "properties": {
+          "blocked_actions": { "type": "array", "minItems": 1 },
+          "rollback": {
+            "properties": { "required": { "const": true } },
+            "required": ["required"]
+          }
+        },
+        "required": ["blocked_actions", "rollback"]
+      }
+    }
+  ]
+}

--- a/tests/contracts/test-agent-harness-contract.test.ts
+++ b/tests/contracts/test-agent-harness-contract.test.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { validateAgainstSchema, SchemaValidationError } from "../../engine";
+
+const schemasDir = path.resolve(process.cwd(), "schemas");
+const schemaPath = path.join(schemasDir, "agent-harness-contract.schema.json");
+const fixturePath = path.resolve(
+  process.cwd(),
+  "examples/resource-aware-operations/fixtures/agent-harness-contract-debugging.json",
+);
+
+function loadFixture(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(fixturePath, "utf-8")) as Record<string, unknown>;
+}
+
+describe("Agent Harness Contract (per-task declaration)", () => {
+  it("validates the realistic Codex debugging contract against the schema", () => {
+    const data = loadFixture();
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects an autonomy_level outside the four-value taxonomy", () => {
+    const data = loadFixture();
+    data.autonomy_level = "fully_autonomous";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a medium-risk write contract with no before_write gate (invariant 1)", () => {
+    const data = loadFixture();
+    (data.gates as Record<string, unknown>).before_write = false;
+    // task is medium risk and includes a write/execute tool -> gate is mandatory
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a low-risk write contract without a before_write gate (invariant 1 not triggered)", () => {
+    const data = loadFixture();
+    (data.task_boundary as Record<string, unknown>).risk_level = "low";
+    (data.gates as Record<string, unknown>).before_write = false;
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a hard_to_reverse task without rollback.required (invariant 2)", () => {
+    const data = loadFixture();
+    (data.task_boundary as Record<string, unknown>).reversibility = "hard_to_reverse";
+    (data.rollback as Record<string, unknown>).required = false;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a hard_to_reverse task without human_review.required (invariant 2)", () => {
+    const data = loadFixture();
+    (data.task_boundary as Record<string, unknown>).reversibility = "hard_to_reverse";
+    (data.rollback as Record<string, unknown>).required = true;
+    (data.human_review as Record<string, unknown>).required = false;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects autonomous_within_bounds with empty blocked_actions (invariant 3)", () => {
+    const data = loadFixture();
+    data.autonomy_level = "autonomous_within_bounds";
+    data.blocked_actions = [];
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts autonomous_within_bounds with blocked_actions and rollback (invariant 3 satisfied)", () => {
+    const data = loadFixture();
+    data.autonomy_level = "autonomous_within_bounds";
+    data.blocked_actions = ["delete_files"];
+    (data.rollback as Record<string, unknown>).required = true;
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a reviewer_role outside the canonical set", () => {
+    const data = loadFixture();
+    (data.human_review as Record<string, unknown>).reviewer_role = "marketing";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a retrieval_mode outside the canonical set", () => {
+    const data = loadFixture();
+    (data.context_policy as Record<string, unknown>).retrieval_mode = "full_text";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a minimal observe read-only contract with no gates fired", () => {
+    const data = loadFixture();
+    data.autonomy_level = "observe";
+    data.allowed_tools = [{ name: "file_read", permission: "read" }];
+    data.blocked_actions = [];
+    data.gates = {
+      before_write: false,
+      before_delete: false,
+      before_external_call: false,
+      before_structural_change: false,
+      before_final_answer: false,
+    };
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

Formalizes the per-task AHC declaration as an optional JSON Schema, **distinct from** the per-action AHGE record schema. **PR-2** of the stack — **based on `feat/ahc-docs`**, not `main`. Review/merge PR-1 first.

## Three safety invariants, encoded structurally (`allOf`/`if-then`)

1. **No unguarded write above low risk** — `risk_level` ∈ {medium, high, critical} with a write/execute tool requires `gates.before_write: true`.
2. **No irreversible action without recovery** — `reversibility: hard_to_reverse` requires `rollback.required` and `human_review.required`.
3. **Bounded autonomy** — `autonomous_within_bounds` requires ≥1 `blocked_actions` and `rollback.required`.

The schema **constrains** the declaration; it never executes or authorizes.

## Changes

- `schemas/agent-harness-contract.schema.json`
- `examples/resource-aware-operations/fixtures/agent-harness-contract-debugging.json`
- `tests/contracts/test-agent-harness-contract.test.ts` (11 cases)

## Verification

- `pnpm test` → **150 passed** (11 new); `pnpm run test:all` green; 4 autonomy levels + 3 invariants present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)