### PR TITLE
docs(visual-ops): record PR 200 dogfood evidence

### DIFF
--- a/docs/pilots/README.md
+++ b/docs/pilots/README.md
@@ -19,6 +19,7 @@ Operation closeouts (session/task records from Hermes and other runtimes) live i
 | [resource-aware-operations-review.md](resource-aware-operations-review.md) | Consolidation of what the 1.2 track proves |
 | [report-core-operating-path-friction-test.md](report-core-operating-path-friction-test.md) | Friction test: is `core-operating-path.md` sufficient for first use? |
 | [visual-operations-pr-193-retrospective.md](visual-operations-pr-193-retrospective.md) | Retrospective reconstruction of PR #193 using the Visual Operations vocabulary |
+| [visual-operations-usage-pr-200-dogfood.md](visual-operations-usage-pr-200-dogfood.md) | First dogfood usage record: PR #200 snapshot supported a post-merge no-new-infrastructure decision |
 | [Visual Operations phase closeout](closeouts/2026-06-15-visual-operations-phase-closeout.md) | Closure evidence and activation gates after PRs #193–#197 |
 
 ## Cycle records

--- a/docs/pilots/visual-operations-usage-pr-200-dogfood.md
+++ b/docs/pilots/visual-operations-usage-pr-200-dogfood.md
@@ -1,0 +1,79 @@
+# Visual Operations Usage Evidence — PR #200 Dogfood
+
+## Identification
+
+| Field | Value |
+|---|---|
+| Evidence ID | `visual-operations-usage-pr-200-dogfood` |
+| Date | 2026-06-15 |
+| Recorder | Codex |
+| Review or decision context | Post-merge dogfood closeout for the AletheIA Visual Operations dogfood protocol slice |
+| Snapshot used | [`examples/visual-operations/github-pr-200-dogfood-output.md`](../../examples/visual-operations/github-pr-200-dogfood-output.md) |
+| Source refs | [PR #200](https://github.com/nevitonsantana/AletheIA/pull/200), [merge commit `cd6c081`](https://github.com/nevitonsantana/AletheIA/commit/cd6c0815a86fe95e4f7ea359d7c1b59103834ccb), [CI run](https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684) |
+
+## Usage boundary
+
+- What was being reviewed: whether the newly merged dogfood protocol slice produced enough evidence
+  to activate another Visual Operations surface or only to keep dogfood evidence collection open.
+- Who used the snapshot: Codex, acting as maintainer/operator in the AletheIA development loop.
+- Decision or question the snapshot supported: decide whether PR #200 justifies a collector, UI,
+  backend, CI allowlist expansion, Adaptive Skills integration, or only a first usage record.
+- Source refs: PR #200, merge commit `cd6c081`, CI run `27580494684`, and the generated local
+  snapshot files listed above.
+
+## Snapshot utility
+
+| Question | Answer | Source refs |
+|---|---|---|
+| Which fields helped the review? | `presentation_lane=closed`, `lane_confidence=confirmed`, `evidence_status=sufficient`, CI evidence provenance, empty follow-up slices, and unavailable runtime/token/cost fields. | [`github-pr-200-dogfood-output.md`](../../examples/visual-operations/github-pr-200-dogfood-output.md), PR #200 |
+| Which fields were missing, misleading, stale, or too noisy? | Human review remains `unavailable`; planning depth, readiness, runtime, tokens, and cost remain unavailable or unknown. This is accurate but limits deeper operational measurement. | [`github-pr-200-dogfood-output.md`](../../examples/visual-operations/github-pr-200-dogfood-output.md) |
+| Did the snapshot change a decision, shorten review, or only confirm known state? | It confirmed that the slice closed cleanly and supported the decision not to activate new infrastructure from this single dogfood instance. | PR #200, merge commit `cd6c081` |
+| Did the reviewer need to open the source PR, CI run, or evidence file anyway? | Yes. The snapshot summarized state and provenance, but the PR and CI records were still opened to verify source details and avoid treating the projection as authority. | PR #200, CI run `27580494684` |
+
+## Missing or unavailable signals
+
+Record `unknown` or `unavailable`; do not infer values.
+
+| Signal | Status | Why | Source refs |
+|---|---|---|---|
+| Planning depth | unknown | No governed planning-depth record was supplied to the projector. | [`github-pr-200-dogfood-output.md`](../../examples/visual-operations/github-pr-200-dogfood-output.md) |
+| Human review requirement | unknown | PR #200 was authorized and merged, but no separate durable review-requirement record was projected. | PR #200 |
+| Runtime session | unavailable | No authoritative runtime-session export was attached to the slice. | [`github-pr-200-dogfood-output.md`](../../examples/visual-operations/github-pr-200-dogfood-output.md) |
+| Skill activation | unknown | No durable skill-activation record was supplied. | [`github-pr-200-dogfood-output.md`](../../examples/visual-operations/github-pr-200-dogfood-output.md) |
+| Tokens | unavailable | No provider or harness token telemetry was supplied. | [`github-pr-200-dogfood-output.md`](../../examples/visual-operations/github-pr-200-dogfood-output.md) |
+| Cost | unavailable | No governed cost record was supplied. | [`github-pr-200-dogfood-output.md`](../../examples/visual-operations/github-pr-200-dogfood-output.md) |
+
+## Activation signal check
+
+This record is not enough by itself to activate future infrastructure. Mark only what this usage
+actually supports.
+
+| Possible future surface | Supported by this evidence? | Reason | Source refs |
+|---|---|---|---|
+| Add another checked-in snapshot to CI | no | PR #200 is a useful dogfood example, but it does not add a distinct projector scenario beyond already covered closed PRs. | [`github-pr-200-dogfood-output.md`](../../examples/visual-operations/github-pr-200-dogfood-output.md), [`scripts/check-visual-ops-snapshots.sh`](../../scripts/check-visual-ops-snapshots.sh) |
+| Improve projector field mapping | unclear | The snapshot was understandable, but the `human_review=unavailable` limitation may need repeated evidence before changing mapping. | [`github-pr-200-dogfood-output.md`](../../examples/visual-operations/github-pr-200-dogfood-output.md) |
+| Add GitHub collection/import | no | The input was assembled manually once; this does not demonstrate repeated assembly cost or error. | [`github-pr-200-dogfood-input.json`](../../examples/visual-operations/github-pr-200-dogfood-input.json) |
+| Add dashboard/UI | no | Markdown was sufficient for this closeout decision. | [`github-pr-200-dogfood-output.md`](../../examples/visual-operations/github-pr-200-dogfood-output.md) |
+| Add persistence/backend | no | No cross-slice query or retention need was demonstrated. | This record |
+| Add Adaptive Skills integration | no | No durable non-sensitive skill-activation record was used. | This record |
+| Add runtime/token/cost telemetry | no | The useful outcome was that these fields stayed unavailable rather than invented. | [`github-pr-200-dogfood-output.md`](../../examples/visual-operations/github-pr-200-dogfood-output.md) |
+
+## Outcome
+
+- Decision supported: keep Visual Operations dogfood evidence collection open, but do not activate a
+  collector, UI, persistence/backend, Adaptive Skills integration, or telemetry surface from PR #200.
+- Follow-up Work Slice, if any: none from this single record. Repeat dogfood usage on future real
+  PRs before proposing infrastructure.
+- Stop condition or reason to keep phase closed: one successful dogfood closeout confirms the static
+  snapshot can support review, but it does not satisfy repeated-use activation thresholds.
+- Source refs: PR #200, merge commit `cd6c081`, CI run `27580494684`, and generated snapshot files.
+
+## Privacy and restrictions
+
+- Sensitive content withheld: no prompt, secret, private source body, or personal data beyond public
+  GitHub actor labels was stored.
+- Metadata-only references used: PR URL, commit URL, CI job URLs, file paths, and summarized local
+  validation from the PR body.
+- Hashes or authorized summaries: merge commit `cd6c0815a86fe95e4f7ea359d7c1b59103834ccb` and head
+  SHA `0e52eb2af56501171c29e6355dd03a99e1cdd07f`.
+- Source refs: PR #200, CI run `27580494684`, generated JSON/Markdown snapshot files.

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,6 +44,7 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
 - `visual-operations/`
   - projeção sintética e somente leitura de duas Work Slices, com eventos normalizados, evidência, revisão humana, telemetria opcional e fonte restrita representada apenas por metadados
   - entrada e saídas reproduzíveis do projetor GitHub PR → Visual Operations, incluindo distinção entre evidência observada por CI e validação reportada pelo autor
+  - snapshot dogfood do PR #200 usado para registrar a primeira evidência real de uso da Visual Operations no próprio AletheIA
   - segundo piloto real da PR #195, gerado e verificável pelo CLI local com `--check`
 
 ---

--- a/examples/visual-operations/github-pr-200-dogfood-input.json
+++ b/examples/visual-operations/github-pr-200-dogfood-input.json
@@ -1,0 +1,111 @@
+{
+  "project_id": "aletheia",
+  "projected_at": "2026-06-15T22:45:00Z",
+  "repository": {
+    "full_name": "nevitonsantana/AletheIA",
+    "url": "https://github.com/nevitonsantana/AletheIA"
+  },
+  "pull_request": {
+    "number": 200,
+    "title": "docs(visual-ops): add AletheIA dogfood protocol",
+    "url": "https://github.com/nevitonsantana/AletheIA/pull/200",
+    "state": "closed",
+    "draft": false,
+    "author": "nevitonsantana",
+    "created_at": "2026-06-15T22:26:26Z",
+    "merged_at": "2026-06-15T22:34:45Z",
+    "closed_at": "2026-06-15T22:34:45Z",
+    "head_sha": "0e52eb2af56501171c29e6355dd03a99e1cdd07f",
+    "base_ref": "main"
+  },
+  "timeline": [
+    {
+      "id": "pr-200-merged",
+      "type": "merged",
+      "created_at": "2026-06-15T22:34:45Z",
+      "actor": "nevitonsantana",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/200"
+    },
+    {
+      "id": "pr-200-closed",
+      "type": "closed",
+      "created_at": "2026-06-15T22:34:45Z",
+      "actor": "nevitonsantana",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/200"
+    }
+  ],
+  "checks": [
+    {
+      "id": "81539363901",
+      "name": "Governance Check (scripts/check-governance.sh)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T22:26:32Z",
+      "completed_at": "2026-06-15T22:26:37Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363901"
+    },
+    {
+      "id": "81539363943",
+      "name": "Install & TypeScript Build",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T22:26:32Z",
+      "completed_at": "2026-06-15T22:26:48Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363943"
+    },
+    {
+      "id": "81539363892",
+      "name": "Lockfile sync (package.json ↔ pnpm-lock.yaml)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T22:26:32Z",
+      "completed_at": "2026-06-15T22:26:35Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363892"
+    },
+    {
+      "id": "81539406046",
+      "name": "Tests (Vitest)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T22:26:50Z",
+      "completed_at": "2026-06-15T22:27:14Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539406046"
+    },
+    {
+      "id": "81539405921",
+      "name": "Visual Operations Snapshots",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T22:26:56Z",
+      "completed_at": "2026-06-15T22:27:13Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539405921"
+    },
+    {
+      "id": "81539469950",
+      "name": "Quality Gate (aggregator)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T22:27:23Z",
+      "completed_at": "2026-06-15T22:27:25Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539469950"
+    }
+  ],
+  "reviews": [],
+  "findings": [],
+  "author_reported_validations": [
+    {
+      "id": "pr-200-local-validation",
+      "name": "Local docs validation",
+      "status": "passed",
+      "summary": "The PR description reports pnpm check:governance, pnpm test, git diff --check, local Markdown link checks across changed docs, and a scope check confirming only docs changed while plans/ stayed untracked.",
+      "reported_at": "2026-06-15T22:26:26Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/200"
+    }
+  ]
+}

--- a/examples/visual-operations/github-pr-200-dogfood-output.json
+++ b/examples/visual-operations/github-pr-200-dogfood-output.json
@@ -1,0 +1,379 @@
+{
+  "projection": {
+    "mode": "read_only",
+    "projector": "github_pull_request",
+    "projected_at": "2026-06-15T22:45:00Z",
+    "source_refs": [
+      "https://github.com/nevitonsantana/AletheIA/pull/200"
+    ]
+  },
+  "work_slice_visual_state": {
+    "work_slice_id": "github-pr-200",
+    "title": "docs(visual-ops): add AletheIA dogfood protocol",
+    "objective": "unknown",
+    "presentation_lane": "closed",
+    "lane_confidence": "confirmed",
+    "risk_level": "unknown",
+    "planning_depth": "unknown",
+    "readiness_outcome": "unknown",
+    "evidence_status": "sufficient",
+    "human_review": {
+      "required": "unknown",
+      "status": "unavailable",
+      "reviewer_role": null,
+      "open_question": null,
+      "source_refs": []
+    },
+    "primary_skill": {
+      "skill_id": "unknown",
+      "activation_status": "unknown",
+      "source_refs": []
+    },
+    "runtime": {
+      "runtime_id": "unavailable",
+      "session_status": "unavailable",
+      "source_refs": []
+    },
+    "telemetry": {
+      "tokens": {
+        "value": null,
+        "provenance": "unavailable",
+        "source_refs": []
+      },
+      "cost": {
+        "value": null,
+        "currency": null,
+        "provenance": "unavailable",
+        "source_refs": []
+      }
+    },
+    "alerts": [],
+    "evidence": [
+      {
+        "evidence_id": "evidence-check-81539363901",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Governance Check (scripts/check-governance.sh): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363901"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81539363943",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Install & TypeScript Build: completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363943"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81539363892",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Lockfile sync (package.json ↔ pnpm-lock.yaml): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363892"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81539406046",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Tests (Vitest): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539406046"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81539405921",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Visual Operations Snapshots: completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539405921"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81539469950",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Quality Gate (aggregator): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539469950"
+        ]
+      },
+      {
+        "evidence_id": "evidence-author-pr-200-local-validation",
+        "type": "author_reported_validation",
+        "status": "passed",
+        "provenance": "author_reported",
+        "summary": "The PR description reports pnpm check:governance, pnpm test, git diff --check, local Markdown link checks across changed docs, and a scope check confirming only docs changed while plans/ stayed untracked.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/pull/200"
+        ]
+      }
+    ],
+    "source_refs": [
+      "https://github.com/nevitonsantana/AletheIA",
+      "https://github.com/nevitonsantana/AletheIA/pull/200",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363901",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363943",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363892",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539406046",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539405921",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539469950"
+    ],
+    "projected_at": "2026-06-15T22:45:00Z"
+  },
+  "normalized_events": [
+    {
+      "event_id": "evt-github-pr-200-author-validation-pr-200-local-validation",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-200",
+      "timestamp": "2026-06-15T22:26:26Z",
+      "source_type": "external",
+      "event_type": "evidence.added",
+      "actor": "nevitonsantana",
+      "summary": "The PR description reports pnpm check:governance, pnpm test, git diff --check, local Markdown link checks across changed docs, and a scope check confirming only docs changed while plans/ stayed untracked.",
+      "payload_metadata": {
+        "validation_name": "Local docs validation",
+        "validation_status": "passed",
+        "provenance": "author_reported"
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/pull/200"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_pull_request_report",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/200"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-200-created",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-200",
+      "timestamp": "2026-06-15T22:26:26Z",
+      "source_type": "external",
+      "event_type": "work_slice.created",
+      "actor": "nevitonsantana",
+      "summary": "GitHub pull request #200 was opened.",
+      "payload_metadata": {
+        "repository": "nevitonsantana/AletheIA",
+        "base_ref": "main",
+        "head_sha": "0e52eb2af56501171c29e6355dd03a99e1cdd07f",
+        "draft": false
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_pull_request",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/200"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-200-check-81539363892",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-200",
+      "timestamp": "2026-06-15T22:26:35Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Lockfile sync (package.json ↔ pnpm-lock.yaml) reported success.",
+      "payload_metadata": {
+        "check_name": "Lockfile sync (package.json ↔ pnpm-lock.yaml)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363892"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363892"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-200-check-81539363901",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-200",
+      "timestamp": "2026-06-15T22:26:37Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Governance Check (scripts/check-governance.sh) reported success.",
+      "payload_metadata": {
+        "check_name": "Governance Check (scripts/check-governance.sh)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363901"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363901"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-200-check-81539363943",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-200",
+      "timestamp": "2026-06-15T22:26:48Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Install & TypeScript Build reported success.",
+      "payload_metadata": {
+        "check_name": "Install & TypeScript Build",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363943"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363943"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-200-check-81539405921",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-200",
+      "timestamp": "2026-06-15T22:27:13Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Visual Operations Snapshots reported success.",
+      "payload_metadata": {
+        "check_name": "Visual Operations Snapshots",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539405921"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539405921"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-200-check-81539406046",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-200",
+      "timestamp": "2026-06-15T22:27:14Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Tests (Vitest) reported success.",
+      "payload_metadata": {
+        "check_name": "Tests (Vitest)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539406046"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539406046"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-200-check-81539469950",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-200",
+      "timestamp": "2026-06-15T22:27:25Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Quality Gate (aggregator) reported success.",
+      "payload_metadata": {
+        "check_name": "Quality Gate (aggregator)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539469950"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539469950"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-200-timeline-pr-200-closed",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-200",
+      "timestamp": "2026-06-15T22:34:45Z",
+      "source_type": "external",
+      "event_type": "reconcile.created",
+      "actor": "nevitonsantana",
+      "summary": "GitHub recorded pull request event: closed.",
+      "payload_metadata": {
+        "github_event_type": "closed"
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_timeline_event",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/200"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-200-timeline-pr-200-merged",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-200",
+      "timestamp": "2026-06-15T22:34:45Z",
+      "source_type": "external",
+      "event_type": "reconcile.created",
+      "actor": "nevitonsantana",
+      "summary": "GitHub recorded pull request event: merged.",
+      "payload_metadata": {
+        "github_event_type": "merged"
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_timeline_event",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/200"
+        }
+      ],
+      "sensitivity": "internal"
+    }
+  ],
+  "follow_up_slices": []
+}

--- a/examples/visual-operations/github-pr-200-dogfood-output.md
+++ b/examples/visual-operations/github-pr-200-dogfood-output.md
@@ -1,0 +1,42 @@
+# Visual Operations Snapshot — github-pr-200
+
+> Read-only projection generated at 2026-06-15T22:45:00Z. Source records remain authoritative.
+
+## State
+
+| Field | Value |
+|---|---|
+| Title | docs(visual-ops): add AletheIA dogfood protocol |
+| Presentation lane | closed (confirmed) |
+| Evidence status | sufficient |
+| Risk | unknown |
+| Planning depth | unknown |
+| Readiness outcome | unknown |
+| Human review | unavailable |
+| Runtime | unavailable |
+| Tokens | unavailable |
+| Cost | unavailable |
+
+## Evidence
+
+| Evidence | Status | Provenance | Source refs |
+|---|---|---|---|
+| Governance Check (scripts/check-governance.sh): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363901 |
+| Install & TypeScript Build: completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363943 |
+| Lockfile sync (package.json ↔ pnpm-lock.yaml): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539363892 |
+| Tests (Vitest): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539406046 |
+| Visual Operations Snapshots: completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539405921 |
+| Quality Gate (aggregator): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27580494684/job/81539469950 |
+| The PR description reports pnpm check:governance, pnpm test, git diff --check, local Markdown link checks across changed docs, and a scope check confirming only docs changed while plans/ stayed untracked. | passed | author_reported | https://github.com/nevitonsantana/AletheIA/pull/200 |
+
+## Alerts
+
+| Severity | Type | Summary | Source refs |
+|---|---|---|---|
+| info | none | No projected alerts. | — |
+
+## Follow-up slices
+
+| Work Slice | Reason | Source refs |
+|---|---|---|
+| none | No follow-up slice projected. | — |


### PR DESCRIPTION
## What changed

- Added a reproducible Visual Operations snapshot for PR #200:
  - `examples/visual-operations/github-pr-200-dogfood-input.json`
  - `examples/visual-operations/github-pr-200-dogfood-output.json`
  - `examples/visual-operations/github-pr-200-dogfood-output.md`
- Added the first dogfood usage evidence record in `docs/pilots/visual-operations-usage-pr-200-dogfood.md`.
- Linked the record from the pilots index and described the example in the examples README.

## Why it changed

After merging the AletheIA dogfood protocol, we used PR #200 itself as a real post-merge closeout decision: the generated snapshot helped decide that one dogfood instance supports keeping evidence collection open, but does not justify collector, UI, persistence, Adaptive Skills integration, runtime telemetry, or CI allowlist expansion.

## How to validate

- `./scripts/visual-ops-project.sh --input examples/visual-operations/github-pr-200-dogfood-input.json --json examples/visual-operations/github-pr-200-dogfood-output.json --markdown examples/visual-operations/github-pr-200-dogfood-output.md --check`
- `python3 -m json.tool` on the new input and output JSON files
- Local Markdown link check for changed docs
- `pnpm check:governance`
- `pnpm test`
- `./scripts/check-visual-ops-snapshots.sh`
- `git diff --check`

## Risks, assumptions or follow-ups

- This is a usage evidence record, not activation of new infrastructure.
- The PR #200 snapshot is intentionally not added to the CI snapshot allowlist because it does not add a distinct projector scenario.
- Missing signals remain `unknown` or `unavailable`; no token, cost, runtime, skill, readiness, or human-review requirement was inferred.
- `plans/` remains untracked and untouched.
