### PR TITLE
docs(harness): policy verdicts, autonomy levels, tool risk, audit record

### DIFF
--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -22,6 +22,8 @@ If you need a step-by-step guide, see [`guides/`](../guides/README.md). If you n
 | [handoff-capture-pattern.md](handoff-capture-pattern.md) | How to capture handoff signals from completed work |
 | [slice-finalization-and-restart.md](../guides/slice-finalization-and-restart.md) | → see guides/ |
 | [agent-harness-contract.md](agent-harness-contract.md) | The declared per-task operating envelope (autonomy, tools, gates, sensors, rollback) |
+| [autonomy-levels.md](autonomy-levels.md) | The four canonical authority levels and how external five-level drafts map onto them |
+| [tool-risk-taxonomy.md](tool-risk-taxonomy.md) | Coarse risk classes for skill declaration, mapped to the authoritative permission matrix |
 | [agent-computer-interface.md](agent-computer-interface.md) | How to design tools agents consume (ACI), complementing the permission matrix |
 | [context-rot-controls.md](context-rot-controls.md) | Signals of long-session degradation and the minimal controls + checkpoint |
 | [self-application.md](self-application.md) | How AletheIA governs its own evolution |

--- a/docs/concepts/autonomy-levels.md
+++ b/docs/concepts/autonomy-levels.md
@@ -1,0 +1,57 @@
+# Autonomy Levels
+
+> Posture: `docs_first`, `advisory_first`. This document describes vocabulary and required behavior.
+> It does not implement a runtime, a permission engine, or any tool. It is provider-agnostic.
+
+## Goal
+
+Name the levels of authority an agent may hold, so a skill can declare a ceiling and a harness can
+enforce one. **Autonomy is about authority, not depth.** How deep a task runs (effort) is governed by
+the [Runtime Effort Governance Contract](../contracts/runtime-effort-governance-contract.md); how much
+authority the agent holds is this axis.
+
+## Canonical levels
+
+These four values are the **source of truth** and are enforced structurally by the
+[Agent Harness Contract schema](../../schemas/agent-harness-contract.schema.json)
+(`enum: ["observe", "advise", "act_with_approval", "autonomous_within_bounds"]`) and described in
+[`agent-harness-contract.md`](../contracts/agent-harness-contract.md) and
+[ADR-013](../adr/ADR-013-agent-harness-contract.md). Do not invent additional level names.
+
+```yaml
+autonomy_levels:
+  observe:
+    description: "Can inspect context and summarize. No recommendations that trigger action."
+  advise:
+    description: "Can recommend options and record decisions. No tool side effects."
+  act_with_approval:
+    description: "Can prepare or execute bounded actions only after explicit approval gates."
+  autonomous_within_bounds:
+    description: "Can act within narrow, pre-approved constraints; must declare blocked actions and rollback."
+```
+
+The schema enforces that `autonomous_within_bounds` declares at least one blocked action and requires
+rollback (Invariant 3). Treat unbounded autonomy as out of scope for this phase.
+
+## Vocabulary reconciliation
+
+External material (the Agent Harness Enforcement Addendum drafts) sometimes uses a five-level model
+with `bounded_autonomous` and a standalone `autonomous`. Map them to the canonical vocabulary:
+
+| External draft term | Canonical AletheIA level |
+|---|---|
+| `observe` | `observe` |
+| `advise` | `advise` |
+| `act_with_approval` | `act_with_approval` |
+| `bounded_autonomous` | `autonomous_within_bounds` |
+| `autonomous` (unbounded) | out of scope — not a level in this phase |
+
+Skills in the Adaptative Skills repo declare an autonomy `floor` and `ceiling` using **these canonical
+names** in their per-skill `harness_requirements` (see Adaptative Skills
+`docs/harness-requirements-for-skills.md`).
+
+## See also
+
+- [agent-harness-contract.md](../contracts/agent-harness-contract.md) — per-task envelope that carries the level.
+- [tool-risk-taxonomy.md](tool-risk-taxonomy.md) — the orthogonal "how risky is this tool" axis.
+- [enforcement-boundaries.md](enforcement-boundaries.md) — who declares vs. who enforces.

