### PR TITLE
docs(epgp): surface execution pattern docs in indexes

### DIFF
--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -26,6 +26,10 @@ If you need a step-by-step guide, see [`guides/`](../guides/README.md). If you n
 | [tool-risk-taxonomy.md](tool-risk-taxonomy.md) | Coarse risk classes for skill declaration, mapped to the authoritative permission matrix |
 | [agent-computer-interface.md](agent-computer-interface.md) | How to design tools agents consume (ACI), complementing the permission matrix |
 | [context-rot-controls.md](context-rot-controls.md) | Signals of long-session degradation and the minimal controls + checkpoint |
+| [execution-pattern-governance.md](execution-pattern-governance.md) | How AletheIA chooses the execution topology before task execution |
+| [execution-pattern-library.md](execution-pattern-library.md) | The ten canonical execution patterns and selection rules |
+| [execution-vehicle-selection.md](execution-vehicle-selection.md) | Vehicle vs pattern and proportionality before autonomy |
+| [comprehension-debt.md](comprehension-debt.md) | When generated material outpaces human understanding, distinct from context rot |
 | [self-application.md](self-application.md) | How AletheIA governs its own evolution |
 | [structured-risk-inference.md](structured-risk-inference.md) | Experimental risk inference layer |
 | [project-extension-pattern.md](project-extension-pattern.md) | How projects extend the overlay without distorting it |

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -36,6 +36,12 @@ If you need conceptual background, see [`concepts/`](../concepts/README.md). If 
 | [agent-harness-contract.md](agent-harness-contract.md) | The per-task declaration: autonomy, allowed tools/skills, gates, sensors, rollback, human review, context policy |
 | [policy-verdicts.md](policy-verdicts.md) | The verdict vocabulary (allow/deny/require_approval/transform/log_only) and its mapping to harness decision values |
 | [agent-action-audit-record.md](agent-action-audit-record.md) | Minimum audit fields proving skill → tool → verdict → evidence → approval |
+| [execution-pattern-selection.md](execution-pattern-selection.md) | How a task records its selected execution topology and required controls |
+| [orchestration-contract.md](orchestration-contract.md) | What an orchestrated execution must declare before stages run |
+| [loop-state-contract.md](loop-state-contract.md) | Minimum state shape for recurring or looped work |
+| [objective-gate-policy.md](objective-gate-policy.md) | Objective stop/gate requirements before loops can run safely |
+| [maker-checker-policy.md](maker-checker-policy.md) | When separate generation and verification roles are required |
+| [execution-audit-record.md](execution-audit-record.md) | Pattern-level audit view over existing AHGE evidence |
 
 ### Operationalized by security checklists
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,15 +49,31 @@ Reading map organized by intent. Each entry links to the most useful starting po
 
 ---
 
+## I want to choose an execution pattern
+
+1. [Execution Pattern Governance](concepts/execution-pattern-governance.md) — topology selection before task execution
+2. [Execution Pattern Library](concepts/execution-pattern-library.md) — ten canonical patterns and when to use them
+3. [Execution Vehicle Selection](concepts/execution-vehicle-selection.md) — vehicle, pattern, and proportionality rules
+4. [Execution Pattern Selection contract](contracts/execution-pattern-selection.md) — declaration shape for selected topology and controls
+5. [Orchestration Contract](contracts/orchestration-contract.md) — stage-level declaration for orchestrated work
+6. [Objective Gate Policy](contracts/objective-gate-policy.md) — when loops need gates, budgets, state, and review
+7. [Maker-Checker Policy](contracts/maker-checker-policy.md) — when separate verifier roles are required
+8. [Comprehension Debt](concepts/comprehension-debt.md) — when output volume outpaces understanding
+
+---
+
 ## I want to configure an agent harness (Claude Code, Codex, Qwen)
 
 1. [Runtime adapter — Claude Code](reference/runtime-adapter-claude-code.md)
 2. [Runtime adapter — Codex](reference/runtime-adapter-codex.md)
 3. [Runtime adapter — Qwen](reference/runtime-adapter-qwen.md)
 4. [Setting up harnesses](guides/setting-up-harnesses.md) — wire a consumer project to Claude Code via the shim pack
-5. [Runtime adapter contract](contracts/runtime-adapter-contract.md) — what any adapter must honor
-6. [Agent role catalog](reference/agent-role-catalog.md) — portable roles across runtimes
-7. [Agent runtime decision guide](guides/agent-runtime-decision-guide.md) — choosing between runtimes
+5. [Agent Harness Contract](concepts/agent-harness-contract.md) — declared per-task envelope before tools run
+6. [Agent Harness Contract spec](contracts/agent-harness-contract.md) — autonomy, tools, gates, sensors, rollback, and review fields
+7. [Agent Harness Governance Extension](contracts/agent-harness-governance-extension.md) — per-action authorization, budgets, and observations
+8. [Runtime adapter contract](contracts/runtime-adapter-contract.md) — what any adapter must honor
+9. [Agent role catalog](reference/agent-role-catalog.md) — portable roles across runtimes
+10. [Agent runtime decision guide](guides/agent-runtime-decision-guide.md) — choosing between runtimes
 
 ---
 
@@ -72,8 +88,12 @@ Reading map organized by intent. Each entry links to the most useful starting po
 7. [Work Slice Visual State Contract](contracts/work-slice-visual-state-contract.md)
 8. [Visual Operations Privacy Boundaries](contracts/visual-ops-privacy-boundaries.md)
 9. [Runtime effort governance contract](contracts/runtime-effort-governance-contract.md) — how an agent decides effort: start, escalate, de-escalate, stop, checkpoint
-10. [Agent harness governance extension](contracts/agent-harness-governance-extension.md) — how the harness authorizes, budgets, and bounds execution of model-proposed actions
-11. [All contracts →](contracts/README.md)
+10. [Agent Harness Contract](contracts/agent-harness-contract.md) — per-task autonomy, tools, gates, sensors, rollback, and review declaration
+11. [Agent harness governance extension](contracts/agent-harness-governance-extension.md) — how the harness authorizes, budgets, and bounds execution of model-proposed actions
+12. [Execution Pattern Selection](contracts/execution-pattern-selection.md) — selected topology and required controls before execution
+13. [Orchestration Contract](contracts/orchestration-contract.md) — stage-level declaration for orchestrated work
+14. [Objective Gate Policy](contracts/objective-gate-policy.md) — loop gates, budgets, state, and human review requirements
+15. [All contracts →](contracts/README.md)
 
 ---
 


### PR DESCRIPTION
## What changed

- Added Execution Pattern Governance navigation to `docs/index.md`.
- Added AHC entries to the harness and normative-contract reading paths in `docs/index.md`.
- Added EPGP concept docs to `docs/concepts/README.md`.
- Added EPGP contract docs to `docs/contracts/README.md`.

## Why it changed

The RANS-V, AHC, and EPGP implementation artifacts already existed in `main`, but the top-level and section indexes did not fully expose AHC/EPGP reading paths. This patch makes the existing docs discoverable without adding new governance surface.

## How to validate

- Local Markdown link check for the changed index files
- `grep -rli "dynamic workflow\|ultracode" docs examples` returns only `docs/reference/external-references-execution-patterns.md`
- `pnpm check:governance`
- `pnpm test`
- `git diff --check`

## Risks, assumptions or follow-ups

- Navigation-only change; no contracts, schemas, runtime, examples, or tests changed.
- `plans/` remains untracked and untouched.
