### PR TITLE
docs(visual-ops): add usage evidence capture

### DIFF
--- a/docs/guides/visual-operations-usage-evidence.md
+++ b/docs/guides/visual-operations-usage-evidence.md
@@ -1,0 +1,80 @@
+# Visual Operations Usage Evidence
+
+## Purpose
+
+Use this guide when a maintainer, reviewer, or operator actually uses a generated Visual Operations
+snapshot to support a review, handoff, closeout, or planning decision.
+
+The goal is to capture usage evidence before expanding the Visual Operations surface. A usage record
+is field evidence; it is not a new authority, lifecycle, importer, dashboard, or telemetry source.
+
+## When to create a record
+
+Create a usage evidence record only when all are true:
+
+1. a generated JSON or Markdown snapshot was opened during a real review or decision;
+2. the reviewer can name the question or decision it supported;
+3. the record can cite source references without copying restricted content;
+4. missing signals can remain `unknown` or `unavailable`.
+
+Do not create a record just because a snapshot exists, CI passed, or a PR merged.
+
+## Template
+
+Copy:
+
+```text
+starter-pack/templates/visual-ops-usage-evidence-template.md
+```
+
+Recommended destination for repository-local evidence:
+
+```text
+docs/pilots/visual-operations-usage-<short-slug>.md
+```
+
+A usage record may also stay outside the repository if the review context includes private or
+restricted information. In that case, store only an allowed summary or reference in AletheIA.
+
+## What to record
+
+A useful record answers:
+
+- which snapshot was used;
+- which decision, question, or review it supported;
+- which fields helped;
+- which fields were missing, stale, misleading, or too noisy;
+- whether source PRs, CI jobs, or evidence files still had to be opened;
+- whether the evidence supports a future surface, such as another CI snapshot or a field-mapping
+  improvement.
+
+Do not infer planning depth, human-review requirements, skill activations, runtime sessions, tokens,
+or cost unless a durable source explicitly provides them.
+
+## Activation discipline
+
+One usage record is not enough to justify broad infrastructure. Treat it as input to the activation
+signals in the [Visual Operations phase closeout](../pilots/closeouts/2026-06-15-visual-operations-phase-closeout.md).
+
+Examples:
+
+| If the usage shows... | Small next slice |
+|---|---|
+| A checked-in snapshot caught drift or supported review clearly | Add that specific snapshot to the explicit CI allowlist |
+| A field was misleading or missing across repeated reviews | Patch projector mapping or snapshot wording |
+| Manual evidence assembly repeatedly caused mistakes | Propose a bounded collector/importer with authentication and privacy guardrails |
+| Reviewers could not use Markdown/JSON in a real cadence | Consider a UI prototype, but only after documenting the failed review path |
+
+## Non-goals
+
+- no backfilled proof from memory;
+- no storage of prompts, secrets, or restricted source bodies;
+- no automatic promotion from usage evidence to roadmap commitment;
+- no new decision, readiness, policy, or Work Slice authority;
+- no remote collection or UI work in the evidence record itself.
+
+## Related
+
+- [GitHub PR Visual Operations Projector](github-pr-visual-operations-projector.md)
+- [Visual Operations phase closeout](../pilots/closeouts/2026-06-15-visual-operations-phase-closeout.md)
+- [Visual Operations Privacy Boundaries](../contracts/visual-ops-privacy-boundaries.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ Reading map organized by intent. Each entry links to the most useful starting po
 6. [Synthetic Mission Control example](../examples/visual-operations/dashboard-snapshot.md) — reconstructible static snapshot
 7. [GitHub PR projector](guides/github-pr-visual-operations-projector.md) — deterministic JSON and Markdown projection from supplied evidence
 8. [Visual Operations phase closeout](pilots/closeouts/2026-06-15-visual-operations-phase-closeout.md) — delivered boundary, evidence, and future activation gates
+9. [Usage evidence guide](guides/visual-operations-usage-evidence.md) — how to record real snapshot use without backfilling or expanding scope
 
 ---
 

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -225,6 +225,8 @@ truth, read and adapt:
 - `scripts/visual-ops-project.ts`
 - `scripts/visual-ops-project.sh`
 - `scripts/check-visual-ops-snapshots.sh`
+- `docs/guides/visual-operations-usage-evidence.md`
+- `starter-pack/templates/visual-ops-usage-evidence-template.md`
 - `examples/visual-operations/github-pr-195-cli-input.json`
 - `examples/visual-operations/github-pr-195-cli-output.json`
 - `examples/visual-operations/github-pr-195-cli-output.md`

--- a/starter-pack/templates/visual-ops-usage-evidence-template.md
+++ b/starter-pack/templates/visual-ops-usage-evidence-template.md
@@ -1,0 +1,74 @@
+# Visual Operations Usage Evidence
+
+> Use this only after a generated Visual Operations snapshot was actually used in a review,
+> planning, handoff, or closeout decision. Do not backfill from memory and do not invent missing
+> telemetry.
+
+## Identification
+
+| Field | Value |
+|---|---|
+| Evidence ID |  |
+| Date | YYYY-MM-DD |
+| Recorder |  |
+| Review or decision context |  |
+| Snapshot used | path or URL |
+| Source refs |  |
+
+## Usage boundary
+
+- What was being reviewed:
+- Who used the snapshot:
+- Decision or question the snapshot supported:
+- Source refs:
+
+## Snapshot utility
+
+| Question | Answer | Source refs |
+|---|---|---|
+| Which fields helped the review? |  |  |
+| Which fields were missing, misleading, stale, or too noisy? |  |  |
+| Did the snapshot change a decision, shorten review, or only confirm known state? |  |  |
+| Did the reviewer need to open the source PR, CI run, or evidence file anyway? |  |  |
+
+## Missing or unavailable signals
+
+Record `unknown` or `unavailable`; do not infer values.
+
+| Signal | Status | Why | Source refs |
+|---|---|---|---|
+| Planning depth | unknown / available |  |  |
+| Human review requirement | unknown / available |  |  |
+| Runtime session | unavailable / available |  |  |
+| Skill activation | unknown / available |  |  |
+| Tokens | unavailable / reported / estimated |  |  |
+| Cost | unavailable / reported / estimated |  |  |
+
+## Activation signal check
+
+This record is not enough by itself to activate future infrastructure. Mark only what this usage
+actually supports.
+
+| Possible future surface | Supported by this evidence? | Reason | Source refs |
+|---|---|---|---|
+| Add another checked-in snapshot to CI | yes / no / unclear |  |  |
+| Improve projector field mapping | yes / no / unclear |  |  |
+| Add GitHub collection/import | yes / no / unclear |  |  |
+| Add dashboard/UI | yes / no / unclear |  |  |
+| Add persistence/backend | yes / no / unclear |  |  |
+| Add Adaptive Skills integration | yes / no / unclear |  |  |
+| Add runtime/token/cost telemetry | yes / no / unclear |  |  |
+
+## Outcome
+
+- Decision supported:
+- Follow-up Work Slice, if any:
+- Stop condition or reason to keep phase closed:
+- Source refs:
+
+## Privacy and restrictions
+
+- Sensitive content withheld:
+- Metadata-only references used:
+- Hashes or authorized summaries:
+- Source refs:


### PR DESCRIPTION
## What changed

- adds a Visual Operations usage evidence guide
- adds a starter-pack template for recording real snapshot usage
- updates Visual Operations navigation and starter-pack references
- explicitly forbids backfilling usage from memory
- separates usage observations from activation gates for future infrastructure

## Why it changed

The Visual Operations phase closeout defined usage evidence as the next acceptable step before any collector, UI, persistence, telemetry, or Adaptive Skills integration. This slice creates a safe capture path without claiming that usage has already happened.

## How to validate

- `pnpm check:governance`
- `pnpm test` — 19 files and 193 tests passed
- `pnpm exec tsc --noEmit`
- `./scripts/check-visual-ops-snapshots.sh`
- `git diff --check`
- local Markdown link validation for the new guide/template and indexes

## Risks, assumptions, or follow-ups

- this adds capture guidance, not real usage evidence
- no new runtime, backend, collector, UI, schema, or CI gate is introduced
- future records should only be created after a snapshot is actually used in review
- activation criteria remain evidence gates, not roadmap commitments
