### PR TITLE
feat: EPGP schemas, loop-rule invariants, ADR-015 (phase 5)

### DIFF
--- a/docs/adr/ADR-015-execution-pattern-governance-pack.md
+++ b/docs/adr/ADR-015-execution-pattern-governance-pack.md
@@ -1,0 +1,147 @@
+# ADR 015 — Execution Pattern Governance Pack
+
+| Field | Value |
+|---|---|
+| Status | Accepted |
+| Date | 2026-06-12 |
+| Author | Neviton Santana |
+| Deciders | Neviton Santana |
+| Related | ADR-008 (Knowledge Governance Layer), ADR-009 (Feature Value Governance Pack), ADR-010 (Runtime Effort Governance Contract), ADR-011 (Agent Harness Governance Extension), ADR-013 (Agent Harness Contract), ADR-014 (Harness Enforcement Addendum) |
+| Supersedes | — (replaces the never-built "Loop Engineering Addendum" proposal) |
+
+## 1. Context
+
+The repository governs effort (REGC, ADR-010), the per-task envelope (AHC, ADR-013), per-action
+execution (AHGE, ADR-011/014), and authorized context (Knowledge Governance, ADR-008). None of
+these answer a question that the rise of agentic workflows makes urgent: **which shape of execution
+should this task run in at all?** A single agent? A fan-out with synthesis? An adversarial
+maker-checker pair? A loop?
+
+The pressure is real: external runtimes now make loops and orchestrated workflows cheap to start,
+which creates a default-to-loop failure mode — point tasks become unnecessary automations,
+judgment work gets treated as a technical loop, fan-out without synthesis produces volume without
+decision, and loops without stop conditions burn budget. The external pack that motivated this
+layer began as a "Loop Engineering Addendum" and was deliberately broadened: loop is one execution
+shape among many, and the governing decision is *which shape is proportional*.
+
+A vocabulary risk comes with the references: the primary external source describes vendor-specific
+"dynamic workflows". AletheIA and Adaptative Skills must learn from it without adopting its
+nomenclature as a conceptual dependency.
+
+## 2. Decision
+
+1. **Add an Execution Pattern Governance layer: pattern selection happens before execution, upstream
+   of the AHC.** AletheIA does not decide only which agent or skill to use; it decides **which
+   execution pattern is proportional** to the work type, risk, cost, context, and available
+   verification. The chain becomes:
+
+   ```
+   request → task assessment → execution pattern selection (per-task topology)
+     → orchestration contract (when orchestrated)
+       → AHC (per-task envelope, ADR-013)
+         → skills → AHGE (per-action execution, ADR-011) → audit → human review
+   ```
+
+2. **A ten-pattern, vendor-agnostic library is canonical.** `manual_prompt`, `single_agent`,
+   `classify_and_act`, `fan_out_and_synthesize`, `adversarial_verification`, `generate_and_filter`,
+   `tournament_compare`, `loop_until_done`, `scheduled_stateful_loop`, `human_led_workflow`.
+   Loop is one pattern among ten, never the default. Three orthogonal axes are kept distinct:
+   **pattern = topology**, **mode = depth** (Adaptative Skills), **autonomy = authority** (AHC).
+3. **The loop rule is structural.** A loop is admissible only with an objective stop condition, a
+   budget, persistent state when recurring, an objective gate when artifacts change, and human
+   review before irreversible action. Without an objective gate there is no autonomous loop — the
+   vehicle degrades to a human-led workflow.
+4. **Skills declare compatibility; they do not select or enforce.** The Adaptative Skills repo
+   ships `skill_execution_patterns` declarations (compatible/incompatible patterns with rationales,
+   evidence by pattern, escalation triggers). A skill does not decide alone that it can run in any
+   topology; an agent checker is never the only gate on a critical task (maker-checker policy).
+5. **Reconcile, never duplicate.** The execution audit record is an **extension view** over the
+   AHGE per-action record — no parallel record. Maker-checker outcomes map onto AHGE verdicts.
+   The objective gate policy references AHC `gates`. Selection consumes REGC's classification.
+   Knowledge Governance restricts what loop state may persist.
+6. **Vendor workflow terms are not canonical.** "Dynamic workflow" (and similar vendor terms)
+   appear only in [`external-references-execution-patterns.md`](../reference/external-references-execution-patterns.md).
+7. **Formalize the declarations as optional schemas.** Ship
+   [`execution-pattern-selection.schema.json`](../../schemas/execution-pattern-selection.schema.json)
+   and [`skill-execution-patterns.schema.json`](../../schemas/skill-execution-patterns.schema.json),
+   enforcing the loop rule structurally (invariants 1–4: loop ⇒ gate + budget; recurrence ⇒ state +
+   audit; no verification ⇒ no approved loop; irreversibility ⇒ human review) and the declaration
+   discipline (incompatibility carries a rationale; loop compatibility keeps the
+   `objective_gate_missing` escalation trigger). A vitest suite exercises each invariant.
+   An `orchestration-contract` schema is deferred (see §6).
+
+## 3. Consequences
+
+**Positive**
+- The topology decision becomes explicit, reviewable, and auditable — closing the gap where
+  "make it a loop" happened by default and unreviewed.
+- The loop rule becomes executable in CI, mirroring the REGC/AHC/AHGE schema posture.
+- Judgment work gains protected negative space: feature value review and similar skills declare
+  loop patterns inadmissible with recorded rationales.
+- The framework stays additive and vendor-neutral; existing contracts are referenced, not changed.
+
+**Negative / accepted tradeoffs**
+- A fourth governance artifact per task (selection + AHC + AHGE record + audit) raises declaration
+  overhead. Accepted: proportionality applies to governance itself — `manual_prompt` and
+  `single_agent` selections are one-screen declarations.
+- The schemas validate declarations, not behavior; a runtime must still honor them. Same posture
+  as REGC/AHC/AHGE.
+- Comprehension debt review remains a discipline, not an enforcement — it depends on humans
+  actually reading.
+
+## 4. Alternatives considered
+
+- **Keep the original "Loop Engineering Addendum" scope.** Rejected: it would canonize loop as the
+  center of the system; loop engineering survives as a subset (`loop_until_done`,
+  `scheduled_stateful_loop`).
+- **Adopt the external "dynamic workflows" vocabulary.** Rejected: vendor coupling in canonical
+  language; the abstraction (execution patterns) survives vendor churn.
+- **Fold pattern selection into the AHC.** Rejected: the AHC declares the envelope of a task whose
+  shape is already chosen; conflating topology selection with envelope declaration would blur the
+  selection-before-envelope boundary (same reasoning that kept AHC separate from AHGE in ADR-013).
+- **A domain pack instead of a cross-domain layer.** Rejected: the existing
+  product-value-governance orchestration pattern is domain-specific; topology selection applies to
+  engineering, research, and governance work alike.
+- **An orchestration runtime or scheduler.** Rejected: docs-first phase; no runtime, no scheduler,
+  no policy engine, no real automation.
+
+## 5. Relationship
+
+- Sits upstream of ADR-013 (AHC) and composes with ADR-010 (REGC, effort), ADR-011/014 (AHGE,
+  execution + verdicts), and ADR-008 (Knowledge Governance, context and state restrictions).
+- Concepts: [`execution-pattern-governance.md`](../concepts/execution-pattern-governance.md),
+  [`execution-pattern-library.md`](../concepts/execution-pattern-library.md),
+  [`execution-vehicle-selection.md`](../concepts/execution-vehicle-selection.md),
+  [`comprehension-debt.md`](../concepts/comprehension-debt.md).
+- Contracts: [`execution-pattern-selection.md`](../contracts/execution-pattern-selection.md),
+  [`orchestration-contract.md`](../contracts/orchestration-contract.md),
+  [`loop-state-contract.md`](../contracts/loop-state-contract.md),
+  [`objective-gate-policy.md`](../contracts/objective-gate-policy.md),
+  [`maker-checker-policy.md`](../contracts/maker-checker-policy.md),
+  [`execution-audit-record.md`](../contracts/execution-audit-record.md).
+- Examples: `examples/execution-patterns/` (four worked selections + JSON fixtures).
+- Schemas + tests:
+  [`execution-pattern-selection.schema.json`](../../schemas/execution-pattern-selection.schema.json),
+  [`skill-execution-patterns.schema.json`](../../schemas/skill-execution-patterns.schema.json),
+  `tests/contracts/test-execution-pattern-selection.test.ts`,
+  `tests/contracts/test-skill-execution-patterns.test.ts`.
+- Counterpart in the Adaptative Skills repo: `docs/execution-patterns-for-skills.md`,
+  `docs/looping-models-for-skills.md`, `docs/skills-in-orchestrated-workflows.md`,
+  `docs/pattern-compatibility-guidelines.md`, `templates/skill-execution-patterns.yaml`,
+  `templates/orchestration-step-requirements.yaml`, `examples/execution-patterns/`.
+- External references evaluated:
+  [`external-references-execution-patterns.md`](../reference/external-references-execution-patterns.md).
+- Adds docs + optional declaration schemas only; modifies no existing contract.
+
+## 6. Review
+
+Revisit this ADR when any of the following becomes true:
+
+- Real task traces show pattern selection is too heavy for small tasks or too thin for orchestrated
+  ones (live validation on ≥2 real slices is deferred, mirroring ADR-013 §6).
+- The ten-pattern library needs a new pattern or a split — additions require worked examples and at
+  least one real selection that did not fit.
+- An `orchestration-contract.schema.json` becomes justified by real orchestrated runs (deferred in
+  this phase).
+- Comprehension-debt reviews show the declaration exists but is not read — then the discipline,
+  not the schema, needs redesign.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -76,3 +76,4 @@ Do *not* write one for:
 | [ADR-012](ADR-012-resource-aware-signal-validation.md) | Resource-Aware Signal Validation Layer | Accepted |
 | [ADR-013](ADR-013-agent-harness-contract.md) | Agent Harness Contract (per-task declaration) | Accepted |
 | [ADR-014](ADR-014-harness-enforcement-addendum.md) | Harness Enforcement Addendum: vocabulary reconciliation | Accepted |
