### PR TITLE
feat(visual-ops): add local projection CLI

### DIFF
--- a/docs/guides/github-pr-visual-operations-projector.md
+++ b/docs/guides/github-pr-visual-operations-projector.md
@@ -29,6 +29,34 @@ The input must be assembled from already authorized evidence. The projector acce
 timestamps, summaries, and source URLs; it intentionally has no field for full prompts, secrets,
 restricted source bodies, or personal data beyond the explicitly supplied actor labels.
 
+## Local CLI
+
+The repository includes a local file adapter over the same projector:
+
+```bash
+pnpm visual-ops:project -- \
+  --input examples/visual-operations/github-pr-195-cli-input.json \
+  --json examples/visual-operations/github-pr-195-cli-output.json \
+  --markdown examples/visual-operations/github-pr-195-cli-output.md
+```
+
+To verify that checked-in outputs still match their authorized input without writing files:
+
+```bash
+pnpm visual-ops:project -- \
+  --input examples/visual-operations/github-pr-195-cli-input.json \
+  --json examples/visual-operations/github-pr-195-cli-output.json \
+  --markdown examples/visual-operations/github-pr-195-cli-output.md \
+  --check
+```
+
+`--check` exits with code `2` when an output is missing or stale. Usage, parsing, and projection
+errors exit with code `1`. Current outputs exit with code `0`.
+
+Writes are staged in the destination directories and installed only after all output bodies have
+been generated. If installation fails, previous outputs are restored. The CLI also refuses to use
+the input file as an output or to point JSON and Markdown at the same path.
+
 ## Conservative derivation rules
 
 1. A merged or authoritatively closed PR projects to the `closed` presentation lane.
@@ -62,10 +90,13 @@ URLs or infer omitted data from a PR body.
 - [Input evidence](../../examples/visual-operations/github-pr-projector-input.json)
 - [Projected JSON](../../examples/visual-operations/github-pr-projector-output.json)
 - [Projected Markdown](../../examples/visual-operations/github-pr-projector-output.md)
