### PR TITLE
docs(visual-ops): record PR 207 dogfood evidence

### DIFF
--- a/docs/pilots/README.md
+++ b/docs/pilots/README.md
@@ -21,6 +21,7 @@ Operation closeouts (session/task records from Hermes and other runtimes) live i
 | [visual-operations-pr-193-retrospective.md](visual-operations-pr-193-retrospective.md) | Retrospective reconstruction of PR #193 using the Visual Operations vocabulary |
 | [visual-operations-usage-pr-200-dogfood.md](visual-operations-usage-pr-200-dogfood.md) | First dogfood usage record: PR #200 snapshot supported a post-merge no-new-infrastructure decision |
 | [visual-operations-usage-pr-201-dogfood.md](visual-operations-usage-pr-201-dogfood.md) | Second dogfood usage record: PR #201 snapshot confirmed static closeout utility and no activation threshold met |
+| [visual-operations-usage-pr-207-dogfood.md](visual-operations-usage-pr-207-dogfood.md) | Third dogfood usage record: PR #207 confirmed human-review unavailable is a source-bound design signal, not a UI failure |
 | [Visual Operations phase closeout](closeouts/2026-06-15-visual-operations-phase-closeout.md) | Closure evidence and activation gates after PRs #193–#197 |
 
 ## Cycle records

