### PR TITLE
feat(visual-ops): add GitHub PR projector

### DIFF
--- a/docs/guides/github-pr-visual-operations-projector.md
+++ b/docs/guides/github-pr-visual-operations-projector.md
@@ -1,0 +1,82 @@
+# GitHub PR Visual Operations Projector
+
+## Purpose
+
+The GitHub PR projector is a small, deterministic adapter that turns explicitly supplied pull
+request evidence into:
+
+- normalized Visual Operations events;
+- one derived Work Slice visual state;
+- a list of bounded follow-up slices for post-close findings;
+- an optional Markdown snapshot.
+
+It is a read-only library function. It does not call GitHub, mutate a pull request, persist records,
+run a backend, or become a new source of truth.
+
+## Public functions
+
+```ts
+import {
+  projectGitHubPullRequest,
+  renderGitHubPullRequestProjectionMarkdown,
+} from "./engine";
+
+const projection = projectGitHubPullRequest(input);
+const markdown = renderGitHubPullRequestProjectionMarkdown(projection);
+```
+
+The input must be assembled from already authorized evidence. The projector accepts metadata,
+timestamps, summaries, and source URLs; it intentionally has no field for full prompts, secrets,
+restricted source bodies, or personal data beyond the explicitly supplied actor labels.
+
+## Conservative derivation rules
+
+1. A merged or authoritatively closed PR projects to the `closed` presentation lane.
+2. A post-close finding creates an alert and a linked follow-up Work Slice identifier; it does not
+   reopen or rewrite the historical lane.
+3. Required CI checks that all passed may support `evidence_status: sufficient` only when the PR is
+   merged. Before merge, the same evidence remains `partial`.
+4. CI checks use `provenance: ci_observed`. Local validations supplied from PR prose use
+   `provenance: author_reported` and are never promoted to CI evidence.
+5. Risk, planning depth, readiness, skill activation, runtime, tokens, and cost remain `unknown` or
+   `unavailable` unless a future authorized adapter supplies durable records for them.
+6. Every normalized event, evidence item, alert, follow-up slice, and derived state includes source
+   references.
+
+## Input boundary
+
+The TypeScript interface `GitHubPullRequestProjectionInput` accepts:
+
+- repository and PR metadata;
+- selected PR timeline events;
+- check-run outcomes;
+- review summaries;
+- bounded finding summaries;
+- explicitly labeled author-reported validations.
+
+The projector validates required IDs, timestamps, and source references. It does not verify remote
+URLs or infer omitted data from a PR body.
+
+## Reproducible example
+
+- [Input evidence](../../examples/visual-operations/github-pr-projector-input.json)
+- [Projected JSON](../../examples/visual-operations/github-pr-projector-output.json)
+- [Projected Markdown](../../examples/visual-operations/github-pr-projector-output.md)
+- [Field-evidence retrospective](../pilots/visual-operations-pr-193-retrospective.md)
+
+The example uses the durable evidence already documented for PR #193. Tests regenerate the
+projection in memory and compare it with both checked-in outputs.
+
+## Non-goals
+
+- no GitHub API client or importer;
+- no webhook, polling loop, event bus, database, or dashboard runtime;
+- no canonical lifecycle or readiness authority;
+- no automatic risk, planning-depth, skill, token, or cost inference;
+- no integration with Adaptive Skills in this slice.
+
+## Related
+
+- [Visual Operations Event Model](../contracts/visual-operations-event-model.md)
+- [Work Slice Visual State Contract](../contracts/work-slice-visual-state-contract.md)
+- [Visual Operations Privacy Boundaries](../contracts/visual-ops-privacy-boundaries.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@ Reading map organized by intent. Each entry links to the most useful starting po
 4. [Work Slice Visual State Contract](contracts/work-slice-visual-state-contract.md) — presentation lanes without a new lifecycle
 5. [Visual Operations Privacy Boundaries](contracts/visual-ops-privacy-boundaries.md) — metadata-first handling of sensitive sources
 6. [Synthetic Mission Control example](../examples/visual-operations/dashboard-snapshot.md) — reconstructible static snapshot
+7. [GitHub PR projector](guides/github-pr-visual-operations-projector.md) — deterministic JSON and Markdown projection from supplied evidence
 
 ---
 

--- a/engine/index.ts
+++ b/engine/index.ts
@@ -14,3 +14,4 @@ export * from "./registry";
 export * from "./resolver";
 export * from "./context-pack";
 export * from "./audit-log";
+export * from "./visual-operations-projector";

--- a/engine/visual-operations-projector.ts
+++ b/engine/visual-operations-projector.ts
@@ -1,0 +1,659 @@
+export type GitHubCheckConclusion =
+  | "success"
+  | "failure"
+  | "cancelled"
+  | "timed_out"
+  | "action_required"
+  | "neutral"
+  | "skipped"
+  | "unknown";
+
+export interface GitHubProjectorSourceRef {
+  kind: string;
+  ref: string;
+}
+
+export interface GitHubPullRequestProjectionInput {
+  project_id: string;
+  projected_at: string;
+  repository: {
+    full_name: string;
+    url: string;
+  };
+  pull_request: {
+    number: number;
+    title: string;
+    url: string;
+    state: "open" | "closed";
+    draft: boolean;
+    author: string;
+    created_at: string;
+    merged_at?: string;
+    closed_at?: string;
+    head_sha: string;
+    base_ref: string;
+  };
+  timeline?: Array<{
+    id: string;
+    type: "ready_for_review" | "converted_to_draft" | "merged" | "closed" | "reopened";
+    created_at: string;
+    actor: string;
+    source_url: string;
+  }>;
+  checks?: Array<{
+    id: string;
+    name: string;
+    status: "queued" | "in_progress" | "completed";
+    conclusion: GitHubCheckConclusion;
+    required: boolean;
+    started_at?: string;
+    completed_at?: string;
+    source_url: string;
+  }>;
+  reviews?: Array<{
+    id: string;
+    state: "approved" | "changes_requested" | "commented" | "dismissed";
+    submitted_at: string;
+    actor: string;
+    summary: string;
+    source_url: string;
+  }>;
+  findings?: Array<{
+    id: string;
+    severity: "info" | "warning" | "critical";
+    summary: string;
+    created_at: string;
+    source_url: string;
+    requires_human_review: boolean;
+    resolved_at?: string;
+  }>;
+  author_reported_validations?: Array<{
+    id: string;
+    name: string;
+    status: "passed" | "failed" | "not_run";
+    summary: string;
+    reported_at: string;
+    source_url: string;
+  }>;
+}
+
+export interface VisualOperationsEvent {
+  event_id: string;
+  project_id: string;
+  work_slice_id: string;
+  timestamp: string;
+  source_type: "project_record" | "external";
+  event_type: string;
+  actor: string;
+  summary: string;
+  payload_metadata: Record<string, unknown>;
+  evidence_refs: string[];
+  source_refs: GitHubProjectorSourceRef[];
+  sensitivity: "internal";
+}
+
+export interface ProjectedEvidence {
+  evidence_id: string;
+  type: "ci_check" | "author_reported_validation";
+  status: "passed" | "failed" | "incomplete" | "unknown";
+  provenance: "ci_observed" | "author_reported";
+  summary: string;
+  source_refs: string[];
+}
+
+export interface ProjectedAlert {
+  alert_id: string;
+  type: string;
+  severity: "info" | "warning" | "critical";
+  summary: string;
+  suggested_review: string;
+  source_refs: string[];
+  resolved_at: string | null;
+  resolution_ref: string | null;
+  follow_up_work_slice_id?: string;
+}
+
+export interface GitHubPullRequestProjection {
+  projection: {
+    mode: "read_only";
+    projector: "github_pull_request";
+    projected_at: string;
+    source_refs: string[];
+  };
+  work_slice_visual_state: {
+    work_slice_id: string;
+    title: string;
+    objective: "unknown";
+    presentation_lane:
+      | "intake"
+      | "framing"
+      | "validation"
+      | "human_review"
+      | "closed";
+    lane_confidence: "confirmed" | "inferred" | "unknown";
+    risk_level: "unknown";
+    planning_depth: "unknown";
+    readiness_outcome: "unknown";
+    evidence_status: "none" | "partial" | "sufficient" | "failed" | "unknown";
+    human_review: {
+      required: boolean | "unknown";
+      status: "pending" | "completed" | "unavailable";
+      reviewer_role: "repository_reviewer" | null;
+      open_question: string | null;
+      source_refs: string[];
+    };
+    primary_skill: {
+      skill_id: "unknown";
+      activation_status: "unknown";
+      source_refs: string[];
+    };
+    runtime: {
+      runtime_id: "unavailable";
+      session_status: "unavailable";
+      source_refs: string[];
+    };
+    telemetry: {
+      tokens: { value: null; provenance: "unavailable"; source_refs: string[] };
+      cost: {
+        value: null;
+        currency: null;
+        provenance: "unavailable";
+        source_refs: string[];
+      };
+    };
+    alerts: ProjectedAlert[];
+    evidence: ProjectedEvidence[];
+    source_refs: string[];
+    projected_at: string;
+  };
+  normalized_events: VisualOperationsEvent[];
+  follow_up_slices: Array<{
+    work_slice_id: string;
+    reason: string;
+    source_refs: string[];
+  }>;
+}
+
+function assertIsoDate(value: string, field: string): void {
+  if (Number.isNaN(Date.parse(value))) {
+    throw new Error(`${field} must be an ISO-8601 timestamp`);
+  }
+}
+
+function assertSource(value: string, field: string): void {
+  if (!value.trim()) {
+    throw new Error(`${field} must contain a source reference`);
+  }
+}
+
+function assertPresent(value: string, field: string): void {
+  if (!value.trim()) throw new Error(`${field} is required`);
+}
+
+function stableId(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function event(
+  input: GitHubPullRequestProjectionInput,
+  suffix: string,
+  timestamp: string,
+  eventType: string,
+  actor: string,
+  summary: string,
+  sourceRef: GitHubProjectorSourceRef,
+  payloadMetadata: Record<string, unknown> = {},
+  evidenceRefs: string[] = [],
+): VisualOperationsEvent {
+  return {
+    event_id: `evt-github-pr-${input.pull_request.number}-${stableId(suffix)}`,
+    project_id: input.project_id,
+    work_slice_id: `github-pr-${input.pull_request.number}`,
+    timestamp,
+    source_type: "external",
+    event_type: eventType,
+    actor,
+    summary,
+    payload_metadata: payloadMetadata,
+    evidence_refs: evidenceRefs,
+    source_refs: [sourceRef],
+    sensitivity: "internal",
+  };
+}
+
+function evidenceStatus(
+  input: GitHubPullRequestProjectionInput,
+): GitHubPullRequestProjection["work_slice_visual_state"]["evidence_status"] {
+  const checks = input.checks ?? [];
+  const reportedValidations = input.author_reported_validations ?? [];
+  if (
+    checks.some((check) => check.conclusion === "failure" || check.conclusion === "timed_out") ||
+    reportedValidations.some((validation) => validation.status === "failed")
+  ) {
+    return "failed";
+  }
+
+  const required = checks.filter((check) => check.required);
+  const requiredPassed =
+    required.length > 0 &&
+    required.every((check) => check.status === "completed" && check.conclusion === "success");
+  if (requiredPassed && Boolean(input.pull_request.merged_at)) return "sufficient";
+  if (checks.length > 0 || (input.author_reported_validations?.length ?? 0) > 0) return "partial";
+  return "none";
+}
+
+function deriveLane(
+  input: GitHubPullRequestProjectionInput,
+  hasPendingReview: boolean,
+): Pick<
+  GitHubPullRequestProjection["work_slice_visual_state"],
+  "presentation_lane" | "lane_confidence"
+> {
+  if (input.pull_request.merged_at || (input.pull_request.state === "closed" && input.pull_request.closed_at)) {
+    return { presentation_lane: "closed", lane_confidence: "confirmed" };
+  }
+  if (hasPendingReview) return { presentation_lane: "human_review", lane_confidence: "confirmed" };
+  if ((input.checks?.length ?? 0) > 0) {
+    return { presentation_lane: "validation", lane_confidence: "inferred" };
+  }
+  if (input.pull_request.draft) return { presentation_lane: "framing", lane_confidence: "inferred" };
+  return { presentation_lane: "intake", lane_confidence: "inferred" };
+}
+
+export function projectGitHubPullRequest(
+  input: GitHubPullRequestProjectionInput,
+): GitHubPullRequestProjection {
+  if (!input.project_id.trim()) throw new Error("project_id is required");
+  if (!Number.isInteger(input.pull_request.number) || input.pull_request.number < 1) {
+    throw new Error("pull_request.number must be a positive integer");
+  }
+  assertIsoDate(input.projected_at, "projected_at");
+  assertIsoDate(input.pull_request.created_at, "pull_request.created_at");
+  if (input.pull_request.merged_at) {
+    assertIsoDate(input.pull_request.merged_at, "pull_request.merged_at");
+  }
+  if (input.pull_request.closed_at) {
+    assertIsoDate(input.pull_request.closed_at, "pull_request.closed_at");
+  }
+  assertPresent(input.repository.full_name, "repository.full_name");
+  assertPresent(input.pull_request.title, "pull_request.title");
+  assertPresent(input.pull_request.author, "pull_request.author");
+  assertPresent(input.pull_request.head_sha, "pull_request.head_sha");
+  assertPresent(input.pull_request.base_ref, "pull_request.base_ref");
+  assertSource(input.repository.url, "repository.url");
+  assertSource(input.pull_request.url, "pull_request.url");
+
+  const events: VisualOperationsEvent[] = [
+    event(
+      input,
+      "created",
+      input.pull_request.created_at,
+      "work_slice.created",
+      input.pull_request.author,
+      `GitHub pull request #${input.pull_request.number} was opened.`,
+      { kind: "github_pull_request", ref: input.pull_request.url },
+      {
+        repository: input.repository.full_name,
+        base_ref: input.pull_request.base_ref,
+        head_sha: input.pull_request.head_sha,
+        draft: input.pull_request.draft,
+      },
+    ),
+  ];
+
+  for (const item of input.timeline ?? []) {
+    assertIsoDate(item.created_at, `timeline.${item.id}.created_at`);
+    assertSource(item.source_url, `timeline.${item.id}.source_url`);
+    const eventType =
+      item.type === "merged" || item.type === "closed"
+        ? "reconcile.created"
+        : "work_slice.state_observed";
+    events.push(
+      event(
+        input,
+        `timeline-${item.id}`,
+        item.created_at,
+        eventType,
+        item.actor,
+        `GitHub recorded pull request event: ${item.type}.`,
+        { kind: "github_timeline_event", ref: item.source_url },
+        { github_event_type: item.type },
+      ),
+    );
+  }
+
+  const timelineTypes = new Set((input.timeline ?? []).map((item) => item.type));
+  if (input.pull_request.merged_at && !timelineTypes.has("merged")) {
+    events.push(
+      event(
+        input,
+        "metadata-merged",
+        input.pull_request.merged_at,
+        "reconcile.created",
+        "github",
+        "GitHub pull request metadata reports that the change was merged.",
+        { kind: "github_pull_request", ref: input.pull_request.url },
+        { github_event_type: "merged" },
+      ),
+    );
+  }
+  if (input.pull_request.closed_at && !timelineTypes.has("closed")) {
+    events.push(
+      event(
+        input,
+        "metadata-closed",
+        input.pull_request.closed_at,
+        "reconcile.created",
+        "github",
+        "GitHub pull request metadata reports that the change was closed.",
+        { kind: "github_pull_request", ref: input.pull_request.url },
+        { github_event_type: "closed" },
+      ),
+    );
+  }
+
+  const evidence: ProjectedEvidence[] = [];
+  const alerts: ProjectedAlert[] = [];
+
+  for (const check of input.checks ?? []) {
+    assertSource(check.source_url, `checks.${check.id}.source_url`);
+    const timestamp = check.completed_at ?? check.started_at ?? input.projected_at;
+    assertIsoDate(timestamp, `checks.${check.id}.timestamp`);
+    const status: ProjectedEvidence["status"] =
+      check.status !== "completed"
+        ? "incomplete"
+        : check.conclusion === "success"
+          ? "passed"
+          : check.conclusion === "failure" || check.conclusion === "timed_out"
+            ? "failed"
+            : "unknown";
+    evidence.push({
+      evidence_id: `evidence-check-${stableId(check.id)}`,
+      type: "ci_check",
+      status,
+      provenance: "ci_observed",
+      summary: `${check.name}: ${check.status}/${check.conclusion}.`,
+      source_refs: [check.source_url],
+    });
+    events.push(
+      event(
+        input,
+        `check-${check.id}`,
+        timestamp,
+        status === "passed" ? "validation.passed" : status === "failed" ? "validation.failed" : "evidence.added",
+        "github-actions",
+        `GitHub check ${check.name} reported ${check.conclusion}.`,
+        { kind: "github_check", ref: check.source_url },
+        { check_name: check.name, conclusion: check.conclusion, required: check.required },
+        [check.source_url],
+      ),
+    );
+    if (status === "failed" && check.required) {
+      alerts.push({
+        alert_id: `alert-check-${stableId(check.id)}`,
+        type: "required_validation_failed",
+        severity: "critical",
+        summary: `Required check ${check.name} failed.`,
+        suggested_review: "Review the authoritative check result before continuing or merging.",
+        source_refs: [check.source_url],
+        resolved_at: null,
+        resolution_ref: null,
+      });
+    }
+  }
+
+  for (const validation of input.author_reported_validations ?? []) {
+    assertIsoDate(
+      validation.reported_at,
+      `author_reported_validations.${validation.id}.reported_at`,
+    );
+    assertSource(validation.source_url, `author_reported_validations.${validation.id}.source_url`);
+    evidence.push({
+      evidence_id: `evidence-author-${stableId(validation.id)}`,
+      type: "author_reported_validation",
+      status:
+        validation.status === "passed"
+          ? "passed"
+          : validation.status === "failed"
+            ? "failed"
+            : "incomplete",
+      provenance: "author_reported",
+      summary: validation.summary,
+      source_refs: [validation.source_url],
+    });
+    events.push(
+      event(
+        input,
+        `author-validation-${validation.id}`,
+        validation.reported_at,
+        "evidence.added",
+        input.pull_request.author,
+        validation.summary,
+        { kind: "github_pull_request_report", ref: validation.source_url },
+        {
+          validation_name: validation.name,
+          validation_status: validation.status,
+          provenance: "author_reported",
+        },
+        [validation.source_url],
+      ),
+    );
+  }
+
+  const closeTimestamp = input.pull_request.merged_at ?? input.pull_request.closed_at;
+  const preCloseReviews = (input.reviews ?? []).filter(
+    (review) => !closeTimestamp || Date.parse(review.submitted_at) <= Date.parse(closeTimestamp),
+  );
+  const requestedChanges = preCloseReviews.filter((review) => review.state === "changes_requested");
+  const approvedReviews = preCloseReviews.filter((review) => review.state === "approved");
+
+  for (const review of input.reviews ?? []) {
+    assertIsoDate(review.submitted_at, `reviews.${review.id}.submitted_at`);
+    assertSource(review.source_url, `reviews.${review.id}.source_url`);
+    events.push(
+      event(
+        input,
+        `review-${review.id}`,
+        review.submitted_at,
+        review.state === "changes_requested" ? "human_review.requested" : "human_review.completed",
+        review.actor,
+        review.summary,
+        { kind: "github_review", ref: review.source_url },
+        { review_state: review.state },
+      ),
+    );
+  }
+
+  if (requestedChanges.length > 0) {
+    alerts.push({
+      alert_id: "alert-review-changes-requested",
+      type: "human_review_pending",
+      severity: "warning",
+      summary: "A GitHub review requested changes before closure.",
+      suggested_review: "Resolve the authoritative review or record why it no longer blocks the slice.",
+      source_refs: requestedChanges.map((review) => review.source_url),
+      resolved_at: null,
+      resolution_ref: null,
+    });
+  }
+
+  const followUps: GitHubPullRequestProjection["follow_up_slices"] = [];
+  for (const finding of input.findings ?? []) {
+    assertIsoDate(finding.created_at, `findings.${finding.id}.created_at`);
+    assertSource(finding.source_url, `findings.${finding.id}.source_url`);
+    const postClose = Boolean(closeTimestamp && Date.parse(finding.created_at) > Date.parse(closeTimestamp));
+    const followUpId = postClose
+      ? `github-pr-${input.pull_request.number}-follow-up-${stableId(finding.id)}`
+      : undefined;
+    if (followUpId) {
+      followUps.push({
+        work_slice_id: followUpId,
+        reason: finding.summary,
+        source_refs: [finding.source_url],
+      });
+    }
+    alerts.push({
+      alert_id: `alert-finding-${stableId(finding.id)}`,
+      type: postClose ? "post_close_finding" : "review_finding",
+      severity: finding.severity,
+      summary: finding.summary,
+      suggested_review: postClose
+        ? "Track this finding in the linked follow-up slice; do not rewrite the closed historical lane."
+        : "Review the finding against the authoritative pull request evidence.",
+      source_refs: [finding.source_url],
+      resolved_at: finding.resolved_at ?? null,
+      resolution_ref: null,
+      ...(followUpId ? { follow_up_work_slice_id: followUpId } : {}),
+    });
+    events.push(
+      event(
+        input,
+        `finding-${finding.id}`,
+        finding.created_at,
+        "alert.raised",
+        "github-review",
+        finding.summary,
+        { kind: "github_finding", ref: finding.source_url },
+        {
+          severity: finding.severity,
+          requires_human_review: finding.requires_human_review,
+          post_close: postClose,
+          follow_up_work_slice_id: followUpId,
+        },
+      ),
+    );
+  }
+
+  const preCloseReviewFindings = (input.findings ?? []).filter(
+    (finding) =>
+      finding.requires_human_review &&
+      !finding.resolved_at &&
+      (!closeTimestamp || Date.parse(finding.created_at) <= Date.parse(closeTimestamp)),
+  );
+  const hasPendingReview = requestedChanges.length > 0 || preCloseReviewFindings.length > 0;
+  const lane = deriveLane(input, hasPendingReview);
+  const reviewRefs = [
+    ...requestedChanges.map((review) => review.source_url),
+    ...approvedReviews.map((review) => review.source_url),
+    ...preCloseReviewFindings.map((finding) => finding.source_url),
+  ];
+  const sourceRefs = [
+    input.repository.url,
+    input.pull_request.url,
+    ...(input.timeline ?? []).map((item) => item.source_url),
+    ...(input.checks ?? []).map((check) => check.source_url),
+    ...(input.reviews ?? []).map((review) => review.source_url),
+    ...(input.findings ?? []).map((finding) => finding.source_url),
+  ];
+
+  return {
+    projection: {
+      mode: "read_only",
+      projector: "github_pull_request",
+      projected_at: input.projected_at,
+      source_refs: [input.pull_request.url],
+    },
+    work_slice_visual_state: {
+      work_slice_id: `github-pr-${input.pull_request.number}`,
+      title: input.pull_request.title,
+      objective: "unknown",
+      ...lane,
+      risk_level: "unknown",
+      planning_depth: "unknown",
+      readiness_outcome: "unknown",
+      evidence_status: evidenceStatus(input),
+      human_review: {
+        required: hasPendingReview ? true : "unknown",
+        status: hasPendingReview ? "pending" : approvedReviews.length > 0 ? "completed" : "unavailable",
+        reviewer_role: reviewRefs.length > 0 ? "repository_reviewer" : null,
+        open_question: hasPendingReview
+          ? (requestedChanges[0]?.summary ?? preCloseReviewFindings[0]?.summary ?? null)
+          : null,
+        source_refs: reviewRefs,
+      },
+      primary_skill: { skill_id: "unknown", activation_status: "unknown", source_refs: [] },
+      runtime: { runtime_id: "unavailable", session_status: "unavailable", source_refs: [] },
+      telemetry: {
+        tokens: { value: null, provenance: "unavailable", source_refs: [] },
+        cost: { value: null, currency: null, provenance: "unavailable", source_refs: [] },
+      },
+      alerts,
+      evidence,
+      source_refs: [...new Set(sourceRefs)],
+      projected_at: input.projected_at,
+    },
+    normalized_events: events.sort(
+      (left, right) => left.timestamp.localeCompare(right.timestamp) || left.event_id.localeCompare(right.event_id),
+    ),
+    follow_up_slices: followUps,
+  };
+}
+
+export function renderGitHubPullRequestProjectionMarkdown(
+  projection: GitHubPullRequestProjection,
+): string {
+  const escapeCell = (value: string): string => value.replaceAll("|", "\\|").replaceAll("\n", " ");
+  const state = projection.work_slice_visual_state;
+  const evidenceRows = state.evidence.length
+    ? state.evidence
+        .map(
+          (item) =>
+            `| ${escapeCell(item.summary)} | ${item.status} | ${item.provenance} | ${item.source_refs.join(", ")} |`,
+        )
+        .join("\n")
+    : "| No evidence supplied | unknown | unavailable | — |";
+  const alertRows = state.alerts.length
+    ? state.alerts
+        .map(
+          (item) =>
+            `| ${item.severity} | ${item.type} | ${escapeCell(item.summary)} | ${item.source_refs.join(", ")} |`,
+        )
+        .join("\n")
+    : "| info | none | No projected alerts. | — |";
+  const followUpRows = projection.follow_up_slices.length
+    ? projection.follow_up_slices
+        .map(
+          (item) =>
+            `| ${item.work_slice_id} | ${escapeCell(item.reason)} | ${item.source_refs.join(", ")} |`,
+        )
+        .join("\n")
+    : "| none | No follow-up slice projected. | — |";
+
+  return `# Visual Operations Snapshot — ${state.work_slice_id}
+
+> Read-only projection generated at ${state.projected_at}. Source records remain authoritative.
+
+## State
+
+| Field | Value |
+|---|---|
+| Title | ${escapeCell(state.title)} |
+| Presentation lane | ${state.presentation_lane} (${state.lane_confidence}) |
+| Evidence status | ${state.evidence_status} |
+| Risk | ${state.risk_level} |
+| Planning depth | ${state.planning_depth} |
+| Readiness outcome | ${state.readiness_outcome} |
+| Human review | ${state.human_review.status} |
+| Runtime | ${state.runtime.session_status} |
+| Tokens | ${state.telemetry.tokens.provenance} |
+| Cost | ${state.telemetry.cost.provenance} |
+
+## Evidence
+
+| Evidence | Status | Provenance | Source refs |
+|---|---|---|---|
+${evidenceRows}
+
+## Alerts
+
+| Severity | Type | Summary | Source refs |
+|---|---|---|---|
+${alertRows}
+
+## Follow-up slices
+
+| Work Slice | Reason | Source refs |
+|---|---|---|
+${followUpRows}
+`;
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,6 +43,7 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
   - Execution Pattern Selections trabalhadas (topologia antes da execução): CI triage (scheduled stateful loop), síntese de entrevistas (fan-out + filter), review adversarial de PRD (maker-checker) e feature value review (loops explicitamente inadmissíveis)
 - `visual-operations/`
   - projeção sintética e somente leitura de duas Work Slices, com eventos normalizados, evidência, revisão humana, telemetria opcional e fonte restrita representada apenas por metadados
+  - entrada e saídas reproduzíveis do projetor GitHub PR → Visual Operations, incluindo distinção entre evidência observada por CI e validação reportada pelo autor
 
 ---
 

--- a/examples/visual-operations/github-pr-projector-input.json
+++ b/examples/visual-operations/github-pr-projector-input.json
@@ -1,0 +1,120 @@
+{
+  "project_id": "aletheia",
+  "projected_at": "2026-06-15T04:05:00Z",
+  "repository": {
+    "full_name": "nevitonsantana/AletheIA",
+    "url": "https://github.com/nevitonsantana/AletheIA"
+  },
+  "pull_request": {
+    "number": 193,
+    "title": "docs: add visual operations projection",
+    "url": "https://github.com/nevitonsantana/AletheIA/pull/193",
+    "state": "closed",
+    "draft": false,
+    "author": "nevitonsantana",
+    "created_at": "2026-06-15T03:51:39Z",
+    "merged_at": "2026-06-15T03:57:36Z",
+    "closed_at": "2026-06-15T03:57:36Z",
+    "head_sha": "40c53937aae9ac587660b7974dbcb848c328a16b",
+    "base_ref": "main"
+  },
+  "timeline": [
+    {
+      "id": "ready-for-review",
+      "type": "ready_for_review",
+      "created_at": "2026-06-15T03:54:05Z",
+      "actor": "nevitonsantana",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/193"
+    },
+    {
+      "id": "merged",
+      "type": "merged",
+      "created_at": "2026-06-15T03:57:36Z",
+      "actor": "nevitonsantana",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/193"
+    },
+    {
+      "id": "closed",
+      "type": "closed",
+      "created_at": "2026-06-15T03:57:36Z",
+      "actor": "github",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/193"
+    }
+  ],
+  "checks": [
+    {
+      "id": "governance",
+      "name": "Governance Check",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "completed_at": "2026-06-15T03:51:46Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+    },
+    {
+      "id": "lockfile",
+      "name": "Lockfile sync",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "completed_at": "2026-06-15T03:51:47Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+    },
+    {
+      "id": "typescript",
+      "name": "Install & TypeScript Build",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "completed_at": "2026-06-15T03:52:03Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+    },
+    {
+      "id": "vitest",
+      "name": "Tests (Vitest)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "completed_at": "2026-06-15T03:52:26Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+    },
+    {
+      "id": "quality-gate",
+      "name": "Quality Gate",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "completed_at": "2026-06-15T03:52:37Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+    }
+  ],
+  "reviews": [],
+  "findings": [
+    {
+      "id": "regulated-sensitivity",
+      "severity": "warning",
+      "summary": "The event sensitivity vocabulary omitted the canonical regulated value.",
+      "created_at": "2026-06-15T03:58:11Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/193",
+      "requires_human_review": true
+    }
+  ],
+  "author_reported_validations": [
+    {
+      "id": "json-jsonl-yaml",
+      "name": "JSON, JSONL, and YAML parsing",
+      "status": "passed",
+      "summary": "The PR description reports successful parsing of JSON, every JSONL line, and YAML templates.",
+      "reported_at": "2026-06-15T03:54:05Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/193"
+    },
+    {
+      "id": "markdown-links",
+      "name": "Markdown link validation",
+      "status": "passed",
+      "summary": "The PR description reports that local Markdown links resolved.",
+      "reported_at": "2026-06-15T03:54:05Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/193"
+    }
+  ]
+}

--- a/examples/visual-operations/github-pr-projector-output.json
+++ b/examples/visual-operations/github-pr-projector-output.json
@@ -1,0 +1,441 @@
+{
+  "projection": {
+    "mode": "read_only",
+    "projector": "github_pull_request",
+    "projected_at": "2026-06-15T04:05:00Z",
+    "source_refs": [
+      "https://github.com/nevitonsantana/AletheIA/pull/193"
+    ]
+  },
+  "work_slice_visual_state": {
+    "work_slice_id": "github-pr-193",
+    "title": "docs: add visual operations projection",
+    "objective": "unknown",
+    "presentation_lane": "closed",
+    "lane_confidence": "confirmed",
+    "risk_level": "unknown",
+    "planning_depth": "unknown",
+    "readiness_outcome": "unknown",
+    "evidence_status": "sufficient",
+    "human_review": {
+      "required": "unknown",
+      "status": "unavailable",
+      "reviewer_role": null,
+      "open_question": null,
+      "source_refs": []
+    },
+    "primary_skill": {
+      "skill_id": "unknown",
+      "activation_status": "unknown",
+      "source_refs": []
+    },
+    "runtime": {
+      "runtime_id": "unavailable",
+      "session_status": "unavailable",
+      "source_refs": []
+    },
+    "telemetry": {
+      "tokens": {
+        "value": null,
+        "provenance": "unavailable",
+        "source_refs": []
+      },
+      "cost": {
+        "value": null,
+        "currency": null,
+        "provenance": "unavailable",
+        "source_refs": []
+      }
+    },
+    "alerts": [
+      {
+        "alert_id": "alert-finding-regulated-sensitivity",
+        "type": "post_close_finding",
+        "severity": "warning",
+        "summary": "The event sensitivity vocabulary omitted the canonical regulated value.",
+        "suggested_review": "Track this finding in the linked follow-up slice; do not rewrite the closed historical lane.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/pull/193"
+        ],
+        "resolved_at": null,
+        "resolution_ref": null,
+        "follow_up_work_slice_id": "github-pr-193-follow-up-regulated-sensitivity"
+      }
+    ],
+    "evidence": [
+      {
+        "evidence_id": "evidence-check-governance",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Governance Check: completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-lockfile",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Lockfile sync: completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-typescript",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Install & TypeScript Build: completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-vitest",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Tests (Vitest): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-quality-gate",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Quality Gate: completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+        ]
+      },
+      {
+        "evidence_id": "evidence-author-json-jsonl-yaml",
+        "type": "author_reported_validation",
+        "status": "passed",
+        "provenance": "author_reported",
+        "summary": "The PR description reports successful parsing of JSON, every JSONL line, and YAML templates.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/pull/193"
+        ]
+      },
+      {
+        "evidence_id": "evidence-author-markdown-links",
+        "type": "author_reported_validation",
+        "status": "passed",
+        "provenance": "author_reported",
+        "summary": "The PR description reports that local Markdown links resolved.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/pull/193"
+        ]
+      }
+    ],
+    "source_refs": [
+      "https://github.com/nevitonsantana/AletheIA",
+      "https://github.com/nevitonsantana/AletheIA/pull/193",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+    ],
+    "projected_at": "2026-06-15T04:05:00Z"
+  },
+  "normalized_events": [
+    {
+      "event_id": "evt-github-pr-193-created",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-193",
+      "timestamp": "2026-06-15T03:51:39Z",
+      "source_type": "external",
+      "event_type": "work_slice.created",
+      "actor": "nevitonsantana",
+      "summary": "GitHub pull request #193 was opened.",
+      "payload_metadata": {
+        "repository": "nevitonsantana/AletheIA",
+        "base_ref": "main",
+        "head_sha": "40c53937aae9ac587660b7974dbcb848c328a16b",
+        "draft": false
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_pull_request",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/193"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-193-check-governance",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-193",
+      "timestamp": "2026-06-15T03:51:46Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Governance Check reported success.",
+      "payload_metadata": {
+        "check_name": "Governance Check",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-193-check-lockfile",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-193",
+      "timestamp": "2026-06-15T03:51:47Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Lockfile sync reported success.",
+      "payload_metadata": {
+        "check_name": "Lockfile sync",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-193-check-typescript",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-193",
+      "timestamp": "2026-06-15T03:52:03Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Install & TypeScript Build reported success.",
+      "payload_metadata": {
+        "check_name": "Install & TypeScript Build",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-193-check-vitest",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-193",
+      "timestamp": "2026-06-15T03:52:26Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Tests (Vitest) reported success.",
+      "payload_metadata": {
+        "check_name": "Tests (Vitest)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-193-check-quality-gate",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-193",
+      "timestamp": "2026-06-15T03:52:37Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Quality Gate reported success.",
+      "payload_metadata": {
+        "check_name": "Quality Gate",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-193-author-validation-json-jsonl-yaml",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-193",
+      "timestamp": "2026-06-15T03:54:05Z",
+      "source_type": "external",
+      "event_type": "evidence.added",
+      "actor": "nevitonsantana",
+      "summary": "The PR description reports successful parsing of JSON, every JSONL line, and YAML templates.",
+      "payload_metadata": {
+        "validation_name": "JSON, JSONL, and YAML parsing",
+        "validation_status": "passed",
+        "provenance": "author_reported"
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/pull/193"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_pull_request_report",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/193"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-193-author-validation-markdown-links",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-193",
+      "timestamp": "2026-06-15T03:54:05Z",
+      "source_type": "external",
+      "event_type": "evidence.added",
+      "actor": "nevitonsantana",
+      "summary": "The PR description reports that local Markdown links resolved.",
+      "payload_metadata": {
+        "validation_name": "Markdown link validation",
+        "validation_status": "passed",
+        "provenance": "author_reported"
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/pull/193"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_pull_request_report",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/193"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-193-timeline-ready-for-review",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-193",
+      "timestamp": "2026-06-15T03:54:05Z",
+      "source_type": "external",
+      "event_type": "work_slice.state_observed",
+      "actor": "nevitonsantana",
+      "summary": "GitHub recorded pull request event: ready_for_review.",
+      "payload_metadata": {
+        "github_event_type": "ready_for_review"
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_timeline_event",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/193"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-193-timeline-closed",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-193",
+      "timestamp": "2026-06-15T03:57:36Z",
+      "source_type": "external",
+      "event_type": "reconcile.created",
+      "actor": "github",
+      "summary": "GitHub recorded pull request event: closed.",
+      "payload_metadata": {
+        "github_event_type": "closed"
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_timeline_event",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/193"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-193-timeline-merged",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-193",
+      "timestamp": "2026-06-15T03:57:36Z",
+      "source_type": "external",
+      "event_type": "reconcile.created",
+      "actor": "nevitonsantana",
+      "summary": "GitHub recorded pull request event: merged.",
+      "payload_metadata": {
+        "github_event_type": "merged"
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_timeline_event",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/193"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-193-finding-regulated-sensitivity",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-193",
+      "timestamp": "2026-06-15T03:58:11Z",
+      "source_type": "external",
+      "event_type": "alert.raised",
+      "actor": "github-review",
+      "summary": "The event sensitivity vocabulary omitted the canonical regulated value.",
+      "payload_metadata": {
+        "severity": "warning",
+        "requires_human_review": true,
+        "post_close": true,
+        "follow_up_work_slice_id": "github-pr-193-follow-up-regulated-sensitivity"
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_finding",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/193"
+        }
+      ],
+      "sensitivity": "internal"
+    }
+  ],
+  "follow_up_slices": [
+    {
+      "work_slice_id": "github-pr-193-follow-up-regulated-sensitivity",
+      "reason": "The event sensitivity vocabulary omitted the canonical regulated value.",
+      "source_refs": [
+        "https://github.com/nevitonsantana/AletheIA/pull/193"
+      ]
+    }
+  ]
+}

--- a/examples/visual-operations/github-pr-projector-output.md
+++ b/examples/visual-operations/github-pr-projector-output.md
@@ -1,0 +1,42 @@
+# Visual Operations Snapshot — github-pr-193
+
+> Read-only projection generated at 2026-06-15T04:05:00Z. Source records remain authoritative.
+
+## State
+
+| Field | Value |
+|---|---|
+| Title | docs: add visual operations projection |
+| Presentation lane | closed (confirmed) |
+| Evidence status | sufficient |
+| Risk | unknown |
+| Planning depth | unknown |
+| Readiness outcome | unknown |
+| Human review | unavailable |
+| Runtime | unavailable |
+| Tokens | unavailable |
+| Cost | unavailable |
+
+## Evidence
+
+| Evidence | Status | Provenance | Source refs |
+|---|---|---|---|
+| Governance Check: completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401 |
+| Lockfile sync: completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401 |
+| Install & TypeScript Build: completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401 |
+| Tests (Vitest): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401 |
+| Quality Gate: completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401 |
+| The PR description reports successful parsing of JSON, every JSONL line, and YAML templates. | passed | author_reported | https://github.com/nevitonsantana/AletheIA/pull/193 |
+| The PR description reports that local Markdown links resolved. | passed | author_reported | https://github.com/nevitonsantana/AletheIA/pull/193 |
+
+## Alerts
+
+| Severity | Type | Summary | Source refs |
+|---|---|---|---|
+| warning | post_close_finding | The event sensitivity vocabulary omitted the canonical regulated value. | https://github.com/nevitonsantana/AletheIA/pull/193 |
+
+## Follow-up slices
+
+| Work Slice | Reason | Source refs |
+|---|---|---|
+| github-pr-193-follow-up-regulated-sensitivity | The event sensitivity vocabulary omitted the canonical regulated value. | https://github.com/nevitonsantana/AletheIA/pull/193 |

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -218,6 +218,10 @@ truth, read and adapt:
 - `starter-pack/templates/slice-trace-template.md`
 - `starter-pack/templates/visual-ops-reconcile-template.md`
 - `examples/visual-operations/dashboard-snapshot.md`
+- `docs/guides/github-pr-visual-operations-projector.md`
+- `examples/visual-operations/github-pr-projector-input.json`
+- `examples/visual-operations/github-pr-projector-output.json`
+- `examples/visual-operations/github-pr-projector-output.md`
 
 These materials are read-only projection guidance. Board lanes are presentation states, events retain
 their authoritative `source_refs`, and missing telemetry remains `unknown` or `unavailable`.

--- a/tests/visual-operations/test-github-pr-projector.test.ts
+++ b/tests/visual-operations/test-github-pr-projector.test.ts
@@ -1,0 +1,270 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  projectGitHubPullRequest,
+  renderGitHubPullRequestProjectionMarkdown,
+  type GitHubPullRequestProjectionInput,
+} from "../../engine";
+
+function inputFixture(): GitHubPullRequestProjectionInput {
+  return {
+    project_id: "aletheia",
+    projected_at: "2026-06-15T04:00:00Z",
+    repository: {
+      full_name: "nevitonsantana/AletheIA",
+      url: "https://github.com/nevitonsantana/AletheIA",
+    },
+    pull_request: {
+      number: 193,
+      title: "docs: add visual operations projection",
+      url: "https://github.com/nevitonsantana/AletheIA/pull/193",
+      state: "closed",
+      draft: false,
+      author: "nevitonsantana",
+      created_at: "2026-06-15T03:51:39Z",
+      merged_at: "2026-06-15T03:57:36Z",
+      closed_at: "2026-06-15T03:57:36Z",
+      head_sha: "40c53937aae9ac587660b7974dbcb848c328a16b",
+      base_ref: "main",
+    },
+    timeline: [
+      {
+        id: "ready",
+        type: "ready_for_review",
+        created_at: "2026-06-15T03:54:05Z",
+        actor: "nevitonsantana",
+        source_url: "https://github.com/nevitonsantana/AletheIA/pull/193#event-ready",
+      },
+      {
+        id: "merged",
+        type: "merged",
+        created_at: "2026-06-15T03:57:36Z",
+        actor: "nevitonsantana",
+        source_url: "https://github.com/nevitonsantana/AletheIA/pull/193#event-merged",
+      },
+    ],
+    checks: [
+      {
+        id: "governance",
+        name: "Governance Check",
+        status: "completed",
+        conclusion: "success",
+        required: true,
+        completed_at: "2026-06-15T03:51:46Z",
+        source_url: "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401/job/governance",
+      },
+      {
+        id: "tests",
+        name: "Tests (Vitest)",
+        status: "completed",
+        conclusion: "success",
+        required: true,
+        completed_at: "2026-06-15T03:52:26Z",
+        source_url: "https://github.com/nevitonsantana/AletheIA/actions/runs/27522883401/job/tests",
+      },
+    ],
+    findings: [
+      {
+        id: "regulated-sensitivity",
+        severity: "warning",
+        summary: "The event sensitivity vocabulary omitted the canonical regulated value.",
+        created_at: "2026-06-15T03:58:11Z",
+        source_url: "https://github.com/nevitonsantana/AletheIA/pull/193#discussion-regulated",
+        requires_human_review: true,
+      },
+    ],
+    author_reported_validations: [
+      {
+        id: "jsonl-validation",
+        name: "JSONL validation",
+        status: "passed",
+        summary: "The PR description reports that every JSONL line parsed successfully.",
+        reported_at: "2026-06-15T03:54:05Z",
+        source_url: "https://github.com/nevitonsantana/AletheIA/pull/193",
+      },
+    ],
+  };
+}
+
+describe("GitHub pull request Visual Operations projector", () => {
+  it("projects a merged PR without fabricating unavailable signals", () => {
+    const result = projectGitHubPullRequest(inputFixture());
+    const state = result.work_slice_visual_state;
+
+    expect(state.presentation_lane).toBe("closed");
+    expect(state.lane_confidence).toBe("confirmed");
+    expect(state.evidence_status).toBe("sufficient");
+    expect(state.risk_level).toBe("unknown");
+    expect(state.planning_depth).toBe("unknown");
+    expect(state.primary_skill.activation_status).toBe("unknown");
+    expect(state.runtime.session_status).toBe("unavailable");
+    expect(state.telemetry.tokens.provenance).toBe("unavailable");
+    expect(state.telemetry.cost.provenance).toBe("unavailable");
+  });
+
+  it("distinguishes CI-observed evidence from author-reported validation", () => {
+    const evidence = projectGitHubPullRequest(inputFixture()).work_slice_visual_state.evidence;
+
+    expect(evidence.filter((item) => item.provenance === "ci_observed")).toHaveLength(2);
+    expect(evidence.filter((item) => item.provenance === "author_reported")).toHaveLength(1);
+    expect(evidence.every((item) => item.source_refs.length > 0)).toBe(true);
+  });
+
+  it("links post-close findings to a follow-up slice without reopening history", () => {
+    const result = projectGitHubPullRequest(inputFixture());
+
+    expect(result.work_slice_visual_state.presentation_lane).toBe("closed");
+    expect(result.follow_up_slices).toEqual([
+      expect.objectContaining({
+        work_slice_id: "github-pr-193-follow-up-regulated-sensitivity",
+      }),
+    ]);
+    expect(result.work_slice_visual_state.alerts).toEqual([
+      expect.objectContaining({
+        type: "post_close_finding",
+        follow_up_work_slice_id: "github-pr-193-follow-up-regulated-sensitivity",
+      }),
+    ]);
+  });
+
+  it("orders normalized events by source timestamp and preserves source refs", () => {
+    const events = projectGitHubPullRequest(inputFixture()).normalized_events;
+    const timestamps = events.map((item) => item.timestamp);
+
+    expect(timestamps).toEqual([...timestamps].sort());
+    expect(events.every((item) => item.source_refs.length > 0)).toBe(true);
+    expect(events.find((item) => item.event_type === "alert.raised")?.payload_metadata).toMatchObject({
+      post_close: true,
+    });
+  });
+
+  it("projects required check failure conservatively", () => {
+    const input = inputFixture();
+    input.pull_request.state = "open";
+    delete input.pull_request.merged_at;
+    delete input.pull_request.closed_at;
+    input.findings = [];
+    input.checks![0].conclusion = "failure";
+
+    const result = projectGitHubPullRequest(input);
+
+    expect(result.work_slice_visual_state.presentation_lane).toBe("validation");
+    expect(result.work_slice_visual_state.evidence_status).toBe("failed");
+    expect(result.work_slice_visual_state.alerts[0]).toMatchObject({
+      type: "required_validation_failed",
+      severity: "critical",
+    });
+  });
+
+  it("keeps author-reported validation provenance while preserving a reported failure", () => {
+    const input = inputFixture();
+    input.author_reported_validations![0].status = "failed";
+
+    const state = projectGitHubPullRequest(input).work_slice_visual_state;
+
+    expect(state.evidence_status).toBe("failed");
+    expect(
+      state.evidence.find((item) => item.type === "author_reported_validation"),
+    ).toMatchObject({ status: "failed", provenance: "author_reported" });
+  });
+
+  it("projects an open change request into human review", () => {
+    const input = inputFixture();
+    input.pull_request.state = "open";
+    delete input.pull_request.merged_at;
+    delete input.pull_request.closed_at;
+    input.findings = [];
+    input.reviews = [
+      {
+        id: "review-1",
+        state: "changes_requested",
+        submitted_at: "2026-06-15T03:56:00Z",
+        actor: "maintainer",
+        summary: "Confirm the source-reference boundary before merge.",
+        source_url: "https://github.com/nevitonsantana/AletheIA/pull/193#review-1",
+      },
+    ];
+
+    const result = projectGitHubPullRequest(input);
+
+    expect(result.work_slice_visual_state.presentation_lane).toBe("human_review");
+    expect(result.work_slice_visual_state.human_review).toMatchObject({
+      required: true,
+      status: "pending",
+      open_question: "Confirm the source-reference boundary before merge.",
+    });
+  });
+
+  it("does not infer that an approved review was mandatory", () => {
+    const input = inputFixture();
+    input.reviews = [
+      {
+        id: "review-approved",
+        state: "approved",
+        submitted_at: "2026-06-15T03:56:00Z",
+        actor: "maintainer",
+        summary: "The change is approved.",
+        source_url: "https://github.com/nevitonsantana/AletheIA/pull/193#review-approved",
+      },
+    ];
+
+    const review = projectGitHubPullRequest(input).work_slice_visual_state.human_review;
+
+    expect(review.required).toBe("unknown");
+    expect(review.status).toBe("completed");
+  });
+
+  it("emits merge and close events from PR metadata when timeline items are absent", () => {
+    const input = inputFixture();
+    input.timeline = [];
+
+    const events = projectGitHubPullRequest(input).normalized_events;
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ event_id: "evt-github-pr-193-metadata-merged" }),
+        expect.objectContaining({ event_id: "evt-github-pr-193-metadata-closed" }),
+      ]),
+    );
+  });
+
+  it("renders the projection as a source-backed Markdown snapshot", () => {
+    const markdown = renderGitHubPullRequestProjectionMarkdown(
+      projectGitHubPullRequest(inputFixture()),
+    );
+
+    expect(markdown).toContain("Presentation lane | closed (confirmed)");
+    expect(markdown).toContain("ci_observed");
+    expect(markdown).toContain("author_reported");
+    expect(markdown).toContain("github-pr-193-follow-up-regulated-sensitivity");
+  });
+
+  it("rejects input that cannot provide a resolvable PR source", () => {
+    const input = inputFixture();
+    input.pull_request.url = "";
+
+    expect(() => projectGitHubPullRequest(input)).toThrow(
+      "pull_request.url must contain a source reference",
+    );
+  });
+
+  it("reconstructs the checked-in JSON and Markdown example", () => {
+    const exampleDir = path.resolve(process.cwd(), "examples/visual-operations");
+    const input = JSON.parse(
+      fs.readFileSync(path.join(exampleDir, "github-pr-projector-input.json"), "utf8"),
+    ) as GitHubPullRequestProjectionInput;
+    const expectedJson = JSON.parse(
+      fs.readFileSync(path.join(exampleDir, "github-pr-projector-output.json"), "utf8"),
+    ) as unknown;
+    const expectedMarkdown = fs.readFileSync(
+      path.join(exampleDir, "github-pr-projector-output.md"),
+      "utf8",
+    );
+
+    const result = projectGitHubPullRequest(input);
+
+    expect(result).toEqual(expectedJson);
+    expect(renderGitHubPullRequestProjectionMarkdown(result)).toBe(expectedMarkdown);
+  });
+});


### PR DESCRIPTION
## What changed

- adds a deterministic, read-only GitHub PR projector to the Visual Operations layer
- accepts explicitly supplied PR metadata, timeline events, checks, reviews, findings, and author-reported validations
- emits normalized events, one derived Work Slice visual state, linked follow-up slices, JSON, and Markdown
- keeps CI-observed evidence separate from author-reported validation
- adds a reproducible PR #193 fixture and generated snapshots
- documents the adapter boundary and updates docs, examples, and starter-pack indexes

## Why it changed

The PR #193 retrospective showed that the next useful slice was a small projector before any UI, backend, importer, webhook, database, or Adaptive Skills integration. This adapter makes the docs-first model executable while preserving GitHub and AletheIA records as the authorities.

## How to validate

- `pnpm check:governance`
- `pnpm test` — 18 files and 185 tests passed
- `pnpm exec tsc --noEmit`
- `git diff --check`
- checked-in PR #193 JSON and Markdown outputs are reconstructed in tests
- Markdown links and source-reference coverage were checked locally

## Risks, assumptions, or follow-ups

- input evidence must be collected and authorized outside this pure projector
- no remote URL verification or GitHub API client is included
- risk, planning depth, readiness, skill activation, runtime, tokens, and cost remain `unknown` or `unavailable` without durable sources
- post-close findings create linked follow-up slice IDs and do not reopen historical state
- a future slice may add an explicit CLI or connector adapter, but should not add a new authority