### PR TITLE
docs(visual-ops): close first projection phase

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ Reading map organized by intent. Each entry links to the most useful starting po
 5. [Visual Operations Privacy Boundaries](contracts/visual-ops-privacy-boundaries.md) — metadata-first handling of sensitive sources
 6. [Synthetic Mission Control example](../examples/visual-operations/dashboard-snapshot.md) — reconstructible static snapshot
 7. [GitHub PR projector](guides/github-pr-visual-operations-projector.md) — deterministic JSON and Markdown projection from supplied evidence
+8. [Visual Operations phase closeout](pilots/closeouts/2026-06-15-visual-operations-phase-closeout.md) — delivered boundary, evidence, and future activation gates
 
 ---
 

--- a/docs/pilots/README.md
+++ b/docs/pilots/README.md
@@ -19,6 +19,7 @@ Operation closeouts (session/task records from Hermes and other runtimes) live i
 | [resource-aware-operations-review.md](resource-aware-operations-review.md) | Consolidation of what the 1.2 track proves |
 | [report-core-operating-path-friction-test.md](report-core-operating-path-friction-test.md) | Friction test: is `core-operating-path.md` sufficient for first use? |
 | [visual-operations-pr-193-retrospective.md](visual-operations-pr-193-retrospective.md) | Retrospective reconstruction of PR #193 using the Visual Operations vocabulary |
+| [Visual Operations phase closeout](closeouts/2026-06-15-visual-operations-phase-closeout.md) | Closure evidence and activation gates after PRs #193–#197 |
 
 ## Cycle records
 