--- a/docs/pilots/visual-operations-usage-pr-207-dogfood.md
+++ b/docs/pilots/visual-operations-usage-pr-207-dogfood.md
@@ -1,0 +1,94 @@
+# Visual Operations Usage Evidence — PR #207 Dogfood
+
+## Identification
+
+| Field | Value |
+|---|---|
+| Evidence ID | `visual-operations-usage-pr-207-dogfood` |
+| Date | 2026-06-16 |
+| Recorder | Codex |
+| Review or decision context | Post-merge dogfood closeout for the Visual Operations human-review source mapping slice |
+| Snapshot used | [`examples/visual-operations/github-pr-207-dogfood-output.md`](../../examples/visual-operations/github-pr-207-dogfood-output.md) |
+| Source refs | [PR #207](https://github.com/nevitonsantana/AletheIA/pull/207), [merge commit `39f76cf`](https://github.com/nevitonsantana/AletheIA/commit/39f76cf4afc774f8f45fbc439f2b71331c0b4a8f), [CI run](https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953) |
+
+## Usage boundary
+
+- What was being reviewed: whether the human-review source mapping clarified the repeated
+  `human_review=unavailable` signal without introducing new infrastructure or a false authority.
+- Who used the snapshot: Codex, acting as maintainer/operator in the AletheIA development loop.
+- Decision or question the snapshot supported: decide whether the new mapping changed activation
+  posture for collector, UI, backend, telemetry, Adaptive Skills integration, or schema work.
+- Source refs: PR #207, merge commit `39f76cf`, CI run `27626141953`, and the generated local
+  snapshot files listed above.
+
+## Snapshot utility
+
+| Question | Answer | Source refs |
+|---|---|---|
+| Which fields helped the review? | `presentation_lane=closed`, `evidence_status=sufficient`, CI provenance, author-reported local validation, no alerts, no follow-up slices, and explicit unavailable runtime/token/cost fields. | [`github-pr-207-dogfood-output.md`](../../examples/visual-operations/github-pr-207-dogfood-output.md), PR #207 |
+| Which fields were missing, misleading, stale, or too noisy? | `human_review=unavailable` remains visible, but PR #207 explains why this is correct when no durable review record is supplied. Planning depth, readiness, runtime, token, and cost signals remain unknown or unavailable as expected. | [`github-pr-207-dogfood-output.md`](../../examples/visual-operations/github-pr-207-dogfood-output.md), [`visual-operations-human-review-source-mapping.md`](../reference/visual-operations-human-review-source-mapping.md) |
+| Did the snapshot change a decision, shorten review, or only confirm known state? | It confirmed that the mapping slice closed cleanly and that the dogfood loop should continue measuring before activating UI, collector, backend, or telemetry work. | PR #207, merge commit `39f76cf` |
+| Did the reviewer need to open the source PR, CI run, or evidence file anyway? | Yes. The snapshot was sufficient for orientation and design framing, but the source PR/CI records remained authoritative and were checked before recording the evidence. | PR #207, CI run `27626141953` |
+
+## Missing or unavailable signals
+
+Record `unknown` or `unavailable`; do not infer values.
+
+| Signal | Status | Why | Source refs |
+|---|---|---|---|
+| Planning depth | unknown | No governed planning-depth record was supplied. | [`github-pr-207-dogfood-output.md`](../../examples/visual-operations/github-pr-207-dogfood-output.md) |
+| Human review requirement | unknown | Merge authorization and green checks existed, but no separate durable review-requirement or review-completion record was supplied. PR #207 documents that this must remain unknown/unavailable. | PR #207, [`visual-operations-human-review-source-mapping.md`](../reference/visual-operations-human-review-source-mapping.md) |
+| Runtime session | unavailable | No authoritative runtime-session export was attached. | [`github-pr-207-dogfood-output.md`](../../examples/visual-operations/github-pr-207-dogfood-output.md) |
+| Skill activation | unknown | No durable skill-activation record was supplied. | [`github-pr-207-dogfood-output.md`](../../examples/visual-operations/github-pr-207-dogfood-output.md) |
+| Tokens | unavailable | No provider or harness token telemetry was supplied. | [`github-pr-207-dogfood-output.md`](../../examples/visual-operations/github-pr-207-dogfood-output.md) |
+| Cost | unavailable | No governed cost record was supplied. | [`github-pr-207-dogfood-output.md`](../../examples/visual-operations/github-pr-207-dogfood-output.md) |
+
+## Activation signal check
+
+This record is not enough by itself to activate future infrastructure. Mark only what this usage
+actually supports.
+
+| Possible future surface | Supported by this evidence? | Reason | Source refs |
+|---|---|---|---|
+| Add another checked-in snapshot to CI | no | The PR #207 snapshot is another closed successful PR and does not add a distinct projection scenario for the allowlist. | [`github-pr-207-dogfood-output.md`](../../examples/visual-operations/github-pr-207-dogfood-output.md), [`scripts/check-visual-ops-snapshots.sh`](../../scripts/check-visual-ops-snapshots.sh) |
+| Improve projector field mapping | no | The mapping clarified source rules, but the projected state remains correct with no supplied review record. | [`visual-operations-human-review-source-mapping.md`](../reference/visual-operations-human-review-source-mapping.md) |
+| Add GitHub collection/import | unclear | Manual assembly has now happened across multiple dogfood records, but this slice did not demonstrate material delay or repeated error that justifies a collector yet. | [`github-pr-207-dogfood-input.json`](../../examples/visual-operations/github-pr-207-dogfood-input.json) |
+| Add dashboard/UI | no | Markdown remained sufficient for closeout and design framing. A visual model can be prepared next, but no UI implementation is justified by this record alone. | [`github-pr-207-dogfood-output.md`](../../examples/visual-operations/github-pr-207-dogfood-output.md) |
+| Add persistence/backend | no | No cross-slice query need was demonstrated; checked-in records are sufficient for current review. | This record |
+| Add Adaptive Skills integration | no | No durable non-sensitive skill-activation record was used. | This record |
+| Add runtime/token/cost telemetry | no | The useful behavior remains preserving unavailable telemetry rather than inventing values. | [`github-pr-207-dogfood-output.md`](../../examples/visual-operations/github-pr-207-dogfood-output.md) |
+
+## Design implication
+
+For the future cockpit, this evidence says the visual layer needs an explicit design treatment for
+missing authority. A card should not look failed or incomplete just because it says `unavailable`;
+it should communicate that the system is refusing to claim evidence it does not have.
+
+The useful visual distinction is:
+
+- **Known positive**: there is durable evidence and the card can show completion.
+- **Known pending**: there is durable evidence that review is required or blocked.
+- **Unknown/unavailable**: the source did not provide enough evidence, so the UI should avoid
+  implying either success or failure.
+
+## Outcome
+
+- Decision supported: keep Visual Operations in dogfood measurement mode. PR #207 resolved the
+  semantic ambiguity around `human_review`, but it did not activate collector, UI, persistence,
+  Adaptive Skills integration, telemetry, or schema work.
+- Follow-up Work Slice, if any: prepare a docs-first visual model for the cockpit cards/lanes/alerts
+  using the dogfood evidence, without implementing UI yet.
+- Stop condition or reason to keep phase open: the vocabulary is clearer, but more visual framing is
+  needed before a real dashboard can be designed safely.
+- Source refs: PR #207, merge commit `39f76cf`, CI run `27626141953`, generated JSON/Markdown
+  snapshot files, and the human-review source mapping.
+
+## Privacy and restrictions
+
+- Sensitive content withheld: no prompt, secret, private source body, or personal data beyond public
+  GitHub actor labels was stored.
+- Metadata-only references used: PR URL, commit URL, CI job URLs, file paths, and summarized local
+  validation from the PR body.
+- Hashes or authorized summaries: merge commit `39f76cf4afc774f8f45fbc439f2b71331c0b4a8f` and head
+  SHA `efd7357bdb5bb6481410a0db6a5cc8534c330115`.
+- Source refs: PR #207, CI run `27626141953`, generated JSON/Markdown snapshot files.

--- a/examples/visual-operations/github-pr-207-dogfood-input.json
+++ b/examples/visual-operations/github-pr-207-dogfood-input.json
@@ -1,0 +1,111 @@
+{
+  "project_id": "aletheia",
+  "projected_at": "2026-06-16T15:00:00Z",
+  "repository": {
+    "full_name": "nevitonsantana/AletheIA",
+    "url": "https://github.com/nevitonsantana/AletheIA"
+  },
+  "pull_request": {
+    "number": 207,
+    "title": "docs(visual-ops): map human review sources",
+    "url": "https://github.com/nevitonsantana/AletheIA/pull/207",
+    "state": "closed",
+    "draft": false,
+    "author": "nevitonsantana",
+    "created_at": "2026-06-16T14:47:51Z",
+    "merged_at": "2026-06-16T14:55:31Z",
+    "closed_at": "2026-06-16T14:55:31Z",
+    "head_sha": "efd7357bdb5bb6481410a0db6a5cc8534c330115",
+    "base_ref": "main"
+  },
+  "timeline": [
+    {
+      "id": "pr-207-merged",
+      "type": "merged",
+      "created_at": "2026-06-16T14:55:31Z",
+      "actor": "nevitonsantana",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/207"
+    },
+    {
+      "id": "pr-207-closed",
+      "type": "closed",
+      "created_at": "2026-06-16T14:55:31Z",
+      "actor": "nevitonsantana",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/207"
+    }
+  ],
+  "checks": [
+    {
+      "id": "81688153415",
+      "name": "Governance Check (scripts/check-governance.sh)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-16T14:48:11Z",
+      "completed_at": "2026-06-16T14:48:16Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153415"
+    },
+    {
+      "id": "81688153379",
+      "name": "Install & TypeScript Build",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-16T14:48:12Z",
+      "completed_at": "2026-06-16T14:48:31Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153379"
+    },
+    {
+      "id": "81688153479",
+      "name": "Lockfile sync (package.json ↔ pnpm-lock.yaml)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-16T14:48:06Z",
+      "completed_at": "2026-06-16T14:48:13Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153479"
+    },
+    {
+      "id": "81688264677",
+      "name": "Tests (Vitest)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-16T14:48:40Z",
+      "completed_at": "2026-06-16T14:49:03Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688264677"
+    },
+    {
+      "id": "81688264542",
+      "name": "Visual Operations Snapshots",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-16T14:48:40Z",
+      "completed_at": "2026-06-16T14:48:56Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688264542"
+    },
+    {
+      "id": "81688392735",
+      "name": "Quality Gate (aggregator)",
+      "status": "completed",
+      "conclusion": "success",
+      "required": true,
+      "started_at": "2026-06-16T14:49:12Z",
+      "completed_at": "2026-06-16T14:49:15Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688392735"
+    }
+  ],
+  "reviews": [],
+  "findings": [],
+  "author_reported_validations": [
+    {
+      "id": "pr-207-local-validation",
+      "name": "Local human-review mapping validation",
+      "status": "passed",
+      "summary": "The PR description reports git diff --check, local Markdown link checks for changed docs, reference README direct-file index check, pnpm check:governance, pnpm test, and Visual Operations snapshot checks passing locally.",
+      "reported_at": "2026-06-16T14:47:51Z",
+      "source_url": "https://github.com/nevitonsantana/AletheIA/pull/207"
+    }
+  ]
+}

--- a/examples/visual-operations/github-pr-207-dogfood-output.json
+++ b/examples/visual-operations/github-pr-207-dogfood-output.json
@@ -1,0 +1,379 @@
+{
+  "projection": {
+    "mode": "read_only",
+    "projector": "github_pull_request",
+    "projected_at": "2026-06-16T15:00:00Z",
+    "source_refs": [
+      "https://github.com/nevitonsantana/AletheIA/pull/207"
+    ]
+  },
+  "work_slice_visual_state": {
+    "work_slice_id": "github-pr-207",
+    "title": "docs(visual-ops): map human review sources",
+    "objective": "unknown",
+    "presentation_lane": "closed",
+    "lane_confidence": "confirmed",
+    "risk_level": "unknown",
+    "planning_depth": "unknown",
+    "readiness_outcome": "unknown",
+    "evidence_status": "sufficient",
+    "human_review": {
+      "required": "unknown",
+      "status": "unavailable",
+      "reviewer_role": null,
+      "open_question": null,
+      "source_refs": []
+    },
+    "primary_skill": {
+      "skill_id": "unknown",
+      "activation_status": "unknown",
+      "source_refs": []
+    },
+    "runtime": {
+      "runtime_id": "unavailable",
+      "session_status": "unavailable",
+      "source_refs": []
+    },
+    "telemetry": {
+      "tokens": {
+        "value": null,
+        "provenance": "unavailable",
+        "source_refs": []
+      },
+      "cost": {
+        "value": null,
+        "currency": null,
+        "provenance": "unavailable",
+        "source_refs": []
+      }
+    },
+    "alerts": [],
+    "evidence": [
+      {
+        "evidence_id": "evidence-check-81688153415",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Governance Check (scripts/check-governance.sh): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153415"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81688153379",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Install & TypeScript Build: completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153379"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81688153479",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Lockfile sync (package.json ↔ pnpm-lock.yaml): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153479"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81688264677",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Tests (Vitest): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688264677"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81688264542",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Visual Operations Snapshots: completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688264542"
+        ]
+      },
+      {
+        "evidence_id": "evidence-check-81688392735",
+        "type": "ci_check",
+        "status": "passed",
+        "provenance": "ci_observed",
+        "summary": "Quality Gate (aggregator): completed/success.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688392735"
+        ]
+      },
+      {
+        "evidence_id": "evidence-author-pr-207-local-validation",
+        "type": "author_reported_validation",
+        "status": "passed",
+        "provenance": "author_reported",
+        "summary": "The PR description reports git diff --check, local Markdown link checks for changed docs, reference README direct-file index check, pnpm check:governance, pnpm test, and Visual Operations snapshot checks passing locally.",
+        "source_refs": [
+          "https://github.com/nevitonsantana/AletheIA/pull/207"
+        ]
+      }
+    ],
+    "source_refs": [
+      "https://github.com/nevitonsantana/AletheIA",
+      "https://github.com/nevitonsantana/AletheIA/pull/207",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153415",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153379",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153479",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688264677",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688264542",
+      "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688392735"
+    ],
+    "projected_at": "2026-06-16T15:00:00Z"
+  },
+  "normalized_events": [
+    {
+      "event_id": "evt-github-pr-207-author-validation-pr-207-local-validation",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-207",
+      "timestamp": "2026-06-16T14:47:51Z",
+      "source_type": "external",
+      "event_type": "evidence.added",
+      "actor": "nevitonsantana",
+      "summary": "The PR description reports git diff --check, local Markdown link checks for changed docs, reference README direct-file index check, pnpm check:governance, pnpm test, and Visual Operations snapshot checks passing locally.",
+      "payload_metadata": {
+        "validation_name": "Local human-review mapping validation",
+        "validation_status": "passed",
+        "provenance": "author_reported"
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/pull/207"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_pull_request_report",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/207"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-207-created",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-207",
+      "timestamp": "2026-06-16T14:47:51Z",
+      "source_type": "external",
+      "event_type": "work_slice.created",
+      "actor": "nevitonsantana",
+      "summary": "GitHub pull request #207 was opened.",
+      "payload_metadata": {
+        "repository": "nevitonsantana/AletheIA",
+        "base_ref": "main",
+        "head_sha": "efd7357bdb5bb6481410a0db6a5cc8534c330115",
+        "draft": false
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_pull_request",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/207"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-207-check-81688153479",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-207",
+      "timestamp": "2026-06-16T14:48:13Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Lockfile sync (package.json ↔ pnpm-lock.yaml) reported success.",
+      "payload_metadata": {
+        "check_name": "Lockfile sync (package.json ↔ pnpm-lock.yaml)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153479"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153479"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-207-check-81688153415",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-207",
+      "timestamp": "2026-06-16T14:48:16Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Governance Check (scripts/check-governance.sh) reported success.",
+      "payload_metadata": {
+        "check_name": "Governance Check (scripts/check-governance.sh)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153415"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153415"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-207-check-81688153379",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-207",
+      "timestamp": "2026-06-16T14:48:31Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Install & TypeScript Build reported success.",
+      "payload_metadata": {
+        "check_name": "Install & TypeScript Build",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153379"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153379"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-207-check-81688264542",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-207",
+      "timestamp": "2026-06-16T14:48:56Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Visual Operations Snapshots reported success.",
+      "payload_metadata": {
+        "check_name": "Visual Operations Snapshots",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688264542"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688264542"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-207-check-81688264677",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-207",
+      "timestamp": "2026-06-16T14:49:03Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Tests (Vitest) reported success.",
+      "payload_metadata": {
+        "check_name": "Tests (Vitest)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688264677"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688264677"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-207-check-81688392735",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-207",
+      "timestamp": "2026-06-16T14:49:15Z",
+      "source_type": "external",
+      "event_type": "validation.passed",
+      "actor": "github-actions",
+      "summary": "GitHub check Quality Gate (aggregator) reported success.",
+      "payload_metadata": {
+        "check_name": "Quality Gate (aggregator)",
+        "conclusion": "success",
+        "required": true
+      },
+      "evidence_refs": [
+        "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688392735"
+      ],
+      "source_refs": [
+        {
+          "kind": "github_check",
+          "ref": "https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688392735"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-207-timeline-pr-207-closed",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-207",
+      "timestamp": "2026-06-16T14:55:31Z",
+      "source_type": "external",
+      "event_type": "reconcile.created",
+      "actor": "nevitonsantana",
+      "summary": "GitHub recorded pull request event: closed.",
+      "payload_metadata": {
+        "github_event_type": "closed"
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_timeline_event",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/207"
+        }
+      ],
+      "sensitivity": "internal"
+    },
+    {
+      "event_id": "evt-github-pr-207-timeline-pr-207-merged",
+      "project_id": "aletheia",
+      "work_slice_id": "github-pr-207",
+      "timestamp": "2026-06-16T14:55:31Z",
+      "source_type": "external",
+      "event_type": "reconcile.created",
+      "actor": "nevitonsantana",
+      "summary": "GitHub recorded pull request event: merged.",
+      "payload_metadata": {
+        "github_event_type": "merged"
+      },
+      "evidence_refs": [],
+      "source_refs": [
+        {
+          "kind": "github_timeline_event",
+          "ref": "https://github.com/nevitonsantana/AletheIA/pull/207"
+        }
+      ],
+      "sensitivity": "internal"
+    }
+  ],
+  "follow_up_slices": []
+}

--- a/examples/visual-operations/github-pr-207-dogfood-output.md
+++ b/examples/visual-operations/github-pr-207-dogfood-output.md
@@ -1,0 +1,42 @@
+# Visual Operations Snapshot — github-pr-207
+
+> Read-only projection generated at 2026-06-16T15:00:00Z. Source records remain authoritative.
+
+## State
+
+| Field | Value |
+|---|---|
+| Title | docs(visual-ops): map human review sources |
+| Presentation lane | closed (confirmed) |
+| Evidence status | sufficient |
+| Risk | unknown |
+| Planning depth | unknown |
+| Readiness outcome | unknown |
+| Human review | unavailable |
+| Runtime | unavailable |
+| Tokens | unavailable |
+| Cost | unavailable |
+
+## Evidence
+
+| Evidence | Status | Provenance | Source refs |
+|---|---|---|---|
+| Governance Check (scripts/check-governance.sh): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153415 |
+| Install & TypeScript Build: completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153379 |
+| Lockfile sync (package.json ↔ pnpm-lock.yaml): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688153479 |
+| Tests (Vitest): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688264677 |
+| Visual Operations Snapshots: completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688264542 |
+| Quality Gate (aggregator): completed/success. | passed | ci_observed | https://github.com/nevitonsantana/AletheIA/actions/runs/27626141953/job/81688392735 |
+| The PR description reports git diff --check, local Markdown link checks for changed docs, reference README direct-file index check, pnpm check:governance, pnpm test, and Visual Operations snapshot checks passing locally. | passed | author_reported | https://github.com/nevitonsantana/AletheIA/pull/207 |
+
+## Alerts
+
+| Severity | Type | Summary | Source refs |
+|---|---|---|---|
+| info | none | No projected alerts. | — |
+
+## Follow-up slices
+
+| Work Slice | Reason | Source refs |
+|---|---|---|
+| none | No follow-up slice projected. | — |


### PR DESCRIPTION
## What changed
- Added PR #207 dogfood usage evidence for the Visual Operations human-review source mapping slice.
- Added generated PR #207 Visual Operations input/output JSON and Markdown snapshot.
- Indexed the new usage record in `docs/pilots/README.md`.

## Why it changed
- PR #207 clarified that `human_review=unavailable` is a source-bound projection result, not a UI or projector failure.
- This record preserves the design implication before moving toward cockpit/card visual modeling: unavailable authority needs a clear non-failure visual treatment.

## How to validate
- `git diff --check`
- local Markdown link check for changed/new docs
- JSON parse check for PR #207 dogfood input/output
- `pnpm check:governance`
- `pnpm test`
- `./scripts/check-visual-ops-snapshots.sh`

## Risks, assumptions, follow-ups
- Docs/examples only; no projector, schema, runtime, backend, collector, UI, or policy engine changes.
- The PR #207 snapshot remains outside the CI snapshot allowlist by design because it is dogfood evidence, not a new canonical scenario.
- Next likely docs-first step: prepare a visual model for cockpit cards/lanes/alerts using accumulated dogfood evidence, before implementing any UI.
- `plans/` remains untracked and untouched.