+- [PR #195 CLI input](../../examples/visual-operations/github-pr-195-cli-input.json)
+- [PR #195 CLI JSON output](../../examples/visual-operations/github-pr-195-cli-output.json)
+- [PR #195 CLI Markdown output](../../examples/visual-operations/github-pr-195-cli-output.md)
 - [Field-evidence retrospective](../pilots/visual-operations-pr-193-retrospective.md)
 
-The example uses the durable evidence already documented for PR #193. Tests regenerate the
-projection in memory and compare it with both checked-in outputs.
+The first example uses the durable evidence documented for PR #193. The second uses PR #195 as a
+real CLI pilot. Tests regenerate the projector fixtures, while `--check` verifies the CLI outputs.
 
 ## Non-goals
 

--- a/docs/guides/github-pr-visual-operations-projector.md
+++ b/docs/guides/github-pr-visual-operations-projector.md
@@ -34,7 +34,7 @@ restricted source bodies, or personal data beyond the explicitly supplied actor 
 The repository includes a local file adapter over the same projector:
 
 ```bash
-pnpm visual-ops:project -- \
+./scripts/visual-ops-project.sh \
   --input examples/visual-operations/github-pr-195-cli-input.json \
   --json examples/visual-operations/github-pr-195-cli-output.json \
   --markdown examples/visual-operations/github-pr-195-cli-output.md
@@ -43,7 +43,7 @@ pnpm visual-ops:project -- \
 To verify that checked-in outputs still match their authorized input without writing files:
 
 ```bash
-pnpm visual-ops:project -- \
+./scripts/visual-ops-project.sh \
   --input examples/visual-operations/github-pr-195-cli-input.json \
   --json examples/visual-operations/github-pr-195-cli-output.json \
   --markdown examples/visual-operations/github-pr-195-cli-output.md \

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,6 +44,7 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
 - `visual-operations/`
   - projeção sintética e somente leitura de duas Work Slices, com eventos normalizados, evidência, revisão humana, telemetria opcional e fonte restrita representada apenas por metadados
   - entrada e saídas reproduzíveis do projetor GitHub PR → Visual Operations, incluindo distinção entre evidência observada por CI e validação reportada pelo autor
+  - segundo piloto real da PR #195, gerado e verificável pelo CLI local com `--check`
 
 ---
 

--- a/examples/visual-operations/github-pr-195-cli-input.json
+++ b/examples/visual-operations/github-pr-195-cli-input.json
@@ -1,0 +1,101 @@
+{
+  "project_id": "aletheia",
+  "projected_at": "2026-06-15T13:30:00Z",
+  "repository": {
+    "full_name": "nevitonsantana/AletheIA",
+    "url": "https://github.com/nevitonsantana/AletheIA"
+  },
+  "pull_request": {
+    "number": 195,
+    "title": "feat(visual-ops): add GitHub PR projector",
+    "url": "https://github.com/nevitonsantana/AletheIA/pull/195",
+    "state": "closed",
+    "draft": false,
+    "author": "nevitonsantana",
+    "created_at": "2026-06-15T13:23:35Z",
+    "merged_at": "2026-06-15T13:27:53Z",
+    "closed_at": "2026-06-15T13:27:53Z",
+    "head_sha": "60e8827af5a2d51b0d8de2641dbfde64830cc1d5",
+    "base_ref": "main"
+  },
+  "timeline": [
+    {
+      "id": "26759455062",
+      "type": "merged",
+      "created_at": "2026-06-15T13:27:53Z",
+      "actor": "nevitonsantana",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/195"
+    },
+    {
+      "id": "26759455150",
+      "type": "closed",
+      "created_at": "2026-06-15T13:27:53Z",
+      "actor": "nevitonsantana",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/195"
+    }
+  ],
+  "checks": [
+    {
+      "id": "81431100016",
+      "name": "Governance Check (scripts/check-governance.sh)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T13:23:48Z",
+      "completed_at": "2026-06-15T13:23:53Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100016"
+    },
+    {
+      "id": "81431100060",
+      "name": "Install & TypeScript Build",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T13:23:48Z",
+      "completed_at": "2026-06-15T13:24:08Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100060"
+    },
+    {
+      "id": "81431100067",
+      "name": "Lockfile sync (package.json ↔ pnpm-lock.yaml)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T13:23:48Z",
+      "completed_at": "2026-06-15T13:23:55Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100067"
+    },
+    {
+      "id": "81431197771",
+      "name": "Tests (Vitest)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T13:24:10Z",
+      "completed_at": "2026-06-15T13:24:32Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431197771"
+    },
+    {
+      "id": "81431281805",
+      "name": "Quality Gate (aggregator)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T13:24:34Z",
+      "completed_at": "2026-06-15T13:24:37Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431281805"
+    }
+  ],
+  "reviews": [],
+  "findings": [],
+  "author_reported_validations": [
+    {
+      "id": "local-validation",
+      "name": "Local projector validation",
+      "status": "passed",
+      "summary": "The PR description reports governance, 185 tests, strict TypeScript, diff hygiene, fixture reconstruction, Markdown links, and source-reference checks passing locally.",
+      "reported_at": "2026-06-15T13:23:35Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/195"
+    }
+  ]
+}

--- a/examples/visual-operations/github-pr-195-cli-output.json
+++ b/examples/visual-operations/github-pr-195-cli-output.json
@@ -1,0 +1,343 @@
+{
+  "projection": {
+    "mode": "read_only",
+    "projector": "github_pull_request",
+    "projected_at": "2026-06-15T13:30:00Z",
+    "source_refs": [
+      "https://github.com/nevitonsantana/AletheIA/pull/195"
+    ]
+  },
+  "work_slice_visual_state": {
+    "work_slice_id": "github-pr-195",
+    "title": "feat(visual-ops): add GitHub PR projector",
+    "objective": "unknown",
+    "presentation_lane": "closed",
+    "lane_confidence": "confirmed",
+    "risk_level": "unknown",
+    "planning_depth": "unknown",
+    "readiness_outcome": "unknown",
+    "evidence_status": "sufficient",
+    "human_review": {
+      "required": "unknown",
+      "status": "unavailable",
+      "reviewer_role": null,
+      "open_question": null,
+      "source_refs": []
+    },
+    "primary_skill": {
+      "skill_id": "unknown",
+      "activation_status": "unknown",
+      "source_refs": []
+    },
+    "runtime": {
+      "runtime_id": "unavailable",
+      "session_status": "unavailable",
+      "source_refs": []
+    },
+    "telemetry": {
+      "tokens": {
+        "value": null,
+        "provenance": "unavailable",
+        "source_refs": []
+      },
+      "cost": {
+        "value": null,
+        "currency": null,
+        "provenance": "unavailable",
+        "source_refs": []
+      }
+    },
+    "alerts": [],
+    "evidence": [
+      {
+        "evidence_id": "evidence-check-81431100016",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Governance Check (scripts/check-governance.sh): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100016"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81431100060",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Install & TypeScript Build: completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100060"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81431100067",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Lockfile sync (package.json ↔ pnpm-lock.yaml): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100067"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81431197771",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Tests (Vitest): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431197771"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81431281805",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Quality Gate (aggregator): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431281805"
+        ]
+      },
+      {
+        "evidence_id": "evidence-author-local-validation",
+        "type": "author_reported_validation",
+        "status": "passed",
+        "provenance": "author_reported",
+        "summary": "The PR description reports governance, 185 tests, strict TypeScript, diff hygiene, fixture reconstruction, Markdown links, and source-reference checks passing locally.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/pull/195"
+        ]
+      }
+    ],
+    "source_refs": [
+      "https://github.com/nevitonsantana/AletheIA",
+      "https://github.com/nevitonsantana/AletheIA/pull/195",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100016",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100060",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100067",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431197771",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431281805"
+    ],
+    "projected_at": "2026-06-15T13:30:00Z"
+  },
+  "normalized_events": [
+    {
+      "event_id": "evt-github-pr-195-author-validation-local-validation",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-195",
+      "timestamp": "2026-06-15T13:23:35Z",
+      "source_type": "external",
+      "event_type": "evidence.added",
+      "actor": "nevitonsantana",
+      "summary": "The PR description reports governance, 185 tests, strict TypeScript, diff hygiene, fixture reconstruction, Markdown links, and source-reference checks passing locally.",
+      "payload_metadata": {
+        "validation_name": "Local projector validation",
+        "validation_status": "passed",
+        "provenance": "author_reported"
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/pull/195"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_pull_request_report",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/195"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-195-created",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-195",
+      "timestamp": "2026-06-15T13:23:35Z",
+      "source_type": "external",
+      "event_type": "work_slice.created",
+      "actor": "nevitonsantana",
+      "summary": "GitHub pull request #195 was opened.",
+      "payload_metadata": {
+        "repository": "nevitonsantana/AletheIA",
+        "base_ref": "main",
+        "head_sha": "60e8827af5a2d51b0d8de2641dbfde64830cc1d5",
+        "draft": false
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_pull_request",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/195"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-195-check-81431100016",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-195",
+      "timestamp": "2026-06-15T13:23:53Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Governance Check (scripts/check-governance.sh) reported success.",
+      "payload_metadata": {
+        "check_name": "Governance Check (scripts/check-governance.sh)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100016"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100016"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-195-check-81431100067",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-195",
+      "timestamp": "2026-06-15T13:23:55Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Lockfile sync (package.json ↔ pnpm-lock.yaml) reported success.",
+      "payload_metadata": {
+        "check_name": "Lockfile sync (package.json ↔ pnpm-lock.yaml)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100067"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100067"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-195-check-81431100060",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-195",
+      "timestamp": "2026-06-15T13:24:08Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Install & TypeScript Build reported success.",
+      "payload_metadata": {
+        "check_name": "Install & TypeScript Build",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100060"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100060"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-195-check-81431197771",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-195",
+      "timestamp": "2026-06-15T13:24:32Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Tests (Vitest) reported success.",
+      "payload_metadata": {
+        "check_name": "Tests (Vitest)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431197771"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431197771"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-195-check-81431281805",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-195",
+      "timestamp": "2026-06-15T13:24:37Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Quality Gate (aggregator) reported success.",
+      "payload_metadata": {
+        "check_name": "Quality Gate (aggregator)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431281805"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431281805"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-195-timeline-26759455062",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-195",
+      "timestamp": "2026-06-15T13:27:53Z",
+      "source_type": "external",
+      "event_type": "reconcile.created",
+      "actor": "nevitonsantana",
+      "summary": "GitHub recorded pull request event: merged.",
+      "payload_metadata": {
+        "github_event_type": "merged"
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_timeline_event",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/195"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-195-timeline-26759455150",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-195",
+      "timestamp": "2026-06-15T13:27:53Z",
+      "source_type": "external",
+      "event_type": "reconcile.created",
+      "actor": "nevitonsantana",
+      "summary": "GitHub recorded pull request event: closed.",
+      "payload_metadata": {
+        "github_event_type": "closed"
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_timeline_event",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/195"
+        }
+      ],
+      "sensitivity": "internal"
+    }
+  ],
+  "follow_up_slices": []
+}

--- a/examples/visual-operations/github-pr-195-cli-output.md
+++ b/examples/visual-operations/github-pr-195-cli-output.md
@@ -1,0 +1,41 @@
+# Visual Operations Snapshot — github-pr-195
+
+> Read-only projection generated at 2026-06-15T13:30:00Z. Source records remain authoritative.
+
+## State
+
+| Field | Value |
+|---|---|
+| Title | feat(visual-ops): add GitHub PR projector |
+| Presentation lane | closed (confirmed) |
+| Evidence status | sufficient |
+| Risk | unknown |
+| Planning depth | unknown |
+| Readiness outcome | unknown |
+| Human review | unavailable |
+| Runtime | unavailable |
+| Tokens | unavailable |
+| Cost | unavailable |
+
+## Evidence
+
+| Evidence | Status | Provenance | Source refs |
+|---|---|---|---|
+| Governance Check (scripts/check-governance.sh): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100016 |
+| Install & TypeScript Build: completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100060 |
+| Lockfile sync (package.json ↔ pnpm-lock.yaml): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431100067 |
+| Tests (Vitest): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431197771 |
+| Quality Gate (aggregator): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27549342018/job/81431281805 |
+| The PR description reports governance, 185 tests, strict TypeScript, diff hygiene, fixture reconstruction, Markdown links, and source-reference checks passing locally. | passed | author_reported | https://github.com/nevitonsantana/AletheIA/pull/195 |
+
+## Alerts
+
+| Severity | Type | Summary | Source refs |
+|---|---|---|---|
+| info | none | No projected alerts. | — |
+
+## Follow-up slices
+
+| Work Slice | Reason | Source refs |
+|---|---|---|
+| none | No follow-up slice projected. | — |

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "test:all": "pnpm run check:governance && pnpm run test",
-    "visual-ops:project": "tsc -p tsconfig.visual-ops-cli.json && node dist/visual-ops-cli/scripts/visual-ops-project.js"
+    "test:all": "pnpm run check:governance && pnpm run test"
   },
   "devDependencies": {
     "@types/node": "^25.9.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "test:all": "pnpm run check:governance && pnpm run test"
+    "test:all": "pnpm run check:governance && pnpm run test",
+    "visual-ops:project": "tsc -p tsconfig.visual-ops-cli.json && node dist/visual-ops-cli/scripts/visual-ops-project.js"
   },
   "devDependencies": {
     "@types/node": "^25.9.1",

--- a/scripts/visual-ops-project.sh
+++ b/scripts/visual-ops-project.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+pnpm exec tsc -p tsconfig.visual-ops-cli.json
+exec node dist/visual-ops-cli/scripts/visual-ops-project.js "$@"

--- a/scripts/visual-ops-project.ts
+++ b/scripts/visual-ops-project.ts
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  projectGitHubPullRequest,
+  renderGitHubPullRequestProjectionMarkdown,
+  type GitHubPullRequestProjectionInput,
+} from "../engine/visual-operations-projector.js";
+
+export interface VisualOpsCliOptions {
+  input: string;
+  jsonOutput?: string;
+  markdownOutput?: string;
+  check: boolean;
+}
+
+export interface VisualOpsCliIo {
+  stdout: (message: string) => void;
+  stderr: (message: string) => void;
+}
+
+export const VISUAL_OPS_CHECK_STALE_EXIT_CODE = 2;
+
+const helpText = `Usage:
+  pnpm visual-ops:project -- --input <evidence.json> [--json <snapshot.json>] [--markdown <dashboard.md>]
+  pnpm visual-ops:project -- --input <evidence.json> [--json <snapshot.json>] [--markdown <dashboard.md>] --check
+
+Options:
+  --input       Authorized local GitHub PR evidence JSON.
+  --json        Write the projected JSON snapshot.
+  --markdown    Write the projected Markdown snapshot.
+  --check       Do not write; exit 2 when an output is missing or stale.
+  --help        Show this help.
+
+At least one output is required. The CLI performs no network access and does not collect GitHub data.`;
+
+function requireValue(args: string[], index: number, option: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`${option} requires a value`);
+  return value;
+}
+
+export function parseVisualOpsCliArgs(args: string[]): VisualOpsCliOptions | "help" {
+  let input: string | undefined;
+  let jsonOutput: string | undefined;
+  let markdownOutput: string | undefined;
+  let check = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") continue;
+    if (arg === "--help" || arg === "-h") return "help";
+    if (arg === "--check") {
+      check = true;
+      continue;
+    }
+    if (arg === "--input") {
+      input = requireValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--json") {
+      jsonOutput = requireValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--markdown") {
+      markdownOutput = requireValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown option: ${arg}`);
+  }
+
+  if (!input) throw new Error("--input is required");
+  if (!jsonOutput && !markdownOutput) {
+    throw new Error("at least one of --json or --markdown is required");
+  }
+
+  return { input, jsonOutput, markdownOutput, check };
+}
+
+interface OutputArtifact {
+  label: "json" | "markdown";
+  target: string;
+  content: string;
+}
+
+function resolveArtifacts(options: VisualOpsCliOptions, input: GitHubPullRequestProjectionInput): OutputArtifact[] {
+  const projection = projectGitHubPullRequest(input);
+  const artifacts: OutputArtifact[] = [];
+  if (options.jsonOutput) {
+    artifacts.push({
+      label: "json",
+      target: path.resolve(options.jsonOutput),
+      content: `${JSON.stringify(projection, null, 2)}\n`,
+    });
+  }
+  if (options.markdownOutput) {
+    artifacts.push({
+      label: "markdown",
+      target: path.resolve(options.markdownOutput),
+      content: renderGitHubPullRequestProjectionMarkdown(projection),
+    });
+  }
+  return artifacts;
+}
+
+function validatePaths(inputPath: string, artifacts: OutputArtifact[]): void {
+  const targets = artifacts.map((artifact) => artifact.target);
+  if (new Set(targets).size !== targets.length) {
+    throw new Error("JSON and Markdown outputs must use different paths");
+  }
+  if (targets.includes(inputPath)) {
+    throw new Error("an output path must not overwrite the input evidence file");
+  }
+  for (const target of targets) {
+    if (!fs.existsSync(target)) continue;
+    const stat = fs.lstatSync(target);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error(`output path must be a regular file or not exist: ${target}`);
+    }
+  }
+}
+
+function tempPath(target: string, suffix: string): string {
+  return path.join(
+    path.dirname(target),
+    `.${path.basename(target)}.${process.pid}.${Date.now()}.${suffix}`,
+  );
+}
+
+export function writeArtifactsAtomically(artifacts: OutputArtifact[]): void {
+  const staged = artifacts.map((artifact) => ({
+    ...artifact,
+    temp: tempPath(artifact.target, "tmp"),
+    backup: tempPath(artifact.target, "bak"),
+    hadOriginal: fs.existsSync(artifact.target),
+    installed: false,
+  }));
+
+  try {
+    for (const artifact of staged) {
+      fs.mkdirSync(path.dirname(artifact.target), { recursive: true });
+      fs.writeFileSync(artifact.temp, artifact.content, { encoding: "utf8", flag: "wx" });
+    }
+    for (const artifact of staged) {
+      if (artifact.hadOriginal) fs.renameSync(artifact.target, artifact.backup);
+    }
+    for (const artifact of staged) {
+      fs.renameSync(artifact.temp, artifact.target);
+      artifact.installed = true;
+    }
+  } catch (error) {
+    for (const artifact of [...staged].reverse()) {
+      if (artifact.installed && fs.existsSync(artifact.target)) fs.unlinkSync(artifact.target);
+      if (artifact.hadOriginal && fs.existsSync(artifact.backup)) {
+        fs.renameSync(artifact.backup, artifact.target);
+      }
+      if (fs.existsSync(artifact.temp)) fs.unlinkSync(artifact.temp);
+    }
+    throw error;
+  }
+  for (const artifact of staged) {
+    if (!artifact.hadOriginal || !fs.existsSync(artifact.backup)) continue;
+    try {
+      fs.unlinkSync(artifact.backup);
+    } catch {
+      // Outputs are already committed. A retained backup is safer than destructive rollback.
+    }
+  }
+}
+
+function checkArtifacts(artifacts: OutputArtifact[]): string[] {
+  return artifacts
+    .filter(
+      (artifact) =>
+        !fs.existsSync(artifact.target) || fs.readFileSync(artifact.target, "utf8") !== artifact.content,
+    )
+    .map((artifact) => artifact.target);
+}
+
+function readInput(inputPath: string): GitHubPullRequestProjectionInput {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(inputPath, "utf8"));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`could not read input JSON: ${message}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("input JSON must contain an object");
+  }
+  return parsed as GitHubPullRequestProjectionInput;
+}
+
+export function runVisualOpsCli(
+  args: string[],
+  io: VisualOpsCliIo = {
+    stdout: (message) => process.stdout.write(`${message}\n`),
+    stderr: (message) => process.stderr.write(`${message}\n`),
+  },
+): number {
+  try {
+    const options = parseVisualOpsCliArgs(args);
+    if (options === "help") {
+      io.stdout(helpText);
+      return 0;
+    }
+
+    const inputPath = path.resolve(options.input);
+    const input = readInput(inputPath);
+    const artifacts = resolveArtifacts(options, input);
+    validatePaths(inputPath, artifacts);
+
+    if (options.check) {
+      const stale = checkArtifacts(artifacts);
+      if (stale.length > 0) {
+        io.stderr(`Visual Operations outputs are missing or stale:\n${stale.join("\n")}`);
+        return VISUAL_OPS_CHECK_STALE_EXIT_CODE;
+      }
+      io.stdout(`Visual Operations outputs are current (${artifacts.length}).`);
+      return 0;
+    }
+
+    writeArtifactsAtomically(artifacts);
+    io.stdout(`Wrote ${artifacts.length} Visual Operations output(s).`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    io.stderr(`visual-ops project failed: ${message}`);
+    return 1;
+  }
+}
+
+const isDirectExecution =
+  Boolean(process.argv[1]) && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (isDirectExecution) process.exitCode = runVisualOpsCli(process.argv.slice(2));

--- a/scripts/visual-ops-project.ts
+++ b/scripts/visual-ops-project.ts
@@ -24,8 +24,8 @@ export interface VisualOpsCliIo {
 export const VISUAL_OPS_CHECK_STALE_EXIT_CODE = 2;
 
 const helpText = `Usage:
-  pnpm visual-ops:project -- --input <evidence.json> [--json <snapshot.json>] [--markdown <dashboard.md>]
-  pnpm visual-ops:project -- --input <evidence.json> [--json <snapshot.json>] [--markdown <dashboard.md>] --check
+  ./scripts/visual-ops-project.sh --input <evidence.json> [--json <snapshot.json>] [--markdown <dashboard.md>]
+  ./scripts/visual-ops-project.sh --input <evidence.json> [--json <snapshot.json>] [--markdown <dashboard.md>] --check
 
 Options:
   --input       Authorized local GitHub PR evidence JSON.

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -223,6 +223,7 @@ truth, read and adapt:
 - `examples/visual-operations/github-pr-projector-output.json`
 - `examples/visual-operations/github-pr-projector-output.md`
 - `scripts/visual-ops-project.ts`
+- `scripts/visual-ops-project.sh`
 - `examples/visual-operations/github-pr-195-cli-input.json`
 - `examples/visual-operations/github-pr-195-cli-output.json`
 - `examples/visual-operations/github-pr-195-cli-output.md`

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -222,6 +222,10 @@ truth, read and adapt:
 - `examples/visual-operations/github-pr-projector-input.json`
 - `examples/visual-operations/github-pr-projector-output.json`
 - `examples/visual-operations/github-pr-projector-output.md`
+- `scripts/visual-ops-project.ts`
+- `examples/visual-operations/github-pr-195-cli-input.json`
+- `examples/visual-operations/github-pr-195-cli-output.json`
+- `examples/visual-operations/github-pr-195-cli-output.md`
 
 These materials are read-only projection guidance. Board lanes are presentation states, events retain
 their authoritative `source_refs`, and missing telemetry remains `unknown` or `unavailable`.

--- a/tests/visual-operations/test-visual-ops-cli.test.ts
+++ b/tests/visual-operations/test-visual-ops-cli.test.ts
@@ -1,0 +1,186 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  VISUAL_OPS_CHECK_STALE_EXIT_CODE,
+  parseVisualOpsCliArgs,
+  runVisualOpsCli,
+  writeArtifactsAtomically,
+} from "../../scripts/visual-ops-project";
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "aletheia-visual-ops-cli-"));
+  tempDirs.push(directory);
+  return directory;
+}
+
+function copyInput(directory: string): string {
+  const target = path.join(directory, "evidence.json");
+  fs.copyFileSync(
+    path.resolve(process.cwd(), "examples/visual-operations/github-pr-projector-input.json"),
+    target,
+  );
+  return target;
+}
+
+function captureIo(): { stdout: string[]; stderr: string[]; io: { stdout: (value: string) => void; stderr: (value: string) => void } } {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    io: {
+      stdout: (value) => stdout.push(value),
+      stderr: (value) => stderr.push(value),
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const directory of tempDirs.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe("Visual Operations local CLI", () => {
+  it("parses explicit local input and output options", () => {
+    expect(
+      parseVisualOpsCliArgs([
+        "--",
+        "--input",
+        "evidence.json",
+        "--json",
+        "snapshot.json",
+        "--markdown",
+        "dashboard.md",
+        "--check",
+      ]),
+    ).toEqual({
+      input: "evidence.json",
+      jsonOutput: "snapshot.json",
+      markdownOutput: "dashboard.md",
+      check: true,
+    });
+  });
+
+  it("writes deterministic JSON and Markdown outputs", () => {
+    const directory = tempDir();
+    const input = copyInput(directory);
+    const json = path.join(directory, "snapshot.json");
+    const markdown = path.join(directory, "dashboard.md");
+    const capture = captureIo();
+
+    expect(
+      runVisualOpsCli(
+        ["--input", input, "--json", json, "--markdown", markdown],
+        capture.io,
+      ),
+    ).toBe(0);
+    expect(JSON.parse(fs.readFileSync(json, "utf8"))).toMatchObject({
+      projection: { mode: "read_only", projector: "github_pull_request" },
+      work_slice_visual_state: { work_slice_id: "github-pr-193" },
+    });
+    expect(fs.readFileSync(markdown, "utf8")).toContain(
+      "# Visual Operations Snapshot — github-pr-193",
+    );
+    expect(capture.stdout).toEqual(["Wrote 2 Visual Operations output(s)."]);
+  });
+
+  it("checks current outputs without writing", () => {
+    const directory = tempDir();
+    const input = copyInput(directory);
+    const json = path.join(directory, "snapshot.json");
+    const markdown = path.join(directory, "dashboard.md");
+    const args = ["--input", input, "--json", json, "--markdown", markdown];
+
+    expect(runVisualOpsCli(args, captureIo().io)).toBe(0);
+    const before = fs.statSync(json).mtimeMs;
+    const capture = captureIo();
+    expect(runVisualOpsCli([...args, "--check"], capture.io)).toBe(0);
+    expect(fs.statSync(json).mtimeMs).toBe(before);
+    expect(capture.stdout).toEqual(["Visual Operations outputs are current (2)."]);
+  });
+
+  it("returns exit code 2 when an output is stale", () => {
+    const directory = tempDir();
+    const input = copyInput(directory);
+    const json = path.join(directory, "snapshot.json");
+    fs.writeFileSync(json, "{}\n");
+    const capture = captureIo();
+
+    expect(
+      runVisualOpsCli(["--input", input, "--json", json, "--check"], capture.io),
+    ).toBe(VISUAL_OPS_CHECK_STALE_EXIT_CODE);
+    expect(capture.stderr[0]).toContain("missing or stale");
+    expect(fs.readFileSync(json, "utf8")).toBe("{}\n");
+  });
+
+  it("refuses to overwrite its input evidence", () => {
+    const directory = tempDir();
+    const input = copyInput(directory);
+    const original = fs.readFileSync(input, "utf8");
+    const capture = captureIo();
+
+    expect(runVisualOpsCli(["--input", input, "--json", input], capture.io)).toBe(1);
+    expect(capture.stderr[0]).toContain("must not overwrite the input");
+    expect(fs.readFileSync(input, "utf8")).toBe(original);
+  });
+
+  it("refuses non-file and symbolic-link output targets", () => {
+    const directory = tempDir();
+    const input = copyInput(directory);
+    const outputDirectory = path.join(directory, "snapshot.json");
+    fs.mkdirSync(outputDirectory);
+    const captureDirectory = captureIo();
+
+    expect(
+      runVisualOpsCli(["--input", input, "--json", outputDirectory], captureDirectory.io),
+    ).toBe(1);
+    expect(captureDirectory.stderr[0]).toContain("must be a regular file or not exist");
+
+    const linkedOutput = path.join(directory, "linked-output.json");
+    fs.symlinkSync(input, linkedOutput);
+    const captureLink = captureIo();
+    expect(runVisualOpsCli(["--input", input, "--json", linkedOutput], captureLink.io)).toBe(1);
+    expect(captureLink.stderr[0]).toContain("must be a regular file or not exist");
+  });
+
+  it("restores all previous outputs when installation fails", () => {
+    const directory = tempDir();
+    const json = path.join(directory, "snapshot.json");
+    const markdown = path.join(directory, "dashboard.md");
+    fs.writeFileSync(json, "old-json");
+    fs.writeFileSync(markdown, "old-markdown");
+    const rename = fs.renameSync.bind(fs);
+    let calls = 0;
+    vi.spyOn(fs, "renameSync").mockImplementation((oldPath, newPath) => {
+      calls += 1;
+      if (calls === 4) throw new Error("synthetic install failure");
+      return rename(oldPath, newPath);
+    });
+
+    expect(() =>
+      writeArtifactsAtomically([
+        { label: "json", target: json, content: "new-json" },
+        { label: "markdown", target: markdown, content: "new-markdown" },
+      ]),
+    ).toThrow("synthetic install failure");
+    expect(fs.readFileSync(json, "utf8")).toBe("old-json");
+    expect(fs.readFileSync(markdown, "utf8")).toBe("old-markdown");
+    expect(fs.readdirSync(directory).sort()).toEqual(["dashboard.md", "snapshot.json"]);
+  });
+
+  it("reports malformed JSON without creating an output", () => {
+    const directory = tempDir();
+    const input = path.join(directory, "evidence.json");
+    const output = path.join(directory, "snapshot.json");
+    fs.writeFileSync(input, "{broken");
+    const capture = captureIo();
+
+    expect(runVisualOpsCli(["--input", input, "--json", output], capture.io)).toBe(1);
+    expect(capture.stderr[0]).toContain("could not read input JSON");
+    expect(fs.existsSync(output)).toBe(false);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,6 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["engine/**/*", "tests/**/*"],
+  "include": ["engine/**/*", "scripts/**/*.ts", "tests/**/*"],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.visual-ops-cli.json
+++ b/tsconfig.visual-ops-cli.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": false,
+    "outDir": "dist/visual-ops-cli",
+    "rootDir": "."
+  },
+  "include": [
+    "engine/visual-operations-projector.ts",
+    "scripts/visual-ops-project.ts"
+  ]
+}


### PR DESCRIPTION
## What changed

- adds a local file-only CLI over the existing GitHub PR Visual Operations projector
- supports deterministic JSON and Markdown output
- adds `--check` with exit code 2 for missing or stale snapshots
- stages all outputs before installation and restores previous files if installation fails
- refuses input overwrite, shared output paths, directories, and symbolic-link targets
- adds a second real pilot using merged PR #195
- documents commands, exit codes, safety boundaries, and starter-pack/example references

## Why it changed

The projector was available only as a TypeScript library. This bounded adapter makes it operational for authorized local evidence without adding GitHub collection, network access, a backend, database, UI, or new authority.

## How to validate

- `pnpm check:governance`
- `pnpm test` — 19 files and 193 tests passed
- `pnpm exec tsc --noEmit`
- `./scripts/visual-ops-project.sh --input examples/visual-operations/github-pr-195-cli-input.json --json examples/visual-operations/github-pr-195-cli-output.json --markdown examples/visual-operations/github-pr-195-cli-output.md --check`
- `git diff --check`
- Markdown links, JSON parsing, and absence of network/runtime imports checked locally

## Risks, assumptions, or follow-ups

- evidence collection and authorization remain outside the CLI
- the executable wrapper compiles its bounded TypeScript entrypoint into ignored `dist/` before execution
- `package.json` and `pnpm-lock.yaml` remain unchanged from `main`
- atomic replacement is filesystem-local; backup restoration is tested with a synthetic mid-install failure
- retained backup files are preferred over destructive rollback if post-commit backup cleanup itself fails
- no Adaptive Skills integration is included
- the next useful step is to evaluate whether `--check` belongs in CI for selected checked-in examples