+| [ADR-015](ADR-015-execution-pattern-governance-pack.md) | Execution Pattern Governance Pack | Accepted |

--- a/docs/concepts/execution-pattern-governance.md
+++ b/docs/concepts/execution-pattern-governance.md
@@ -78,6 +78,7 @@ unit is allowed to do (autonomy) — those are declared on their own axes.
 
 ## Related
 
+- [ADR-015](../adr/ADR-015-execution-pattern-governance-pack.md) — the decision record for this layer
 - [Execution Pattern Library](execution-pattern-library.md) — the ten patterns and the selection rules
 - [Execution Vehicle Selection](execution-vehicle-selection.md) — vehicle vs. pattern, proportionality
 - [Comprehension Debt](comprehension-debt.md) — the cost of generating more than anyone reads

--- a/docs/contracts/execution-pattern-selection.md
+++ b/docs/contracts/execution-pattern-selection.md
@@ -108,6 +108,8 @@ record stay with the [Agent Harness Governance Extension](agent-harness-governan
 
 ## Related
 
+- [ADR-015](../adr/ADR-015-execution-pattern-governance-pack.md) — the decision record for this layer
+- [Execution Pattern Selection schema](../../schemas/execution-pattern-selection.schema.json) — optional structured validation (loop-rule invariants)
 - [Execution Pattern Governance](../concepts/execution-pattern-governance.md) — concept and three-axis distinction
 - [Execution Pattern Library](../concepts/execution-pattern-library.md) — the ten patterns and selection rules
 - [Execution Vehicle Selection](../concepts/execution-vehicle-selection.md) — vehicle vs pattern, proportionality

--- a/examples/execution-patterns/fixtures/execution-pattern-selection-ci-triage.json
+++ b/examples/execution-patterns/fixtures/execution-pattern-selection-ci-triage.json
@@ -1,0 +1,40 @@
+{
+  "task_id": "ci-triage-2026-w23",
+  "task": "triage new CI failures, classify by failure type, route to owner or fix queue",
+  "work_type": "engineering",
+  "task_shape": {
+    "repeated": true,
+    "decomposable": true,
+    "independent_units": true,
+    "stages_depend_on_previous_output": false,
+    "requires_judgment": "low",
+    "objective_verification_available": true,
+    "state_required": true
+  },
+  "risk": {
+    "risk_level": "medium",
+    "touches_sensitive_context": false,
+    "external_side_effect": false,
+    "irreversible_action_possible": false
+  },
+  "recommended_vehicle": {
+    "type": "loop",
+    "rationale": "recurring work with uncertain volume per run; each run is bounded and restartable"
+  },
+  "recommended_pattern": {
+    "type": "scheduled_stateful_loop",
+    "rationale": "recurrence plus persistent triage state; each run opens with a classify_and_act stage that types the failure before routing it"
+  },
+  "required_controls": {
+    "state_required": true,
+    "objective_gate_required": true,
+    "maker_checker_required": false,
+    "human_review_required": false,
+    "token_budget_required": true,
+    "audit_record_required": true
+  },
+  "decision": {
+    "verdict": "approved_with_constraints",
+    "notes": "approved while the stop condition holds: a run ends when the new-failure queue is empty or the budget is reached; any action beyond classification and routing escalates to human review"
+  }
+}

--- a/examples/execution-patterns/fixtures/skill-execution-patterns-debugging.json
+++ b/examples/execution-patterns/fixtures/skill-execution-patterns-debugging.json
@@ -1,0 +1,45 @@
+{
+  "skill_id": "debugging",
+  "version": "0.1.0",
+  "compatible_patterns": [
+    {
+      "pattern": "classify_and_act",
+      "conditions": "Classify failure type before selecting fix path.",
+      "required_controls": ["evidence_required"]
+    },
+    {
+      "pattern": "loop_until_done",
+      "conditions": "Only when tests or repro commands provide objective stop condition.",
+      "required_controls": ["objective_gate_required", "max_iterations", "human_review_before_merge"]
+    },
+    {
+      "pattern": "adversarial_verification",
+      "conditions": "Separate verifier checks root cause and recurrence guard.",
+      "required_controls": ["maker_checker_required"]
+    }
+  ],
+  "incompatible_patterns": [
+    {
+      "pattern": "tournament_compare",
+      "rationale": "Usually excessive for ordinary debugging unless root cause hypotheses conflict."
+    }
+  ],
+  "required_evidence_by_pattern": {
+    "classify_and_act": { "evidence": ["failure_classification", "repro_command"] },
+    "loop_until_done": { "evidence": ["failing_test", "passing_run", "iteration_count"] },
+    "adversarial_verification": { "evidence": ["root_cause_statement", "recurrence_guard"] }
+  },
+  "escalation_triggers": [
+    "objective_gate_missing",
+    "touches_sensitive_area",
+    "judgment_required",
+    "recurring_failure",
+    "comprehension_debt_risk"
+  ],
+  "audit_requirements": {
+    "log_skill_id": true,
+    "log_pattern": true,
+    "log_controls": true,
+    "log_evidence_refs": true
+  }
+}

--- a/examples/execution-patterns/fixtures/skill-execution-patterns-feature-value.json
+++ b/examples/execution-patterns/fixtures/skill-execution-patterns-feature-value.json
@@ -1,0 +1,49 @@
+{
+  "skill_id": "feature-value-governance",
+  "version": "0.1.0",
+  "compatible_patterns": [
+    {
+      "pattern": "adversarial_verification",
+      "conditions": "Review feature rationale against evidence, constraints and value contract.",
+      "required_controls": ["source_trace_required", "human_review_required"]
+    },
+    {
+      "pattern": "generate_and_filter",
+      "conditions": "Generate alternatives, then filter by revenue lever, evidence and complexity cost.",
+      "required_controls": ["explicit_filter_criteria", "audit_record_required"]
+    },
+    {
+      "pattern": "tournament_compare",
+      "conditions": "Compare strategic options with explicit trade-offs.",
+      "required_controls": ["human_final_decision"]
+    }
+  ],
+  "incompatible_patterns": [
+    {
+      "pattern": "loop_until_done",
+      "rationale": "Feature judgment does not have objective stop condition."
+    },
+    {
+      "pattern": "scheduled_stateful_loop",
+      "rationale": "Recurring automated roadmap action would create governance risk."
+    }
+  ],
+  "required_evidence_by_pattern": {
+    "adversarial_verification": { "evidence": ["value_contract_reference", "evidence_trace"] },
+    "generate_and_filter": { "evidence": ["alternatives_generated", "filter_criteria", "survivor_rationale"] },
+    "tournament_compare": { "evidence": ["compared_options", "trade_off_record", "human_decision_ref"] }
+  },
+  "escalation_triggers": [
+    "objective_gate_missing",
+    "touches_sensitive_area",
+    "judgment_required",
+    "recurring_failure",
+    "comprehension_debt_risk"
+  ],
+  "audit_requirements": {
+    "log_skill_id": true,
+    "log_pattern": true,
+    "log_controls": true,
+    "log_evidence_refs": true
+  }
+}

--- a/schemas/execution-pattern-selection.schema.json
+++ b/schemas/execution-pattern-selection.schema.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia.local/schemas/execution-pattern-selection.schema.json",
+  "title": "Execution Pattern Selection (per-task declaration)",
+  "description": "Optional structured record for the per-task Execution Pattern Selection (docs/contracts/execution-pattern-selection.md). Filled before execution and upstream of the Agent Harness Contract: it declares the task shape, the risk, the recommended execution vehicle and pattern with rationales, the required controls, and a selection verdict. The schema does not select or execute; it forces the declaration to be explicit and enforces the loop rule structurally: loop patterns require an objective gate and a budget; a scheduled stateful loop additionally requires state and an audit record; a loop without available objective verification cannot be approved; irreversible action requires human review.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "task_id",
+    "task",
+    "work_type",
+    "task_shape",
+    "risk",
+    "recommended_vehicle",
+    "recommended_pattern",
+    "required_controls",
+    "decision"
+  ],
+  "$defs": {
+    "work_type": {
+      "type": "string",
+      "enum": ["engineering", "product", "research", "design", "governance", "communication", "operations"]
+    },
+    "judgment_level": { "type": "string", "enum": ["low", "medium", "high"] },
+    "risk_level": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+    "vehicle": {
+      "type": "string",
+      "enum": ["manual_prompt", "single_agent", "orchestrated_workflow", "loop", "human_led_workflow"]
+    },
+    "pattern": {
+      "type": "string",
+      "enum": [
+        "manual_prompt",
+        "single_agent",
+        "classify_and_act",
+        "fan_out_and_synthesize",
+        "adversarial_verification",
+        "generate_and_filter",
+        "tournament_compare",
+        "loop_until_done",
+        "scheduled_stateful_loop",
+        "human_led_workflow"
+      ]
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["approved", "approved_with_constraints", "rejected", "human_led_required"]
+    }
+  },
+  "properties": {
+    "task_id": { "type": "string", "minLength": 1 },
+    "task": { "type": "string", "minLength": 1 },
+    "work_type": { "$ref": "#/$defs/work_type" },
+    "task_shape": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repeated",
+        "decomposable",
+        "independent_units",
+        "stages_depend_on_previous_output",
+        "requires_judgment",
+        "objective_verification_available",
+        "state_required"
+      ],
+      "properties": {
+        "repeated": { "type": "boolean" },
+        "decomposable": { "type": "boolean" },
+        "independent_units": { "type": "boolean" },
+        "stages_depend_on_previous_output": { "type": "boolean" },
+        "requires_judgment": { "$ref": "#/$defs/judgment_level" },
+        "objective_verification_available": { "type": "boolean" },
+        "state_required": { "type": "boolean" }
+      }
+    },
+    "risk": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["risk_level", "touches_sensitive_context", "external_side_effect", "irreversible_action_possible"],
+      "properties": {
+        "risk_level": { "$ref": "#/$defs/risk_level" },
+        "touches_sensitive_context": { "type": "boolean" },
+        "external_side_effect": { "type": "boolean" },
+        "irreversible_action_possible": { "type": "boolean" }
+      }
+    },
+    "recommended_vehicle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "rationale"],
+      "properties": {
+        "type": { "$ref": "#/$defs/vehicle" },
+        "rationale": { "type": "string", "minLength": 1 }
+      }
+    },
+    "recommended_pattern": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "rationale"],
+      "properties": {
+        "type": { "$ref": "#/$defs/pattern" },
+        "rationale": { "type": "string", "minLength": 1 }
+      }
+    },
+    "required_controls": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state_required",
+        "objective_gate_required",
+        "maker_checker_required",
+        "human_review_required",
+        "token_budget_required",
+        "audit_record_required"
+      ],
+      "properties": {
+        "state_required": { "type": "boolean" },
+        "objective_gate_required": { "type": "boolean" },
+        "maker_checker_required": { "type": "boolean" },
+        "human_review_required": { "type": "boolean" },
+        "token_budget_required": { "type": "boolean" },
+        "audit_record_required": { "type": "boolean" }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verdict"],
+      "properties": {
+        "verdict": { "$ref": "#/$defs/verdict" },
+        "notes": { "type": "string" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "Invariant 1 — loop patterns inherit the loop rule: loop_until_done or scheduled_stateful_loop requires an objective gate and a budget. Encodes the Objective Gate Policy preconditions (a) and (b).",
+      "if": {
+        "properties": {
+          "recommended_pattern": {
+            "properties": { "type": { "enum": ["loop_until_done", "scheduled_stateful_loop"] } },
+            "required": ["type"]
+          }
+        },
+        "required": ["recommended_pattern"]
+      },
+      "then": {
+        "properties": {
+          "required_controls": {
+            "properties": {
+              "objective_gate_required": { "const": true },
+              "token_budget_required": { "const": true }
+            },
+            "required": ["objective_gate_required", "token_budget_required"]
+          }
+        },
+        "required": ["required_controls"]
+      }
+    },
+    {
+      "$comment": "Invariant 2 — recurrence requires state and audit: scheduled_stateful_loop must declare state_required and audit_record_required. Encodes Objective Gate Policy precondition (c) and the audit duty of recurring loops.",
+      "if": {
+        "properties": {
+          "recommended_pattern": {
+            "properties": { "type": { "const": "scheduled_stateful_loop" } },
+            "required": ["type"]
+          }
+        },
+        "required": ["recommended_pattern"]
+      },
+      "then": {
+        "properties": {
+          "required_controls": {
+            "properties": {
+              "state_required": { "const": true },
+              "audit_record_required": { "const": true }
+            },
+            "required": ["state_required", "audit_record_required"]
+          }
+        },
+        "required": ["required_controls"]
+      }
+    },
+    {
+      "$comment": "Invariant 3 — no verification, no autonomous loop: if objective verification is not available and a loop pattern is recommended, the verdict cannot approve it — only rejected or human_led_required are admissible.",
+      "if": {
+        "properties": {
+          "task_shape": {
+            "properties": { "objective_verification_available": { "const": false } },
+            "required": ["objective_verification_available"]
+          },
+          "recommended_pattern": {
+            "properties": { "type": { "enum": ["loop_until_done", "scheduled_stateful_loop"] } },
+            "required": ["type"]
+          }
+        },
+        "required": ["task_shape", "recommended_pattern"]
+      },
+      "then": {
+        "properties": {
+          "decision": {
+            "properties": { "verdict": { "enum": ["rejected", "human_led_required"] } },
+            "required": ["verdict"]
+          }
+        },
+        "required": ["decision"]
+      }
+    },
+    {
+      "$comment": "Invariant 4 — irreversibility requires human review: if irreversible action is possible, human_review_required must be true. Encodes Objective Gate Policy precondition (e) at selection time.",
+      "if": {
+        "properties": {
+          "risk": {
+            "properties": { "irreversible_action_possible": { "const": true } },
+            "required": ["irreversible_action_possible"]
+          }
+        },
+        "required": ["risk"]
+      },
+      "then": {
+        "properties": {
+          "required_controls": {
+            "properties": { "human_review_required": { "const": true } },
+            "required": ["human_review_required"]
+          }
+        },
+        "required": ["required_controls"]
+      }
+    }
+  ]
+}

