### PR TITLE
docs: index remaining public docs

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -28,6 +28,7 @@ If you need conceptual background, see [`concepts/`](../concepts/README.md). If 
 | [pilot-conversion.md](pilot-conversion.md) | How pilot learnings become framework improvements |
 | [github-project-operations.md](github-project-operations.md) | Using GitHub Projects for repo coordination |
 | [setting-up-harnesses.md](setting-up-harnesses.md) | Wiring a consumer project to Claude Code via the shim pack |
+| [install-via-apm.md](install-via-apm.md) | Installing AletheIA through APM and materializing the overlay scaffold |
 | [pilot-crisis-monitor-overlay-handoff.md](pilot-crisis-monitor-overlay-handoff.md) | Brief for the Crisis Monitor team — Epic 7 overlay-adoption pilot |
 | [validating-knowledge-manifests.md](validating-knowledge-manifests.md) | How to load and schema-validate knowledge manifests via the engine loaders |
 | [github-pr-visual-operations-projector.md](github-pr-visual-operations-projector.md) | Projecting supplied GitHub PR evidence into Visual Operations snapshots |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -27,6 +27,7 @@ Consultable material: catalogs, checklists, policies, examples, adapter guides, 
 | [bootstrap-output-examples.md](bootstrap-output-examples.md) | Examples of healthy Alpha 7 bootstrap outputs |
 | [constrained-pilot-review-checklist.md](constrained-pilot-review-checklist.md) | Review checklist for constrained-adoption pilots |
 | [resource-aware-pilot-review-checklist.md](resource-aware-pilot-review-checklist.md) | Review checklist for resource-aware pilots |
+| [external-references-execution-patterns.md](external-references-execution-patterns.md) | External sources evaluated for Execution Pattern Governance and their vocabulary boundary |
 | **Agent roles** | |
 | [agent-role-catalog.md](agent-role-catalog.md) | Index of all portable agent roles |
 | [agent-role-explorer.md](agent-role-explorer.md) | Explorer role spec |

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,12 +35,24 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
   - mostra como uma validação real no Crisis Monitor vira endurecimento pequeno e reutilizável no framework
 - `consumer-overlay-minimal/`
   - instância mínima viável do [consumer-project-overlay contract](../docs/contracts/consumer-project-overlay.md) — layout `ops/ai/` + shims Claude prontos para copiar
+- `delivery/`
+  - exemplo de bundle gerado revisável e seus limites de entrega
+- `distribution/`
+  - exemplo de mapeamento para adoção constrained/distribution
+- `feature-governance/`
+  - exemplos de build/kill/sunset/test para governança de valor de feature
+- `goldens/`
+  - fixtures canônicos para cenários de validação e governança
+- `project-extension/`
+  - exemplos de extensões locais, knowledge packs, trust boundaries, personas e sensitivity mapping
 - `harness/`
   - Agent Harness Contracts trabalhados (per-task envelope) para debugging, testing e feature-planning
 - `agent-harness/`
   - fluxo de **policy/verdict por ação** (allow/deny/require_approval) + audit record, contrastando skill operacional (debugging) vs consultiva (feature-value-governance)
 - `execution-patterns/`
   - Execution Pattern Selections trabalhadas (topologia antes da execução): CI triage (scheduled stateful loop), síntese de entrevistas (fan-out + filter), review adversarial de PRD (maker-checker) e feature value review (loops explicitamente inadmissíveis)
+- `resource-aware-operations/`
+  - exemplos da trilha 1.2 para runtime fit, policy signals, pilotos bounded, restart/finalization e adapters
 - `visual-operations/`
   - projeção sintética e somente leitura de duas Work Slices, com eventos normalizados, evidência, revisão humana, telemetria opcional e fonte restrita representada apenas por metadados
   - entrada e saídas reproduzíveis do projetor GitHub PR → Visual Operations, incluindo distinção entre evidência observada por CI e validação reportada pelo autor


### PR DESCRIPTION
## What changed

- Added `install-via-apm.md` to `docs/guides/README.md`.
- Added `external-references-execution-patterns.md` to `docs/reference/README.md`.
- Added missing public example directories to `examples/README.md`: `delivery/`, `distribution/`, `feature-governance/`, `goldens/`, `project-extension/`, and `resource-aware-operations/`.

## Why it changed

A remaining-index audit found public docs and example directories that existed but were not discoverable from their section indexes. This patch keeps the cleanup navigation-only and does not turn `starter-pack/README.md` into a full file inventory.

## How to validate

- Guides README indexes all `docs/guides/*.md`
- Reference README indexes all `docs/reference/*.md`
- Examples README lists all top-level example directories
- Local Markdown link check for changed READMEs
- `pnpm check:governance`
- `pnpm test`
- `git diff --check`

## Risks, assumptions or follow-ups

- Navigation-only change; no contracts, schemas, runtime, examples, or tests changed.
- `starter-pack/README.md` remains a curated entrypoint rather than an exhaustive file inventory.
- `plans/` remains untracked and untouched.