--- a/docs/concepts/enforcement-boundaries.md
+++ b/docs/concepts/enforcement-boundaries.md
@@ -157,6 +157,29 @@ By adding this distinction, AletheIA should show that:
 
 ---
 
+## Agent Harness Enforcement Addendum — who declares, who enforces
+
+The behavioral/technical distinction has a direct consequence for skills. A skill's prose ("the agent
+must not delete files") is **behavioral**. Turning that into a checkable, blockable outcome is
+**technical** — and it does not belong to the skill.
+
+Three roles, never merged:
+
+- **A skill declares** the operating envelope it needs (autonomy ceiling, expected/restricted tools,
+  approval gates, required evidence). In the Adaptative Skills repo this is the per-skill
+  `harness_requirements` block (`docs/harness-requirements-for-skills.md`). Declaration is behavioral:
+  it states intent, it does not block.
+- **The harness enforces** — it validates arguments, evaluates the permission policy, and produces a
+  verdict (allow / deny / require_approval / transform / log_only). This is technical enforcement,
+  defined in [agent-harness-governance-extension.md](../contracts/agent-harness-governance-extension.md).
+- **AletheIA defines the contracts** the harness enforces against: [autonomy-levels.md](autonomy-levels.md),
+  [tool-risk-taxonomy.md](tool-risk-taxonomy.md), [policy-verdicts.md](../contracts/policy-verdicts.md),
+  [agent-action-audit-record.md](../contracts/agent-action-audit-record.md).
+
+The mistake this addendum guards against is the same Mistake 1 above, applied to skills: treating a
+skill's declared restriction as if it were already enforced. A skill that *says* a tool is denied has
+not denied it. Only the harness can.
+
 ## Future evolution
 
 Later versions may connect this distinction more directly to:

--- a/docs/concepts/tool-risk-taxonomy.md
+++ b/docs/concepts/tool-risk-taxonomy.md
@@ -1,0 +1,66 @@
+# Tool Risk Taxonomy
+
+> Posture: `docs_first`, `advisory_first`. Describes vocabulary and required behavior; implements no
+> runtime, permission engine, or tool. Provider-agnostic.
+
+## Goal
+
+Give skills a **coarse** way to label the risk of a tool they expect to use, and connect that coarse
+label to the **authoritative** fine-grained taxonomy the harness reasons over.
+
+A skill should not have to choose among fifteen risk classes to declare "I read files and run tests."
+So this document defines a four-class coarse scale for **declaration**, and maps it onto the full
+taxonomy used for **enforcement**.
+
+## Coarse classes (for skill declaration)
+
+Used in the Adaptative Skills per-skill `harness_requirements` (`expected_tools[].risk_class`).
+
+```yaml
+tool_risk_classes:
+  low:
+    examples: [filesystem.read, git.diff, docs.read]
+    default_policy: allow
+  medium:
+    examples: [shell.test, filesystem.write, issue.draft]
+    default_policy: log_or_require_approval_by_context
+  high:
+    examples: [dependency.upgrade, migration.generate, config.modify, external_api.write]
+    default_policy: require_approval
+  critical:
+    examples: [filesystem.delete, database.drop, secret.read, production.deploy, email.send]
+    default_policy: deny_or_require_explicit_approval
+```
+
+## Authoritative taxonomy (for harness enforcement)
+
+The harness does **not** decide on the coarse class. It uses the fifteen-class `risk_class` taxonomy
+and per-class default policy defined in
+[tool-permission-matrix.md](../reference/tool-permission-matrix.md) and the tool registry contract in
+[agent-harness-governance-extension.md](../contracts/agent-harness-governance-extension.md). That
+matrix is the source of truth. This coarse scale is a convenience for declaration, not a replacement.
+
+### Mapping coarse → authoritative
+
+| Coarse (declaration) | Authoritative classes (enforcement) |
+|---|---|
+| `low` | `read_only`, `search_only`, `compute_only`, `draft_only` |
+| `medium` | `write_local`, `write_internal` |
+| `high` | `write_external`, `communication`, `network_open_world`, `process_execution` |
+| `critical` | `financial`, `identity_access`, `security_sensitive`, `destructive`, `privileged_admin` |
+
+When a skill's coarse class and the matrix disagree, **the matrix wins** — the coarse label is a hint,
+the matrix is policy. A coarse `medium` tool that the matrix classes as `destructive` is enforced as
+`destructive`.
+
+## Relationship to risk inference
+
+This taxonomy classes the *tool*. [structured-risk-inference.md](structured-risk-inference.md) reasons
+about the *task/decision* risk that triggers extra scrutiny. Both feed the permission decision; neither
+replaces the other.
+
+## See also
+
+- [tool-permission-matrix.md](../reference/tool-permission-matrix.md) — authoritative classes + default policies.
+- [autonomy-levels.md](autonomy-levels.md) — the orthogonal authority axis.
+- [policy-verdicts.md](../contracts/policy-verdicts.md) — the outcomes a permission decision can take.

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -31,6 +31,8 @@ If you need conceptual background, see [`concepts/`](../concepts/README.md). If 
 | [runtime-effort-governance-contract.md](runtime-effort-governance-contract.md) | How an agent decides runtime effort for a work slice: start, escalate, de-escalate, stop, and human checkpoint |
 | [agent-harness-governance-extension.md](agent-harness-governance-extension.md) | How the harness validates, authorizes, executes, budgets, and returns structured observations for model-proposed actions |
 | [agent-harness-contract.md](agent-harness-contract.md) | The per-task declaration: autonomy, allowed tools/skills, gates, sensors, rollback, human review, context policy |
+| [policy-verdicts.md](policy-verdicts.md) | The verdict vocabulary (allow/deny/require_approval/transform/log_only) and its mapping to harness decision values |
+| [agent-action-audit-record.md](agent-action-audit-record.md) | Minimum audit fields proving skill → tool → verdict → evidence → approval |
 
 ### Operationalized by security checklists
 

--- a/docs/contracts/agent-action-audit-record.md
+++ b/docs/contracts/agent-action-audit-record.md
@@ -1,0 +1,61 @@
+# Agent Action Audit Record
+
+> Posture: `docs_first`, `advisory_first`. Describes a record's required fields; implements no runtime,
+> logger, or storage. Provider-agnostic.
+
+## Goal
+
+Define the **minimum** record that proves what happened when an agent took (or was denied) an action:
+which skill, which task, which tool, what risk, which verdict, what evidence, and whether a human
+approved. "Audit proves" — without this record, a permission decision is just a claim.
+
+## Minimum record
+
+```yaml
+agent_action_audit_record:
+  task_id:
+  agent_id:
+  skill_id:
+  autonomy_level:        # observe | advise | act_with_approval | autonomous_within_bounds
+  tool_name:
+  action_type:
+  risk_class:            # coarse (low|medium|high|critical) or authoritative class
+  policy_version:
+  policy_verdict:        # allow | deny | require_approval | transform | log_only
+  approval_required:
+  approval_by:
+  evidence_refs:
+  knowledge_packs_used:
+  restrictions_applied:
+  timestamp:
+  result_summary:
+```
+
+This is the **minimum** for declaration and review. It is not a new logging system.
+
+## Reconciliation with existing observability
+
+The runtime harness already defines a per-event and per-action record:
+
+- `trace_event` / `minimum_events` in
+  [agent-harness-governance-extension.md](agent-harness-governance-extension.md);
+- the per-action JSON Schema
+  [`agent-harness-governance-record.schema.json`](../../schemas/agent-harness-governance-record.schema.json);
+- knowledge-side logging in [knowledge-audit-log-spec.md](knowledge-audit-log-spec.md);
+- slice-level telemetry in [slice-telemetry-model.md](slice-telemetry-model.md).
+
+This audit record is a **skill-and-policy-oriented view** over those: it names the fields a reviewer
+needs to connect *skill → tool → verdict → evidence → approval*. When emitting real traces, populate
+the governance record/schema; this document says which of those fields are non-negotiable for audit of
+a skill-driven action. Where they overlap, the governance record schema is authoritative for structure.
+
+## Non-negotiable fields
+
+At minimum, a recorded action must carry: `skill_id`, `task_id`, `tool_name`, `policy_verdict`,
+`evidence_refs`, and — when the verdict was `require_approval` — `approval_by`.
+
+## See also
+
+- [policy-verdicts.md](policy-verdicts.md) — the `policy_verdict` values.
+- [agent-harness-governance-extension.md](agent-harness-governance-extension.md) — trace events + record schema.
+- [autonomy-levels.md](../concepts/autonomy-levels.md), [tool-risk-taxonomy.md](../concepts/tool-risk-taxonomy.md).

