### PR TITLE
docs(visual-ops): record PR 201 dogfood evidence

### DIFF
--- a/docs/pilots/README.md
+++ b/docs/pilots/README.md
@@ -20,6 +20,7 @@ Operation closeouts (session/task records from Hermes and other runtimes) live i
 | [report-core-operating-path-friction-test.md](report-core-operating-path-friction-test.md) | Friction test: is `core-operating-path.md` sufficient for first use? |
 | [visual-operations-pr-193-retrospective.md](visual-operations-pr-193-retrospective.md) | Retrospective reconstruction of PR #193 using the Visual Operations vocabulary |
 | [visual-operations-usage-pr-200-dogfood.md](visual-operations-usage-pr-200-dogfood.md) | First dogfood usage record: PR #200 snapshot supported a post-merge no-new-infrastructure decision |
+| [visual-operations-usage-pr-201-dogfood.md](visual-operations-usage-pr-201-dogfood.md) | Second dogfood usage record: PR #201 snapshot confirmed static closeout utility and no activation threshold met |
 | [Visual Operations phase closeout](closeouts/2026-06-15-visual-operations-phase-closeout.md) | Closure evidence and activation gates after PRs #193–#197 |
 
 ## Cycle records

--- a/docs/pilots/visual-operations-usage-pr-201-dogfood.md
+++ b/docs/pilots/visual-operations-usage-pr-201-dogfood.md
@@ -1,0 +1,81 @@
+# Visual Operations Usage Evidence — PR #201 Dogfood
+
+## Identification
+
+| Field | Value |
+|---|---|
+| Evidence ID | `visual-operations-usage-pr-201-dogfood` |
+| Date | 2026-06-15 |
+| Recorder | Codex |
+| Review or decision context | Post-merge dogfood closeout for the first checked-in Visual Operations usage evidence slice |
+| Snapshot used | [`examples/visual-operations/github-pr-201-dogfood-output.md`](../../examples/visual-operations/github-pr-201-dogfood-output.md) |
+| Source refs | [PR #201](https://github.com/nevitonsantana/AletheIA/pull/201), [merge commit `e8488d5`](https://github.com/nevitonsantana/AletheIA/commit/e8488d5f1ab47c88b28562c290fbeafdd9bdb442), [CI run](https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377) |
+
+## Usage boundary
+
+- What was being reviewed: whether the first checked-in dogfood usage evidence record changed the
+  activation posture for Visual Operations or simply added a second measurement point.
+- Who used the snapshot: Codex, acting as maintainer/operator in the AletheIA development loop.
+- Decision or question the snapshot supported: decide whether two consecutive dogfood closeouts now
+  justify a collector, UI, backend, CI allowlist expansion, Adaptive Skills integration, or telemetry
+  surface.
+- Source refs: PR #201, merge commit `e8488d5`, CI run `27581612377`, and the generated local
+  snapshot files listed above.
+
+## Snapshot utility
+
+| Question | Answer | Source refs |
+|---|---|---|
+| Which fields helped the review? | `presentation_lane=closed`, `evidence_status=sufficient`, explicit CI provenance, author-reported local validation, no alerts, no follow-up slices, and unavailable runtime/token/cost fields. | [`github-pr-201-dogfood-output.md`](../../examples/visual-operations/github-pr-201-dogfood-output.md), PR #201 |
+| Which fields were missing, misleading, stale, or too noisy? | `human_review=unavailable` remains the main repeated gap. Planning depth, readiness, skill, runtime, token, and cost signals remain unknown or unavailable as expected. | [`github-pr-201-dogfood-output.md`](../../examples/visual-operations/github-pr-201-dogfood-output.md) |
+| Did the snapshot change a decision, shorten review, or only confirm known state? | It confirmed the slice closed cleanly and supported the decision that two consecutive dogfood records still do not activate new infrastructure. It also made the repeated human-review visibility gap easier to name. | PR #201, merge commit `e8488d5` |
+| Did the reviewer need to open the source PR, CI run, or evidence file anyway? | Yes. The snapshot was sufficient for orientation and decision framing, but source PR/CI records remained authoritative and were checked before recording the evidence. | PR #201, CI run `27581612377` |
+
+## Missing or unavailable signals
+
+Record `unknown` or `unavailable`; do not infer values.
+
+| Signal | Status | Why | Source refs |
+|---|---|---|---|
+| Planning depth | unknown | No governed planning-depth record was supplied. | [`github-pr-201-dogfood-output.md`](../../examples/visual-operations/github-pr-201-dogfood-output.md) |
+| Human review requirement | unknown | Authorization and merge occurred, but no separate durable review-requirement record was projected. | PR #201 |
+| Runtime session | unavailable | No authoritative runtime-session export was attached. | [`github-pr-201-dogfood-output.md`](../../examples/visual-operations/github-pr-201-dogfood-output.md) |
+| Skill activation | unknown | No durable skill-activation record was supplied. | [`github-pr-201-dogfood-output.md`](../../examples/visual-operations/github-pr-201-dogfood-output.md) |
+| Tokens | unavailable | No provider or harness token telemetry was supplied. | [`github-pr-201-dogfood-output.md`](../../examples/visual-operations/github-pr-201-dogfood-output.md) |
+| Cost | unavailable | No governed cost record was supplied. | [`github-pr-201-dogfood-output.md`](../../examples/visual-operations/github-pr-201-dogfood-output.md) |
+
+## Activation signal check
+
+This record is not enough by itself to activate future infrastructure. Mark only what this usage
+actually supports.
+
+| Possible future surface | Supported by this evidence? | Reason | Source refs |
+|---|---|---|---|
+| Add another checked-in snapshot to CI | no | The PR #201 snapshot is another closed successful PR and does not add a distinct projection scenario for the allowlist. | [`github-pr-201-dogfood-output.md`](../../examples/visual-operations/github-pr-201-dogfood-output.md), [`scripts/check-visual-ops-snapshots.sh`](../../scripts/check-visual-ops-snapshots.sh) |
+| Improve projector field mapping | unclear | Two records now show `human_review=unavailable`; this is a candidate observation, but not enough to change mapping without a durable review source. | [`github-pr-200-dogfood-output.md`](../../examples/visual-operations/github-pr-200-dogfood-output.md), [`github-pr-201-dogfood-output.md`](../../examples/visual-operations/github-pr-201-dogfood-output.md) |
+| Add GitHub collection/import | no | Manual assembly has happened twice but has not yet shown repeated material error or delay. | [`github-pr-201-dogfood-input.json`](../../examples/visual-operations/github-pr-201-dogfood-input.json) |
+| Add dashboard/UI | no | Markdown remained sufficient for the closeout decision. | [`github-pr-201-dogfood-output.md`](../../examples/visual-operations/github-pr-201-dogfood-output.md) |
+| Add persistence/backend | no | No cross-slice query need was demonstrated; two checked-in records are sufficient for current review. | This record |
+| Add Adaptive Skills integration | no | No durable non-sensitive skill-activation record was used. | This record |
+| Add runtime/token/cost telemetry | no | The useful behavior remains preserving unavailable telemetry rather than inventing values. | [`github-pr-201-dogfood-output.md`](../../examples/visual-operations/github-pr-201-dogfood-output.md) |
+
+## Outcome
+
+- Decision supported: keep Visual Operations in dogfood measurement mode. Two consecutive dogfood
+  records support static snapshot utility for closeout, but still do not justify collector, UI,
+  persistence/backend, Adaptive Skills integration, telemetry, or CI allowlist expansion.
+- Follow-up Work Slice, if any: none yet. If a third real usage repeats the human-review visibility
+  gap, consider a bounded mapping/review-source analysis before any infrastructure work.
+- Stop condition or reason to keep phase closed: repeated successful closeout utility is useful but
+  remains below activation thresholds for broader surfaces.
+- Source refs: PR #201, merge commit `e8488d5`, CI run `27581612377`, and generated snapshot files.
+
+## Privacy and restrictions
+
+- Sensitive content withheld: no prompt, secret, private source body, or personal data beyond public
+  GitHub actor labels was stored.
+- Metadata-only references used: PR URL, commit URL, CI job URLs, file paths, and summarized local
+  validation from the PR body.
+- Hashes or authorized summaries: merge commit `e8488d5f1ab47c88b28562c290fbeafdd9bdb442` and head
+  SHA `349a2931cb2648ba0634233a41efec8475d44925`.
+- Source refs: PR #201, CI run `27581612377`, generated JSON/Markdown snapshot files.

--- a/examples/README.md
+++ b/examples/README.md
@@ -45,6 +45,7 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
   - projeção sintética e somente leitura de duas Work Slices, com eventos normalizados, evidência, revisão humana, telemetria opcional e fonte restrita representada apenas por metadados
   - entrada e saídas reproduzíveis do projetor GitHub PR → Visual Operations, incluindo distinção entre evidência observada por CI e validação reportada pelo autor
   - snapshot dogfood do PR #200 usado para registrar a primeira evidência real de uso da Visual Operations no próprio AletheIA
+  - snapshot dogfood do PR #201 usado como segunda evidência real e confirmação de que não há threshold para nova infraestrutura
   - segundo piloto real da PR #195, gerado e verificável pelo CLI local com `--check`
 
 ---

--- a/examples/visual-operations/github-pr-201-dogfood-input.json
+++ b/examples/visual-operations/github-pr-201-dogfood-input.json
@@ -1,0 +1,111 @@
+{
+  "project_id": "aletheia",
+  "projected_at": "2026-06-15T23:15:00Z",
+  "repository": {
+    "full_name": "nevitonsantana/AletheIA",
+    "url": "https://github.com/nevitonsantana/AletheIA"
+  },
+  "pull_request": {
+    "number": 201,
+    "title": "docs(visual-ops): record PR 200 dogfood evidence",
+    "url": "https://github.com/nevitonsantana/AletheIA/pull/201",
+    "state": "closed",
+    "draft": false,
+    "author": "nevitonsantana",
+    "created_at": "2026-06-15T22:51:09Z",
+    "merged_at": "2026-06-15T23:04:51Z",
+    "closed_at": "2026-06-15T23:04:51Z",
+    "head_sha": "349a2931cb2648ba0634233a41efec8475d44925",
+    "base_ref": "main"
+  },
+  "timeline": [
+    {
+      "id": "pr-201-merged",
+      "type": "merged",
+      "created_at": "2026-06-15T23:04:51Z",
+      "actor": "nevitonsantana",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/201"
+    },
+    {
+      "id": "pr-201-closed",
+      "type": "closed",
+      "created_at": "2026-06-15T23:04:51Z",
+      "actor": "nevitonsantana",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/201"
+    }
+  ],
+  "checks": [
+    {
+      "id": "81542929847",
+      "name": "Governance Check (scripts/check-governance.sh)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T22:51:14Z",
+      "completed_at": "2026-06-15T22:51:20Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929847"
+    },
+    {
+      "id": "81542929664",
+      "name": "Install & TypeScript Build",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T22:51:15Z",
+      "completed_at": "2026-06-15T22:51:37Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929664"
+    },
+    {
+      "id": "81542929657",
+      "name": "Lockfile sync (package.json ↔ pnpm-lock.yaml)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T22:51:20Z",
+      "completed_at": "2026-06-15T22:51:24Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929657"
+    },
+    {
+      "id": "81542985186",
+      "name": "Tests (Vitest)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T22:51:39Z",
+      "completed_at": "2026-06-15T22:51:57Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542985186"
+    },
+    {
+      "id": "81542985180",
+      "name": "Visual Operations Snapshots",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T22:51:45Z",
+      "completed_at": "2026-06-15T22:52:01Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542985180"
+    },
+    {
+      "id": "81543040007",
+      "name": "Quality Gate (aggregator)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-15T22:52:03Z",
+      "completed_at": "2026-06-15T22:52:05Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81543040007"
+    }
+  ],
+  "reviews": [],
+  "findings": [],
+  "author_reported_validations": [
+    {
+      "id": "pr-201-local-validation",
+      "name": "Local dogfood validation",
+      "status": "passed",
+      "summary": "The PR description reports the PR #200 dogfood snapshot check, JSON validation, local Markdown link checks, pnpm check:governance, pnpm test, Visual Operations snapshot check, and git diff --check passing locally.",
+      "reported_at": "2026-06-15T22:51:09Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/201"
+    }
+  ]
+}

--- a/examples/visual-operations/github-pr-201-dogfood-output.json
+++ b/examples/visual-operations/github-pr-201-dogfood-output.json
@@ -1,0 +1,379 @@
+{
+  "projection": {
+    "mode": "read_only",
+    "projector": "github_pull_request",
+    "projected_at": "2026-06-15T23:15:00Z",
+    "source_refs": [
+      "https://github.com/nevitonsantana/AletheIA/pull/201"
+    ]
+  },
+  "work_slice_visual_state": {
+    "work_slice_id": "github-pr-201",
+    "title": "docs(visual-ops): record PR 200 dogfood evidence",
+    "objective": "unknown",
+    "presentation_lane": "closed",
+    "lane_confidence": "confirmed",
+    "risk_level": "unknown",
+    "planning_depth": "unknown",
+    "readiness_outcome": "unknown",
+    "evidence_status": "sufficient",
+    "human_review": {
+      "required": "unknown",
+      "status": "unavailable",
+      "reviewer_role": null,
+      "open_question": null,
+      "source_refs": []
+    },
+    "primary_skill": {
+      "skill_id": "unknown",
+      "activation_status": "unknown",
+      "source_refs": []
+    },
+    "runtime": {
+      "runtime_id": "unavailable",
+      "session_status": "unavailable",
+      "source_refs": []
+    },
+    "telemetry": {
+      "tokens": {
+        "value": null,
+        "provenance": "unavailable",
+        "source_refs": []
+      },
+      "cost": {
+        "value": null,
+        "currency": null,
+        "provenance": "unavailable",
+        "source_refs": []
+      }
+    },
+    "alerts": [],
+    "evidence": [
+      {
+        "evidence_id": "evidence-check-81542929847",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Governance Check (scripts/check-governance.sh): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929847"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81542929664",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Install & TypeScript Build: completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929664"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81542929657",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Lockfile sync (package.json ↔ pnpm-lock.yaml): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929657"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81542985186",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Tests (Vitest): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542985186"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81542985180",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Visual Operations Snapshots: completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542985180"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81543040007",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Quality Gate (aggregator): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81543040007"
+        ]
+      },
+      {
+        "evidence_id": "evidence-author-pr-201-local-validation",
+        "type": "author_reported_validation",
+        "status": "passed",
+        "provenance": "author_reported",
+        "summary": "The PR description reports the PR #200 dogfood snapshot check, JSON validation, local Markdown link checks, pnpm check:governance, pnpm test, Visual Operations snapshot check, and git diff --check passing locally.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/pull/201"
+        ]
+      }
+    ],
+    "source_refs": [
+      "https://github.com/nevitonsantana/AletheIA",
+      "https://github.com/nevitonsantana/AletheIA/pull/201",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929847",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929664",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929657",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542985186",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542985180",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81543040007"
+    ],
+    "projected_at": "2026-06-15T23:15:00Z"
+  },
+  "normalized_events": [
+    {
+      "event_id": "evt-github-pr-201-author-validation-pr-201-local-validation",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-201",
+      "timestamp": "2026-06-15T22:51:09Z",
+      "source_type": "external",
+      "event_type": "evidence.added",
+      "actor": "nevitonsantana",
+      "summary": "The PR description reports the PR #200 dogfood snapshot check, JSON validation, local Markdown link checks, pnpm check:governance, pnpm test, Visual Operations snapshot check, and git diff --check passing locally.",
+      "payload_metadata": {
+        "validation_name": "Local dogfood validation",
+        "validation_status": "passed",
+        "provenance": "author_reported"
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/pull/201"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_pull_request_report",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/201"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-201-created",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-201",
+      "timestamp": "2026-06-15T22:51:09Z",
+      "source_type": "external",
+      "event_type": "work_slice.created",
+      "actor": "nevitonsantana",
+      "summary": "GitHub pull request #201 was opened.",
+      "payload_metadata": {
+        "repository": "nevitonsantana/AletheIA",
+        "base_ref": "main",
+        "head_sha": "349a2931cb2648ba0634233a41efec8475d44925",
+        "draft": false
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_pull_request",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/201"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-201-check-81542929847",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-201",
+      "timestamp": "2026-06-15T22:51:20Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Governance Check (scripts/check-governance.sh) reported success.",
+      "payload_metadata": {
+        "check_name": "Governance Check (scripts/check-governance.sh)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929847"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929847"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-201-check-81542929657",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-201",
+      "timestamp": "2026-06-15T22:51:24Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Lockfile sync (package.json ↔ pnpm-lock.yaml) reported success.",
+      "payload_metadata": {
+        "check_name": "Lockfile sync (package.json ↔ pnpm-lock.yaml)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929657"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929657"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-201-check-81542929664",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-201",
+      "timestamp": "2026-06-15T22:51:37Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Install & TypeScript Build reported success.",
+      "payload_metadata": {
+        "check_name": "Install & TypeScript Build",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929664"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929664"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-201-check-81542985186",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-201",
+      "timestamp": "2026-06-15T22:51:57Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Tests (Vitest) reported success.",
+      "payload_metadata": {
+        "check_name": "Tests (Vitest)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542985186"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542985186"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-201-check-81542985180",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-201",
+      "timestamp": "2026-06-15T22:52:01Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Visual Operations Snapshots reported success.",
+      "payload_metadata": {
+        "check_name": "Visual Operations Snapshots",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542985180"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542985180"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-201-check-81543040007",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-201",
+      "timestamp": "2026-06-15T22:52:05Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Quality Gate (aggregator) reported success.",
+      "payload_metadata": {
+        "check_name": "Quality Gate (aggregator)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81543040007"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81543040007"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-201-timeline-pr-201-closed",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-201",
+      "timestamp": "2026-06-15T23:04:51Z",
+      "source_type": "external",
+      "event_type": "reconcile.created",
+      "actor": "nevitonsantana",
+      "summary": "GitHub recorded pull request event: closed.",
+      "payload_metadata": {
+        "github_event_type": "closed"
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_timeline_event",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/201"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-201-timeline-pr-201-merged",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-201",
+      "timestamp": "2026-06-15T23:04:51Z",
+      "source_type": "external",
+      "event_type": "reconcile.created",
+      "actor": "nevitonsantana",
+      "summary": "GitHub recorded pull request event: merged.",
+      "payload_metadata": {
+        "github_event_type": "merged"
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_timeline_event",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/201"
+        }
+      ],
+      "sensitivity": "internal"
+    }
+  ],
+  "follow_up_slices": []
+}

--- a/examples/visual-operations/github-pr-201-dogfood-output.md
+++ b/examples/visual-operations/github-pr-201-dogfood-output.md
@@ -1,0 +1,42 @@
+# Visual Operations Snapshot — github-pr-201
+
+> Read-only projection generated at 2026-06-15T23:15:00Z. Source records remain authoritative.
+
+## State
+
+| Field | Value |
+|---|---|
+| Title | docs(visual-ops): record PR 200 dogfood evidence |
+| Presentation lane | closed (confirmed) |
+| Evidence status | sufficient |
+| Risk | unknown |
+| Planning depth | unknown |
+| Readiness outcome | unknown |
+| Human review | unavailable |
+| Runtime | unavailable |
+| Tokens | unavailable |
+| Cost | unavailable |
+
+## Evidence
+
+| Evidence | Status | Provenance | Source refs |
+|---|---|---|---|
+| Governance Check (scripts/check-governance.sh): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929847 |
+| Install & TypeScript Build: completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929664 |
+| Lockfile sync (package.json ↔ pnpm-lock.yaml): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542929657 |
+| Tests (Vitest): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542985186 |
+| Visual Operations Snapshots: completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81542985180 |
+| Quality Gate (aggregator): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27581612377/job/81543040007 |
+| The PR description reports the PR #200 dogfood snapshot check, JSON validation, local Markdown link checks, pnpm check:governance, pnpm test, Visual Operations snapshot check, and git diff --check passing locally. | passed | author_reported | https://github.com/nevitonsantana/AletheIA/pull/201 |
+
+## Alerts
+
+| Severity | Type | Summary | Source refs |
+|---|---|---|---|
+| info | none | No projected alerts. | — |
+
+## Follow-up slices
+
+| Work Slice | Reason | Source refs |
+|---|---|---|
+| none | No follow-up slice projected. | — |


### PR DESCRIPTION
## What changed

- Added a reproducible Visual Operations snapshot for PR #201:
  - `examples/visual-operations/github-pr-201-dogfood-input.json`
  - `examples/visual-operations/github-pr-201-dogfood-output.json`
  - `examples/visual-operations/github-pr-201-dogfood-output.md`
- Added the second dogfood usage evidence record in `docs/pilots/visual-operations-usage-pr-201-dogfood.md`.
- Linked the record from the pilots index and examples README.

## Why it changed

After merging the first checked-in dogfood evidence record, PR #201 itself became the next real AletheIA maintenance slice. Its snapshot supported a post-merge decision: two consecutive dogfood closeouts confirm static snapshot utility, but still do not meet activation thresholds for collector, UI, persistence/backend, Adaptive Skills integration, runtime/cost telemetry, or CI allowlist expansion.

## How to validate

- `./scripts/visual-ops-project.sh --input examples/visual-operations/github-pr-201-dogfood-input.json --json examples/visual-operations/github-pr-201-dogfood-output.json --markdown examples/visual-operations/github-pr-201-dogfood-output.md --check`
- `python3 -m json.tool` on the new input and output JSON files
- Local Markdown link check for changed docs
- `pnpm check:governance`
- `pnpm test`
- `./scripts/check-visual-ops-snapshots.sh`
- `git diff --check`

## Risks, assumptions or follow-ups

- This is a second usage evidence record, not activation of new infrastructure.
- The PR #201 snapshot is intentionally not added to the CI snapshot allowlist because it does not add a distinct projector scenario.
- Two records now repeat the `human_review=unavailable` limitation; this is a candidate observation, not yet a mapping change.
- `plans/` remains untracked and untouched.
