### PR TITLE
ci(visual-ops): verify projected snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,21 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
+  visual-operations-snapshots:
+    name: Visual Operations Snapshots
+    runs-on: ubuntu-latest
+    needs: install-and-typecheck
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Verify selected Visual Operations snapshots
+        run: ./scripts/check-visual-ops-snapshots.sh
+
   lockfile-sync:
     name: Lockfile sync (package.json ↔ pnpm-lock.yaml)
     runs-on: ubuntu-latest
@@ -87,6 +102,7 @@ jobs:
       - install-and-typecheck
       - governance
       - test
+      - visual-operations-snapshots
     steps:
       - name: All required checks passed
         run: echo "Quality Gate passed."

--- a/docs/guides/github-pr-visual-operations-projector.md
+++ b/docs/guides/github-pr-visual-operations-projector.md
@@ -57,6 +57,22 @@ Writes are staged in the destination directories and installed only after all ou
 been generated. If installation fails, previous outputs are restored. The CLI also refuses to use
 the input file as an output or to point JSON and Markdown at the same path.
 
+## CI snapshot check
+
+The CI workflow runs:
+
+```bash
+./scripts/check-visual-ops-snapshots.sh
+```
+
+The script compiles the local CLI once and runs `--check` for an explicit list of reviewed snapshot
+sets. It does not discover examples with a wildcard: adding a fixture to CI is a deliberate change
+to `snapshot_sets` in the script. This prevents temporary or sensitive local files from silently
+becoming governed CI inputs.
+
+The `Visual Operations Snapshots` job is a dependency of the aggregate Quality Gate. A stale or
+missing checked-in output therefore blocks the gate without rewriting the file in CI.
+
 ## Conservative derivation rules
 
 1. A merged or authoritatively closed PR projects to the `closed` presentation lane.

--- a/scripts/check-visual-ops-snapshots.sh
+++ b/scripts/check-visual-ops-snapshots.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+# Only durable, intentionally reviewed examples belong here. Adding a snapshot is an explicit
+# governance choice; discovery by wildcard could silently promote temporary files into CI scope.
+snapshot_sets=(
+  "examples/visual-operations/github-pr-195-cli-input.json|examples/visual-operations/github-pr-195-cli-output.json|examples/visual-operations/github-pr-195-cli-output.md"
+)
+
+pnpm exec tsc -p tsconfig.visual-ops-cli.json
+
+for snapshot_set in "${snapshot_sets[@]}"; do
+  IFS='|' read -r input json_output markdown_output <<< "$snapshot_set"
+  node dist/visual-ops-cli/scripts/visual-ops-project.js \
+    --input "$input" \
+    --json "$json_output" \
+    --markdown "$markdown_output" \
+    --check
+done
+
+echo "Visual Operations snapshot check passed (${#snapshot_sets[@]} set(s))."

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -224,6 +224,7 @@ truth, read and adapt:
 - `examples/visual-operations/github-pr-projector-output.md`
 - `scripts/visual-ops-project.ts`
 - `scripts/visual-ops-project.sh`
+- `scripts/check-visual-ops-snapshots.sh`
 - `examples/visual-operations/github-pr-195-cli-input.json`
 - `examples/visual-operations/github-pr-195-cli-output.json`
 - `examples/visual-operations/github-pr-195-cli-output.md`


### PR DESCRIPTION
## What changed

- adds an explicit allowlist-based checker for reviewed Visual Operations snapshot sets
- compiles the local projector CLI once and runs each selected fixture in read-only `--check` mode
- adds a dedicated `Visual Operations Snapshots` GitHub Actions job
- makes the snapshot job a dependency of the aggregate Quality Gate
- documents how fixtures enter CI scope and why wildcard discovery is intentionally avoided

## Why it changed

The local CLI made checked-in JSON and Markdown projections reproducible, but CI did not yet prevent those outputs from drifting away from their authorized evidence inputs. This change adds that protection without collecting data, regenerating files, or introducing a new authority.

## How to validate

- `bash -n scripts/check-visual-ops-snapshots.sh`
- workflow YAML parsing
- `./scripts/check-visual-ops-snapshots.sh`
- stale-output probe confirms exit code 2 and no rewrite
- `pnpm check:governance`
- `pnpm test` — 19 files and 193 tests passed
- `pnpm exec tsc --noEmit`
- `git diff --check`
- `package.json` and `pnpm-lock.yaml` remain unchanged

## Risks, assumptions, or follow-ups

- only the explicitly listed PR #195 snapshot set is governed in this slice
- adding another snapshot requires a deliberate edit to `snapshot_sets`
- CI is read-only and will fail rather than regenerate stale outputs
- the new job installs existing dependencies in an isolated runner, adding a small amount of CI time
- no GitHub evidence collection, network adapter, UI, backend, or Adaptive Skills integration is introduced