--- a/docs/contracts/agent-harness-governance-extension.md
+++ b/docs/contracts/agent-harness-governance-extension.md
@@ -417,6 +417,30 @@ To validate the contract and this schema against a **real harness trace** (the d
 step), follow
 [agent-harness-governance-validation-checklist.md](../reference/agent-harness-governance-validation-checklist.md).
 
+## Upstream: per-skill harness requirements
+
+This extension governs execution **per action**. The per-task envelope upstream of it is the
+[Agent Harness Contract](agent-harness-contract.md). Upstream of *that*, a skill can declare what
+envelope it generally needs — a **per-skill** `harness_requirements` block defined in the Adaptative
+Skills repo (`docs/harness-requirements-for-skills.md`, `templates/skill-harness-requirements.yaml`).
+
+The chain is declaration → envelope → enforcement:
+
+```txt
+skill harness_requirements   (per-skill, declares: Adaptative Skills)
+  ↓
+agent harness contract        (per-task, declares envelope: this repo)
+  ↓
+this extension                (per-action, validates/authorizes/records: this repo)
+```
+
+A skill's declaration is **not** authorization. It is an input the per-task contract and this
+extension reconcile against policy. The declaration vocabulary projects onto this extension's richer
+vocabulary: skill `risk_class` → [tool-risk-taxonomy.md](../concepts/tool-risk-taxonomy.md) →
+the registry `risk_class` here; skill `restriction` → [policy-verdicts.md](policy-verdicts.md) →
+the `permission_decision.decision` values here; skill `audit_requirements` →
+[agent-action-audit-record.md](agent-action-audit-record.md) → the `trace_event` model here.
+
 ## Versioning
 
 ```yaml

--- a/docs/contracts/policy-verdicts.md
+++ b/docs/contracts/policy-verdicts.md
@@ -1,0 +1,51 @@
+# Policy Verdicts
+
+> Posture: `docs_first`, `advisory_first`. Describes vocabulary and required behavior; implements no
+> runtime, permission engine, or tool. Provider-agnostic.
+
+## Goal
+
+Name the small set of outcomes a permission decision can produce, so skills, contracts, and audit
+records share one vocabulary. A **verdict** is what the harness decides about a proposed action — it
+is decided *outside* the model and recorded.
+
+## Verdicts (declaration vocabulary)
+
+```yaml
+policy_verdicts:
+  allow:           { meaning: "Action may execute." }
+  deny:            { meaning: "Action must not execute." }
+  require_approval:{ meaning: "Action pauses until explicit human approval." }
+  transform:       { meaning: "Action may execute only after being reduced, masked, scoped, or converted." }
+  log_only:        { meaning: "Action may execute but must be logged due to a traceability requirement." }
+```
+
+These five are the vocabulary a **skill** or reviewer uses to talk about outcomes (e.g. a
+`restricted_tools[].restriction` in a per-skill `harness_requirements`).
+
+## Reconciliation with the harness decision values
+
+The runtime harness emits a richer set of decision values, defined authoritatively in
+[agent-harness-governance-extension.md](agent-harness-governance-extension.md) and
+[tool-permission-matrix.md](../reference/tool-permission-matrix.md):
+`allow, deny, ask_user, approval_required, require_stronger_auth, run_in_sandbox, run_as_draft_only`.
+
+The five verdicts above are a **projection** of those values for declaration and review. Map them:
+
+| Verdict (declaration) | Harness decision value(s) (enforcement) |
+|---|---|
+| `allow` | `allow` |
+| `deny` | `deny` |
+| `require_approval` | `approval_required` (or `require_stronger_auth` for high-risk) |
+| `transform` | `run_as_draft_only`, `run_in_sandbox` (scoped/converted execution) |
+| `log_only` | `allow` **with** `audit_policy: full_structured_event` |
+
+`ask_user` (clarification before deciding) has no declaration-level verdict; it is a harness behavior
+that precedes a verdict. When declaration and harness disagree, the harness decision values govern;
+the verdict vocabulary is for human-readable declaration and audit.
+
+## See also
+
+- [agent-action-audit-record.md](agent-action-audit-record.md) — where the verdict is recorded.
+- [tool-permission-matrix.md](../reference/tool-permission-matrix.md) — decision values + per-class defaults.
+- [tool-risk-taxonomy.md](../concepts/tool-risk-taxonomy.md) — what feeds the verdict.

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,10 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
   - mostra como uma validação real no Crisis Monitor vira endurecimento pequeno e reutilizável no framework
 - `consumer-overlay-minimal/`
   - instância mínima viável do [consumer-project-overlay contract](../docs/contracts/consumer-project-overlay.md) — layout `ops/ai/` + shims Claude prontos para copiar
+- `harness/`
+  - Agent Harness Contracts trabalhados (per-task envelope) para debugging, testing e feature-planning
+- `agent-harness/`
+  - fluxo de **policy/verdict por ação** (allow/deny/require_approval) + audit record, contrastando skill operacional (debugging) vs consultiva (feature-value-governance)
 
 ---
 

--- a/examples/agent-harness/codex-debugging-policy-example.md
+++ b/examples/agent-harness/codex-debugging-policy-example.md
@@ -1,0 +1,83 @@
+# Example — Codex debugging, per-action policy flow
+
+A worked **policy/verdict** walkthrough for a Codex `debugging` task. Where
+[`../harness/codex-debugging-harness.md`](../harness/codex-debugging-harness.md) shows the per-task
+*envelope* (the [Agent Harness Contract](../../docs/contracts/agent-harness-contract.md)), this
+example shows what the harness *decides per action* and *records* — the
+[policy verdicts](../../docs/contracts/policy-verdicts.md) and the
+[audit record](../../docs/contracts/agent-action-audit-record.md).
+
+This is an **operational** skill: it may act, but only with approval at the gates it declared. The
+upstream per-skill declaration is the Adaptative Skills
+`examples/harness-requirements/debugging-harness-requirements.yaml`
+(`autonomy.ceiling: act_with_approval`). All content here is synthetic.
+
+## Three proposed actions, three verdicts
+
+### Action 1 — read a source file (allowed)
+
+```yaml
+proposed_action: { tool: filesystem.read, args: { path: src/parser.ts } }
+risk_class: read_only            # coarse: low
+policy_verdict: allow            # harness decision: allow
+reason: "Read-only inspection, within task scope."
+```
+
+```yaml
+agent_action_audit_record:
+  task_id: debug-issue-001
+  agent_id: codex
+  skill_id: debugging
+  autonomy_level: act_with_approval
+  tool_name: filesystem.read
+  action_type: read
+  risk_class: low
+  policy_verdict: allow
+  approval_required: false
+  evidence_refs: [repro_path]
+  result_summary: "Inspected parser.ts; located the failing branch."
+```
+
+### Action 2 — run the repro test (allowed, logged)
+
+```yaml
+proposed_action: { tool: shell.test, args: { cmd: "pytest tests/test_parser.py -k repro" } }
+risk_class: compute_only         # coarse: medium
+policy_verdict: log_only         # harness: allow + full_structured_event
+reason: "Bounded test execution; logged for traceability."
+```
+
+The verdict is `log_only` — the action runs, but the harness records a full structured event because
+the skill's `audit_requirements.log_tool_calls` is true.
+
+### Action 3 — delete a file (denied → escalated to approval)
+
+```yaml
+proposed_action: { tool: filesystem.delete, args: { path: src/old_parser.ts } }
+risk_class: destructive          # coarse: critical
+policy_verdict: require_approval # harness decision: approval_required
+reason: "Deletion is destructive; the skill declared filesystem.delete as require_approval and a
+         before_destructive_action gate."
+```
+
+```yaml
+agent_action_audit_record:
+  task_id: debug-issue-001
+  skill_id: debugging
+  tool_name: filesystem.delete
+  risk_class: critical
+  policy_verdict: require_approval
+  approval_required: true
+  approval_by: null              # paused, awaiting human
+  result_summary: "Action paused at before_destructive_action gate; not executed."
+```
+
+## What this demonstrates
+
+- An operational skill **acts** (Actions 1–2) but **never bypasses a declared gate** (Action 3).
+- The verdict is decided by the harness, not the skill or the model — the skill only *declared* that
+  `filesystem.delete` is `require_approval`; the harness *enforced* it.
+- Every action leaves an audit record connecting `skill_id → tool → verdict → evidence`.
+
+Contrast with [`feature-value-advise-only-example.md`](feature-value-advise-only-example.md), where a
+**consultative** skill produces a verdict but is never permitted to act.

--- a/examples/agent-harness/feature-value-advise-only-example.md
+++ b/examples/agent-harness/feature-value-advise-only-example.md
@@ -1,0 +1,79 @@
+# Example — Feature Value Governance, advise-only
+
+A worked **policy/verdict** walkthrough for a `feature-value-governance` task. This is a
+**consultative** skill: it produces a governed recommendation and nothing more. It must not look like
+authorization to act — it cannot move the roadmap, create issues, or write project files.
+
+It sits alongside [`../harness/feature-planning-harness.md`](../harness/feature-planning-harness.md),
+which also stays at `advise`. The upstream per-skill declaration is the Adaptative Skills
+`examples/harness-requirements/feature-value-governance-harness-requirements.yaml`
+(`autonomy.floor: advise`, `ceiling: advise`). All content here is synthetic.
+
+## The skill produces a verdict — about the feature, not an action
+
+```yaml
+recommendation:
+  feature: "inline-comments-v2"
+  verdict: advance_with_constraints
+  rationale: "Two of three value slots satisfied; one unsatisfied slot (adoption evidence)."
+  unsatisfied_slots: [adoption_evidence]
+  conflicts_and_resolution: "Cost estimate conflicts with the latest sizing capsule; deferred to PM."
+  review_required: true
+```
+
+This `verdict` is the skill's **output**, not a permission decision. It advises a human; it changes
+nothing.
+
+## Three proposed actions, all blocked from acting
+
+### Action 1 — resolve an authorized knowledge pack (allowed)
+
+```yaml
+proposed_action: { tool: knowledge.resolve, args: { pack: "product-value@1.4" } }
+risk_class: search_only          # coarse: medium
+policy_verdict: allow
+reason: "Reading authorized knowledge is within an advise-level skill."
+```
+
+### Action 2 — update the roadmap (denied)
+
+```yaml
+proposed_action: { tool: roadmap.update, args: { item: "inline-comments-v2", status: "committed" } }
+risk_class: write_internal       # coarse: high
+policy_verdict: deny
+reason: "The skill advises; it does not alter roadmap state. Declared restriction: deny."
+```
+
+### Action 3 — create an issue (require approval)
+
+```yaml
+proposed_action: { tool: issue.create, args: { title: "Build inline-comments-v2" } }
+risk_class: write_external       # coarse: high
+policy_verdict: require_approval
+reason: "Creating work items is an external workflow action; declared restriction: require_approval."
+```
+
+```yaml
+agent_action_audit_record:
+  task_id: fvg-eval-014
+  skill_id: feature-value-governance
+  autonomy_level: advise
+  tool_name: issue.create
+  risk_class: high
+  policy_verdict: require_approval
+  approval_required: true
+  approval_by: null
+  evidence_refs: [source_pack_versions, unsatisfied_slots, verdict_rationale]
+  result_summary: "Recommendation produced; issue creation paused for human approval, not executed."
+```
+
+## What this demonstrates
+
+- A consultative skill **never acts**: its only allowed action is reading authorized knowledge; every
+  state-changing tool is `deny` or `require_approval`.
+- A skill *verdict* ("advance the feature") is **not** a policy *verdict* ("allow the tool"). The two
+  must not be confused — that confusion is exactly what `advise`-only enforcement prevents.
+- The audit record proves the skill produced advice and that no roadmap/issue mutation occurred.
+
+Contrast with [`codex-debugging-policy-example.md`](codex-debugging-policy-example.md), where an
+**operational** skill may act with approval.


### PR DESCRIPTION
## Summary
The AletheIA side of the Agent Harness Enforcement Addendum: the **contracts a harness enforces against** when a skill declares its operating envelope. Docs-first — no runtime, permission engine, or tool implemented. Companion to the Adaptative Skills PR that adds the per-skill `harness_requirements` declaration.

## Approach: reconcile, don't fork
AletheIA already has a *richer superset* of this vocabulary (the 15-class `tool-permission-matrix.md`, 7 permission-decision values, and the `trace_event` audit model). The new docs are **thin projections that defer to those authorities**, with explicit mapping tables and "the matrix/harness wins" rules.

## New files
- **`docs/concepts/autonomy-levels.md`** — the 4 canonical authority levels (from the schema / ADR-013); maps the external 5-level drafts (`bounded_autonomous → autonomous_within_bounds`, unbounded `autonomous` = out of scope).
- **`docs/concepts/tool-risk-taxonomy.md`** — coarse `low/medium/high/critical` classes for declaration, mapped to the authoritative 15-class permission matrix.
- **`docs/contracts/policy-verdicts.md`** — `allow / deny / require_approval / transform / log_only`, mapped to the harness decision values.
- **`docs/contracts/agent-action-audit-record.md`** — minimum `skill → tool → verdict → evidence → approval` record, reconciled with `trace_event` + the governance record schema.
- **`examples/agent-harness/`** — per-action verdict + audit walkthroughs contrasting an **operational** skill (debugging, acts with approval) vs a **consultative** one (feature-value-governance, advise-only).

## Evolved (marked addendum sections, no fork)
- `docs/concepts/enforcement-boundaries.md` — who declares vs who enforces.
- `docs/contracts/agent-harness-governance-extension.md` — per-skill harness requirements as the upstream declaration in the declaration → envelope → enforcement chain.

## Validation
- All 6 new files present; canonical autonomy enum used; posture banner (`docs_first`/`advisory_first`) in all 4 new docs.
- No forbidden dependency/runtime language; no proprietary markers in examples; all 9 cross-links resolve.
- `bash scripts/check-governance.sh` → **Governance baseline passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)