--- a/docs/pilots/closeouts/2026-06-15-visual-operations-phase-closeout.md
+++ b/docs/pilots/closeouts/2026-06-15-visual-operations-phase-closeout.md
@@ -1,0 +1,177 @@
+# Visual Operations Phase Closeout
+
+## Identification
+
+| Field | Value |
+|---|---|
+| Title | AletheIA Visual Operations docs-first phase closeout |
+| Date | 2026-06-15 |
+| Repository | `nevitonsantana/AletheIA` |
+| Delivery PRs | [#193](https://github.com/nevitonsantana/AletheIA/pull/193), [#194](https://github.com/nevitonsantana/AletheIA/pull/194), [#195](https://github.com/nevitonsantana/AletheIA/pull/195), [#196](https://github.com/nevitonsantana/AletheIA/pull/196), [#197](https://github.com/nevitonsantana/AletheIA/pull/197) |
+| Final merge commit | [`01f67e8`](https://github.com/nevitonsantana/AletheIA/commit/01f67e877e15ed1bf0e1cf289f1567c314b21b6d) |
+| Executor | Codex |
+| Human operator | Neviton Santana |
+
+## Intent
+
+Close the first Visual Operations phase after proving that AletheIA can project governed work into
+source-backed JSON and Markdown without creating another authority, lifecycle, collector, backend,
+or dashboard runtime.
+
+This closeout records what is complete, what remains intentionally unavailable, and which evidence
+must exist before a future phase can expand the surface.
+
+## Scope completed
+
+The phase delivered five bounded slices:
+
+| Slice | Durable result | Merge commit |
+|---|---|---|
+| Docs-first projection | Concepts, event envelope, derived Work Slice state, privacy boundaries, templates, and synthetic example | [`88fc7b2`](https://github.com/nevitonsantana/AletheIA/commit/88fc7b24924cd92f7b6a41951b3514cca28c7298) |
+| First real retrospective | PR #193 reconstructed from durable GitHub evidence; `regulated` sensitivity drift corrected | [`f7d9b5b`](https://github.com/nevitonsantana/AletheIA/commit/f7d9b5b4c3ce08f96bddeb0961b2c3c734861a12) |
+| Deterministic projector | Pure TypeScript GitHub PR input → normalized events, Work Slice snapshot, follow-ups, and Markdown | [`c6c2610`](https://github.com/nevitonsantana/AletheIA/commit/c6c2610e29ba703554391fed063ca126fc47cbc4) |
+| Local CLI | File-only generation, `--check`, transactional output replacement, and PR #195 pilot | [`c65b658`](https://github.com/nevitonsantana/AletheIA/commit/c65b6589b54184db053027e264d2be0d4f4fc401) |
+| CI snapshot gate | Explicit allowlist check required by the aggregate Quality Gate | [`01f67e8`](https://github.com/nevitonsantana/AletheIA/commit/01f67e877e15ed1bf0e1cf289f1567c314b21b6d) |
+
+## Current operating path
+
+The implemented path is:
+
+```text
+authorized local evidence JSON
+  -> deterministic read-only projector
+  -> normalized events + derived Work Slice state
+  -> JSON and/or Markdown snapshot
+  -> local --check
+  -> selected snapshot sets verified by CI
+```
+
+The source evidence remains authoritative at every step. Generated snapshots are navigation and
+review aids only.
+
+Primary operational surfaces:
+
+- [Visual Operations Layer](../../concepts/visual-operations-layer.md);
+- [GitHub PR projector guide](../../guides/github-pr-visual-operations-projector.md);
+- [`engine/visual-operations-projector.ts`](../../../engine/visual-operations-projector.ts);
+- [`scripts/visual-ops-project.sh`](../../../scripts/visual-ops-project.sh);
+- [`scripts/check-visual-ops-snapshots.sh`](../../../scripts/check-visual-ops-snapshots.sh);
+- [PR #193 retrospective](../visual-operations-pr-193-retrospective.md);
+- [PR #195 CLI snapshot](../../../examples/visual-operations/github-pr-195-cli-output.md).
+
+## Validation evidence
+
+Across PRs #193–#197:
+
+- every merge was protected by the verified head SHA;
+- governance, TypeScript, lockfile, Vitest, and aggregate Quality Gate checks passed;
+- the final CI slice added and passed `Visual Operations Snapshots` as a sixth check;
+- the test suite reached 193 passing tests in 19 files at the end of the CLI slice;
+- the checked-in PR #195 JSON and Markdown outputs passed the local and CI `--check` path;
+- a controlled stale-output probe exited with code `2` and did not rewrite the file;
+- `package.json` and `pnpm-lock.yaml` remained unchanged by the CLI and CI slices;
+- the unrelated local `plans/` directory remained outside every commit.
+
+These claims are bounded to the repository and linked GitHub records. They are not provider-runtime
+telemetry.
+
+## Reconcile
+
+### Work Slice
+
+- Final presentation lane: `closed`.
+- Lane confidence: `confirmed` by merged PRs and synchronized `main`.
+- Source refs: PRs #193–#197 and their merge commits listed above.
+
+### Outcome
+
+- What changed: A docs-first vocabulary became a deterministic, locally operable, CI-verified
+  projection path.
+- Validation outcome: passed for the implemented repository surfaces.
+- Evidence status: sufficient for closing this phase.
+- Human review status: user authorization was required and obtained before each merge; no separate
+  durable GitHub review requirement was recorded, so the canonical review requirement remains
+  `unknown`.
+
+### Resource signals
+
+- Tokens: `unavailable` — no governed provider telemetry was attached to these slices.
+- Cost: `unavailable` — no governed cost record was attached.
+- Runtime: local execution occurred, but no authoritative runtime-session record was exported for
+  this phase.
+- Retry posture: bounded corrections were made for sensitivity vocabulary, pnpm argument forwarding,
+  and package/lockfile CI behavior.
+
+Missing telemetry is preserved as unavailable rather than reconstructed from conversation history.
+
+## Boundary decisions preserved
+
+The phase does **not** introduce:
+
+- a new Work Slice lifecycle or state machine;
+- a readiness, policy, gate, or decision authority;
+- GitHub API collection, polling, webhooks, or remote importers;
+- a database, event bus, backend, dashboard runtime, or static UI;
+- automatic regeneration in CI;
+- prompt, secret, restricted-content, or personal-data storage;
+- token or cost estimates without a governed source;
+- Adaptive Skills authority over gates or decisions;
+- mandatory integration for consumer projects.
+
+Presentation lanes remain derived. Events remain normalized references to existing records. Skills,
+if integrated later, remain traceable activations rather than governance authorities.
+
+## Accepted learnings
+
+1. **Projection is useful before collection.** Real PR evidence was enough to validate the model and
+   reveal contract drift without a remote importer.
+2. **Missing data is an operational result.** Planning depth, human-authorization rationale, skills,
+   runtime, tokens, and cost cannot be inferred from merge success.
+3. **Evidence provenance matters.** CI-observed evidence must remain distinct from author-reported
+   local validation.
+4. **Historical closure is stable.** Post-close findings create linked follow-up slices; they do not
+   reopen the original historical lane.
+5. **Operational adapters should stay narrow.** A local file CLI made the projection usable without
+   coupling it to GitHub or changing package dependencies.
+6. **CI should verify, not mutate.** The snapshot gate detects drift through an explicit allowlist and
+   never rewrites governed outputs.
+
+## Deferred surfaces and activation evidence
+
+| Deferred surface | Evidence required before activation |
+|---|---|
+| GitHub collector or importer | At least two repeated manual evidence-assembly cases where collection effort or errors materially limit the projector, plus explicit authentication, rate-limit, privacy, and failure-mode boundaries |
+| Dashboard or UI | At least three real snapshots used in an actual review cadence, with documented decisions that Markdown/JSON could not support clearly |
+| Persistent event store or backend | A demonstrated need for cross-slice querying or retention that checked-in artifacts cannot satisfy, including ownership and deletion requirements |
+| Adaptive Skills integration | A durable, non-sensitive skill-activation record from a real slice and a reviewed mapping that preserves AletheIA gate authority |
+| Runtime, token, or cost telemetry | An authoritative provider or harness record with consent, provenance, sensitivity classification, and unavailable fallback |
+| Additional CI snapshot | A reviewed real fixture that adds a distinct scenario; explicit addition to `snapshot_sets` is required |
+
+These are activation gates, not roadmap commitments.
+
+## Stop conditions
+
+Do not open the next phase merely to add surface area. Stop or reframe if a proposal:
+
+- makes the projection authoritative;
+- invents values to complete cards;
+- duplicates AHGE, readiness, decision, execution, handoff, restart, or learning records;
+- requires sensitive source bodies instead of metadata-first references;
+- couples Adaptive Skills to macro governance;
+- adds remote collection before its operational need and threat boundary are evidenced.
+
+## Recommended next boundary
+
+Keep the phase closed until real usage supplies one of the activation signals above.
+
+The smallest acceptable follow-up is evidence collection about **usage of the existing outputs**:
+record whether a maintainer used a generated snapshot during review, what decision it supported, and
+which field was missing or misleading. That learning can be a short pilot report; it does not require
+new runtime or product code.
+
+## Closeout verdict
+
+**Closed as complete for the docs-first, local projection, and CI-verification boundary.**
+
+The implemented system observes and explains governed work without governing, authorizing, or
+executing it. Future expansion requires empirical activation evidence and a new bounded Work Slice.

--- a/docs/pilots/closeouts/README.md
+++ b/docs/pilots/closeouts/README.md
@@ -1,7 +1,14 @@
 # Closeouts
 
-Individual operation records from bounded execution sessions. Each file is a completed closeout following the [Hermes closeout template](../../starter-pack/templates/hermes-closeout-template.md).
+Individual operation records from bounded execution sessions. Each file is a completed closeout following the [Hermes closeout template](../../../starter-pack/templates/hermes-closeout-template.md).
 
 Files are named `YYYY-MM-DD-<slug>.md` or `<system>-<slug>-closeout.md`.
 
 Previously located in `docs/aletheia/closeouts/` and `docs/hermes/`. Moved here 2026-05-20 — see [`_meta/MIGRATION.md`](../../_meta/MIGRATION.md).
+
+## Phase closeouts
+
+| Document | What it closes |
+|---|---|
+| [2026-06-15-visual-operations-phase-closeout.md](2026-06-15-visual-operations-phase-closeout.md) | Visual Operations docs-first contracts, real pilots, projector, local CLI, and CI snapshot gate |
+| [2026-05-19-spec-planning-cross-repo-closeout.md](2026-05-19-spec-planning-cross-repo-closeout.md) | AletheIA and Adaptive Skills planning/specification facilitation alignment |


### PR DESCRIPTION
## What changed

- adds the closeout for the first Visual Operations phase
- consolidates delivery and validation evidence from PRs #193–#197
- records the final read-only operating path and unavailable telemetry posture
- preserves boundaries against new authority, lifecycle, collector, backend, UI, persistence, and premature Adaptive Skills integration
- defines empirical activation evidence for each deferred future surface
- adds stop conditions and the smallest acceptable usage-evidence follow-up
- updates docs and pilot closeout indexes
- fixes the pre-existing relative link to the Hermes closeout template

## Why it changed

The phase now has contracts, a real retrospective, a deterministic projector, a safe local CLI, and a CI snapshot gate. A durable reconcile is needed before any expansion so future work starts from explicit evidence rather than momentum or surface-area growth.

## How to validate

- `pnpm check:governance`
- `pnpm test` — 19 files and 193 tests passed
- `pnpm exec tsc --noEmit`
- `./scripts/check-visual-ops-snapshots.sh`
- `git diff --check`
- local Markdown link validation for the closeout and indexes
- merge commit references for PRs #193–#197 verified locally

## Risks, assumptions, or follow-ups

- this closeout is field evidence and a phase boundary, not a new architectural authority
- activation criteria are evidence gates, not roadmap commitments
- tokens, cost, runtime telemetry, skill activation, planning depth, and canonical review requirement remain unavailable or unknown when no durable source exists
- the next acceptable slice is usage evidence about existing snapshots
- remote collection, UI, persistence, telemetry, or Adaptive Skills integration remain deferred