--- a/schemas/skill-execution-patterns.schema.json
+++ b/schemas/skill-execution-patterns.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aletheia.local/schemas/skill-execution-patterns.schema.json",
+  "title": "Skill Execution Patterns (per-skill compatibility declaration)",
+  "description": "Optional structured record for the per-skill execution pattern compatibility declaration shipped by the Adaptative Skills repo (templates/skill-execution-patterns.yaml there; docs/contracts/execution-pattern-selection.md here). A skill declares which execution patterns it can and cannot run in, with conditions, required controls, evidence by pattern, escalation triggers, and audit duties. The schema does not select or enforce; it makes the declaration explicit and enforces structurally that incompatibility carries a rationale, that compatible patterns name at least one control, and that any loop compatibility keeps the objective_gate_missing escalation trigger.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "skill_id",
+    "version",
+    "compatible_patterns",
+    "incompatible_patterns",
+    "escalation_triggers",
+    "audit_requirements"
+  ],
+  "$defs": {
+    "pattern": {
+      "type": "string",
+      "enum": [
+        "manual_prompt",
+        "single_agent",
+        "classify_and_act",
+        "fan_out_and_synthesize",
+        "adversarial_verification",
+        "generate_and_filter",
+        "tournament_compare",
+        "loop_until_done",
+        "scheduled_stateful_loop",
+        "human_led_workflow"
+      ]
+    }
+  },
+  "properties": {
+    "skill_id": { "type": "string", "minLength": 1 },
+    "version": { "type": "string", "minLength": 1 },
+    "compatible_patterns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["pattern", "conditions", "required_controls"],
+        "properties": {
+          "pattern": { "$ref": "#/$defs/pattern" },
+          "conditions": { "type": "string", "minLength": 1 },
+          "required_controls": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "incompatible_patterns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["pattern", "rationale"],
+        "properties": {
+          "pattern": { "$ref": "#/$defs/pattern" },
+          "rationale": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "required_evidence_by_pattern": {
+      "type": "object",
+      "propertyNames": { "$ref": "#/$defs/pattern" },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["evidence"],
+        "properties": {
+          "evidence": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "escalation_triggers": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "audit_requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["log_skill_id", "log_pattern", "log_controls", "log_evidence_refs"],
+      "properties": {
+        "log_skill_id": { "type": "boolean" },
+        "log_pattern": { "type": "boolean" },
+        "log_controls": { "type": "boolean" },
+        "log_evidence_refs": { "type": "boolean" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "Invariant 1 — loop compatibility keeps its escape hatch: a skill declaring compatibility with loop_until_done or scheduled_stateful_loop must keep objective_gate_missing among its escalation triggers, so a run with no objective gate routes back instead of looping anyway.",
+      "if": {
+        "properties": {
+          "compatible_patterns": {
+            "contains": {
+              "properties": { "pattern": { "enum": ["loop_until_done", "scheduled_stateful_loop"] } },
+              "required": ["pattern"]
+            }
+          }
+        },
+        "required": ["compatible_patterns"]
+      },
+      "then": {
+        "properties": {
+          "escalation_triggers": {
+            "contains": { "const": "objective_gate_missing" }
+          }
+        },
+        "required": ["escalation_triggers"]
+      }
+    }
+  ]
+}

--- a/tests/contracts/test-execution-pattern-selection.test.ts
+++ b/tests/contracts/test-execution-pattern-selection.test.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { validateAgainstSchema, SchemaValidationError } from "../../engine";
+
+const schemasDir = path.resolve(process.cwd(), "schemas");
+const schemaPath = path.join(schemasDir, "execution-pattern-selection.schema.json");
+const fixturePath = path.resolve(
+  process.cwd(),
+  "examples/execution-patterns/fixtures/execution-pattern-selection-ci-triage.json",
+);
+
+function loadFixture(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(fixturePath, "utf-8")) as Record<string, unknown>;
+}
+
+describe("Execution Pattern Selection (per-task declaration)", () => {
+  it("validates the realistic CI triage selection against the schema", () => {
+    const data = loadFixture();
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a pattern outside the ten-pattern library", () => {
+    const data = loadFixture();
+    (data.recommended_pattern as Record<string, unknown>).type = "dynamic_workflow";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a vehicle outside the five-vehicle enum", () => {
+    const data = loadFixture();
+    (data.recommended_vehicle as Record<string, unknown>).type = "swarm";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a verdict outside the four selection verdicts", () => {
+    const data = loadFixture();
+    (data.decision as Record<string, unknown>).verdict = "allow";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a missing pattern rationale", () => {
+    const data = loadFixture();
+    (data.recommended_pattern as Record<string, unknown>).rationale = "";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a loop pattern without an objective gate (invariant 1)", () => {
+    const data = loadFixture();
+    (data.required_controls as Record<string, unknown>).objective_gate_required = false;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a loop pattern without a token budget (invariant 1)", () => {
+    const data = loadFixture();
+    (data.required_controls as Record<string, unknown>).token_budget_required = false;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a non-loop pattern without gate or budget controls (invariant 1 not triggered)", () => {
+    const data = loadFixture();
+    (data.recommended_pattern as Record<string, unknown>).type = "classify_and_act";
+    (data.required_controls as Record<string, unknown>).objective_gate_required = false;
+    (data.required_controls as Record<string, unknown>).token_budget_required = false;
+    (data.required_controls as Record<string, unknown>).state_required = false;
+    (data.required_controls as Record<string, unknown>).audit_record_required = false;
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a scheduled stateful loop without persistent state (invariant 2)", () => {
+    const data = loadFixture();
+    (data.required_controls as Record<string, unknown>).state_required = false;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a scheduled stateful loop without an audit record (invariant 2)", () => {
+    const data = loadFixture();
+    (data.required_controls as Record<string, unknown>).audit_record_required = false;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects an approved loop when no objective verification is available (invariant 3)", () => {
+    const data = loadFixture();
+    (data.task_shape as Record<string, unknown>).objective_verification_available = false;
+    // verdict stays approved_with_constraints -> inadmissible for a loop without verification
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a loop without verification when the verdict degrades to human_led_required (invariant 3)", () => {
+    const data = loadFixture();
+    (data.task_shape as Record<string, unknown>).objective_verification_available = false;
+    (data.decision as Record<string, unknown>).verdict = "human_led_required";
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects irreversible action without human review (invariant 4)", () => {
+    const data = loadFixture();
+    (data.risk as Record<string, unknown>).irreversible_action_possible = true;
+    // human_review_required stays false -> inadmissible
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts irreversible action when human review is required (invariant 4 satisfied)", () => {
+    const data = loadFixture();
+    (data.risk as Record<string, unknown>).irreversible_action_possible = true;
+    (data.required_controls as Record<string, unknown>).human_review_required = true;
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+});

--- a/tests/contracts/test-skill-execution-patterns.test.ts
+++ b/tests/contracts/test-skill-execution-patterns.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { validateAgainstSchema, SchemaValidationError } from "../../engine";
+
+const schemasDir = path.resolve(process.cwd(), "schemas");
+const schemaPath = path.join(schemasDir, "skill-execution-patterns.schema.json");
+const fixturesDir = path.resolve(process.cwd(), "examples/execution-patterns/fixtures");
+
+function loadFixture(name: string): Record<string, unknown> {
+  return JSON.parse(
+    fs.readFileSync(path.join(fixturesDir, name), "utf-8"),
+  ) as Record<string, unknown>;
+}
+
+describe("Skill Execution Patterns (per-skill compatibility declaration)", () => {
+  it("validates the debugging skill declaration (operational, loop-compatible)", () => {
+    const data = loadFixture("skill-execution-patterns-debugging.json");
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("validates the feature-value-governance declaration (judgment skill, loops incompatible)", () => {
+    const data = loadFixture("skill-execution-patterns-feature-value.json");
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects a compatible pattern outside the ten-pattern library", () => {
+    const data = loadFixture("skill-execution-patterns-debugging.json");
+    (data.compatible_patterns as Array<Record<string, unknown>>)[0].pattern = "ultra_loop";
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects a compatible pattern with no required controls", () => {
+    const data = loadFixture("skill-execution-patterns-debugging.json");
+    (data.compatible_patterns as Array<Record<string, unknown>>)[0].required_controls = [];
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects an incompatible pattern without a rationale", () => {
+    const data = loadFixture("skill-execution-patterns-feature-value.json");
+    delete (data.incompatible_patterns as Array<Record<string, unknown>>)[0].rationale;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects loop compatibility without the objective_gate_missing escalation trigger (invariant 1)", () => {
+    const data = loadFixture("skill-execution-patterns-debugging.json");
+    data.escalation_triggers = ["touches_sensitive_area", "judgment_required"];
+    // debugging declares loop_until_done compatibility -> the escape hatch is mandatory
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("accepts a loop-free declaration without the objective_gate_missing trigger (invariant 1 not triggered)", () => {
+    const data = loadFixture("skill-execution-patterns-feature-value.json");
+    data.escalation_triggers = ["judgment_required", "comprehension_debt_risk"];
+    // no loop pattern among compatible_patterns -> trigger not structurally required
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("rejects an evidence map keyed by a non-library pattern", () => {
+    const data = loadFixture("skill-execution-patterns-debugging.json");
+    (data.required_evidence_by_pattern as Record<string, unknown>).dynamic_workflow = {
+      evidence: ["anything"],
+    };
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects an audit block missing log_pattern", () => {
+    const data = loadFixture("skill-execution-patterns-debugging.json");
+    delete (data.audit_requirements as Record<string, unknown>).log_pattern;
+    expect(() => validateAgainstSchema(data, schemaPath)).toThrow(SchemaValidationError);
+  });
+});


### PR DESCRIPTION
## Summary

Formalizes the Execution Pattern Governance declarations from #191 as **optional JSON Schemas** (Draft 2020-12) with the loop rule enforced structurally, plus **ADR-015** recording the layer decision. Stacked on #191 (base = `feat/execution-pattern-governance-docs`); GitHub will retarget to `main` when #191 merges.

### Schemas (`schemas/`)
- `execution-pattern-selection.schema.json` — per-task selection declaration. Invariants:
  1. loop pattern ⇒ `objective_gate_required` + `token_budget_required`
  2. `scheduled_stateful_loop` ⇒ `state_required` + `audit_record_required`
  3. no objective verification + loop pattern ⇒ verdict must be `rejected` or `human_led_required`
  4. `irreversible_action_possible` ⇒ `human_review_required`
- `skill-execution-patterns.schema.json` — per-skill compatibility declaration (validates the Adaptative Skills YAMLs from adaptive-skills#63). Invariants: incompatibility carries a rationale; compatible patterns name ≥1 control; loop compatibility keeps the `objective_gate_missing` escalation trigger; evidence map keys restricted to the ten-pattern enum.

### Tests + fixtures
- `tests/contracts/test-execution-pattern-selection.test.ts` (14 cases) and `test-skill-execution-patterns.test.ts` (9 cases) — positive + negative per invariant
- 3 realistic JSON fixtures in `examples/execution-patterns/fixtures/` (CI triage selection; debugging and feature-value skill declarations)
- **173/173 tests green** (150 existing + 23 new); `pnpm check:governance` passes

### ADR
- `docs/adr/ADR-015-execution-pattern-governance-pack.md` — pattern selection upstream of the AHC; ten-pattern library; loop one among ten; reconcile-never-duplicate (audit = extension view over the AHGE record); vendor terms confined to the external-references doc; `orchestration-contract` schema explicitly deferred (§6). ADR index updated.

Mirrors the AHC cadence (#185): docs PR first, schema/ADR PR second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)