### PR TITLE
docs(concepts): index ecosystem map

### DIFF
--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -11,6 +11,7 @@ If you need a step-by-step guide, see [`guides/`](../guides/README.md). If you n
 | [overview.md](overview.md) | What AletheIA is and how the repo is structured |
 | [operating-overlay.md](operating-overlay.md) | The overlay layer: what it is, what belongs in it, what doesn't |
 | [architecture.md](architecture.md) | Core contracts and canonical surfaces |
+| [ecosystem-map.md](ecosystem-map.md) | Where AletheIA and Adaptive Skills fit in the broader agentic tooling ecosystem |
 | [canonical-vocabulary.md](canonical-vocabulary.md) | Stable shared language: Work Slice, Restart Package, Operational Boundary, Handoff, etc. |
 | [governance.md](governance.md) | What is mandatory, forbidden, and requires approval |
 | [quality.md](quality.md) | Quality baseline — what the framework must prove |


### PR DESCRIPTION
## What changed

- Added `ecosystem-map.md` to `docs/concepts/README.md`.

## Why it changed

A concepts index audit found that `docs/concepts/ecosystem-map.md` was the only concept document not listed in the concepts README. This makes the public ecosystem positioning map discoverable without changing content.

## How to validate

- All concept docs are indexed in `docs/concepts/README.md`
- Local Markdown link check for `docs/concepts/README.md`
- `pnpm check:governance`
- `pnpm test`
- `git diff --check`

## Risks, assumptions or follow-ups

- Navigation-only change; no concept content, contracts, schemas, runtime, examples, or tests changed.
- `plans/` remains untracked and untouched.
