### PR TITLE
docs(visual-ops): refine static prototype visual direction

### DIFF
--- a/examples/visual-operations/prototype/README.md
+++ b/examples/visual-operations/prototype/README.md
@@ -4,7 +4,7 @@
 
 This folder contains a static frontend prototype for the Visual Operations cockpit direction.
 
-It renders the refined **Trace Room + Evidence Desk** mock as local HTML/CSS/JS with mock data only.
+It renders the **Evidence Ledger + Inspector** direction as local HTML/CSS/JS with mock data only.
 It does not collect, store, mutate, or fetch real source records.
 
 ## Open locally
@@ -30,23 +30,24 @@ No build step, server, backend, runtime, collector, schema, or package dependenc
 ## Visual status
 
 This prototype is an architectural and interaction scaffold for the Mission Control surface.
-The current refinement pass improves art direction, hierarchy, contrast, and motion, but the artifact remains a static prototype rather than the final product UI.
+The current direction changes composition rather than polishing the earlier board: it uses an **Evidence Ledger + Inspector** structure inspired by the supplied dark operational references.
 
 Design intent:
 
-- sober evidence-room atmosphere instead of a generic dashboard or AI-polished cockpit;
-- trace rail and source rails as the signature visual system;
-- flatter ledger surfaces with less glow, less glass, fewer pill-like controls, and tighter radius;
-- restrained amber, moss, vermilion, and telemetry blue only for evidence state;
-- motion limited to a short surface entrance and narrow inspection transitions.
+- sober app shell with wide breathing room and restrained density;
+- central evidence ledger for Work Slice posture instead of a generic project-management board;
+- persistent right-side inspector for source refs, trace context, confidence, and boundary language;
+- trace/events integrated as context rather than a dominant decorative rail;
+- flatter surfaces with less glow, less glass, fewer pill-like controls, and tighter radius;
+- state color used only for evidence posture: review, critical, stable, and unavailable.
 
 ## What to review
 
-- Does the trace rail explain why the board says what it says?
-- Does the first read prioritize pending review and conflicted validation?
+- Does the surface feel like an operational evidence tool rather than a generic dashboard?
+- Does the central ledger reduce project-management-board vibes?
+- Does the inspector make source refs, confidence, trace context, and boundaries easier to read?
 - Does `unavailable` look neutral rather than failed?
-- Are source refs visible without overwhelming the card scan?
-- Do interactions stay narrow: filter, open detail, show/hide empty lanes?
+- Do interactions stay narrow: filter and inspect only?
 
 ## Source design artifacts
 

--- a/examples/visual-operations/prototype/README.md
+++ b/examples/visual-operations/prototype/README.md
@@ -34,9 +34,10 @@ The current direction changes composition rather than polishing the earlier boar
 
 Design intent:
 
-- sober app shell with wide breathing room and restrained density;
+- full-browser app shell rather than a framed presentation mock;
+- collapsible left navigation that can expand for labels or collapse for workspace focus;
 - central evidence ledger for Work Slice posture instead of a generic project-management board;
-- persistent right-side inspector for source refs, trace context, confidence, and boundary language;
+- right-side evidence inspector as a side sheet for source refs, trace context, confidence, and boundary language;
 - trace/events integrated as context rather than a dominant decorative rail;
 - flatter surfaces with less glow, less glass, fewer pill-like controls, and tighter radius;
 - state color used only for evidence posture: review, critical, stable, and unavailable.
@@ -47,7 +48,9 @@ Design intent:
 - Does the central ledger reduce project-management-board vibes?
 - Does the inspector make source refs, confidence, trace context, and boundaries easier to read?
 - Does `unavailable` look neutral rather than failed?
-- Do interactions stay narrow: filter and inspect only?
+- Do interactions stay narrow: filter, expand/collapse navigation, and inspect only?
+- Does the full-browser shell feel like product UI rather than a centered mockup?
+- Does the side sheet make details available without permanently consuming workspace?
 
 ## Source design artifacts
 

--- a/examples/visual-operations/prototype/README.md
+++ b/examples/visual-operations/prototype/README.md
@@ -27,6 +27,18 @@ No build step, server, backend, runtime, collector, schema, or package dependenc
 - no Adaptive Skills integration;
 - source refs are illustrative and metadata-first.
 
+## Visual status
+
+This prototype is an architectural and interaction scaffold for the Mission Control surface.
+The current refinement pass improves art direction, hierarchy, contrast, and motion, but the artifact remains a static prototype rather than the final product UI.
+
+Design intent:
+
+- darker evidence-room atmosphere instead of a generic light dashboard;
+- trace rail and source rails as the signature visual system;
+- restrained amber, moss, vermilion, and telemetry blue only for evidence state;
+- motion limited to surface entrance, card affordance, and drawer inspection.
+
 ## What to review
 
 - Does the trace rail explain why the board says what it says?

--- a/examples/visual-operations/prototype/README.md
+++ b/examples/visual-operations/prototype/README.md
@@ -34,10 +34,11 @@ The current refinement pass improves art direction, hierarchy, contrast, and mot
 
 Design intent:
 
-- darker evidence-room atmosphere instead of a generic light dashboard;
+- sober evidence-room atmosphere instead of a generic dashboard or AI-polished cockpit;
 - trace rail and source rails as the signature visual system;
+- flatter ledger surfaces with less glow, less glass, fewer pill-like controls, and tighter radius;
 - restrained amber, moss, vermilion, and telemetry blue only for evidence state;
-- motion limited to surface entrance, card affordance, and drawer inspection.
+- motion limited to a short surface entrance and narrow inspection transitions.
 
 ## What to review
 

--- a/examples/visual-operations/prototype/mission-control-static.html
+++ b/examples/visual-operations/prototype/mission-control-static.html
@@ -6,1097 +6,934 @@
   <title>AletheIA Mission Control — Static Prototype</title>
   <style>
     :root {
-      --ink: #e8e4da;
-      --ink-strong: #f8f3e8;
-      --ink-muted: #a7aaa6;
-      --ink-faint: #707872;
-      --void: #0a0d0c;
-      --surface: #111514;
-      --surface-2: #151a18;
-      --surface-3: #1b211f;
-      --ledger-line: rgba(232, 228, 218, 0.14);
-      --ledger-line-strong: rgba(232, 228, 218, 0.28);
-      --verified-moss: #8fb99d;
-      --review-amber: #d2a15f;
-      --stop-vermilion: #d87465;
-      --telemetry-blue: #8ab3c9;
-      --shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
-      --radius: 8px;
-      --radius-soft: 6px;
+      --bg: #090c12;
+      --shell: #0d1119;
+      --panel: #10151f;
+      --panel-2: #141a25;
+      --panel-3: #181f2b;
+      --line: rgba(174, 185, 207, 0.14);
+      --line-strong: rgba(174, 185, 207, 0.24);
+      --text: #e7ebf2;
+      --text-soft: #b3bac8;
+      --text-muted: #727b8e;
+      --critical: #e17063;
+      --review: #d6a35e;
+      --stable: #84b99a;
+      --info: #85b7d3;
+      --violet: #8b6ee8;
+      --radius: 14px;
+      --radius-sm: 9px;
+      --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      --sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       color-scheme: dark;
     }
 
     * { box-sizing: border-box; }
 
-    html { background: var(--void); }
+    html { background: var(--bg); }
 
     body {
       margin: 0;
       min-height: 100vh;
-      background:
-        linear-gradient(90deg, rgba(232, 228, 218, 0.035) 1px, transparent 1px),
-        linear-gradient(180deg, rgba(232, 228, 218, 0.028) 1px, transparent 1px),
-        #0a0d0c;
-      background-size: 56px 56px;
-      color: var(--ink);
-      font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--sans);
       letter-spacing: -0.01em;
     }
 
     button, input { font: inherit; }
 
-    .app-shell {
-      display: grid;
-      grid-template-columns: minmax(310px, 360px) minmax(0, 1fr);
-      gap: 18px;
+    button {
+      color: inherit;
+      border: 0;
+    }
+
+    .stage {
       min-height: 100vh;
-      padding: 22px;
+      display: grid;
+      place-items: center;
+      padding: clamp(18px, 3vw, 42px);
+    }
+
+    .mission-shell {
+      width: min(1540px, 100%);
+      min-height: min(900px, calc(100vh - 48px));
+      display: grid;
+      grid-template-columns: 64px minmax(0, 1fr);
+      border: 1px solid var(--line-strong);
+      border-radius: 22px;
+      background: var(--shell);
+      overflow: hidden;
+      box-shadow: 0 24px 80px rgba(0, 0, 0, 0.34);
+    }
+
+    .side-rail {
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      gap: 18px;
+      padding: 18px 10px;
+      border-right: 1px solid var(--line);
+      background: #0a0e15;
+    }
+
+    .mark {
+      width: 34px;
+      height: 34px;
+      margin: 0 auto;
+      display: grid;
+      place-items: center;
+      border: 1px solid rgba(139, 110, 232, 0.42);
+      border-radius: 10px;
+      color: #c9bcff;
+      font: 800 0.75rem var(--mono);
+      background: rgba(139, 110, 232, 0.08);
+    }
+
+    .rail-stack {
+      display: grid;
+      gap: 10px;
+      align-content: start;
+      justify-items: center;
+    }
+
+    .rail-button {
+      width: 38px;
+      height: 38px;
+      display: grid;
+      place-items: center;
+      border-radius: 11px;
+      background: transparent;
+      color: var(--text-muted);
+      font: 760 0.66rem var(--mono);
+      cursor: pointer;
+    }
+
+    .rail-button.active,
+    .rail-button:hover,
+    .rail-button:focus-visible {
+      background: var(--panel-2);
+      color: var(--text);
+      outline: 1px solid var(--line-strong);
+    }
+
+    .app {
+      display: grid;
+      grid-template-rows: auto 1fr;
+      min-width: 0;
     }
 
     .topbar {
-      grid-column: 1 / -1;
       display: grid;
-      grid-template-columns: minmax(0, 1fr) auto auto;
-      gap: 20px;
-      align-items: end;
-      padding: 0 0 14px;
-      border-bottom: 1px solid var(--ledger-line-strong);
+      grid-template-columns: minmax(0, 1fr) minmax(240px, 410px) auto;
+      gap: 16px;
+      align-items: center;
+      min-height: 74px;
+      padding: 16px 22px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(13, 17, 25, 0.98);
     }
 
-    .brand {
+    .product-title {
       display: flex;
-      align-items: end;
-      gap: 14px;
+      align-items: baseline;
+      gap: 12px;
       min-width: 0;
     }
 
     h1 {
       margin: 0;
-      color: var(--ink-strong);
-      font-size: clamp(2rem, 3.2vw, 3.8rem);
-      line-height: 0.92;
-      letter-spacing: -0.055em;
-      white-space: nowrap;
-      font-weight: 820;
+      font-size: 1.36rem;
+      font-weight: 720;
+      letter-spacing: -0.035em;
     }
 
-    .pill {
-      display: inline-flex;
-      align-items: center;
-      border: 1px solid rgba(143, 185, 157, 0.42);
-      border-radius: 4px;
-      color: #cfe3d5;
-      background: rgba(143, 185, 157, 0.055);
-      padding: 8px 10px;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-weight: 760;
+    .mode-label, .meta, .kicker, .utility, .source-ref, .chip, .metric-label {
+      font-family: var(--mono);
+      letter-spacing: 0.02em;
+    }
+
+    .mode-label {
+      color: var(--stable);
       font-size: 0.68rem;
-      letter-spacing: 0.06em;
       text-transform: uppercase;
-      white-space: nowrap;
     }
 
-    .timestamp, .authority, .utility {
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.72rem;
-      color: var(--ink-muted);
+    .search-box {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-width: 0;
+      height: 38px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: #0b1018;
+      color: var(--text-muted);
+      padding: 0 12px;
+      font-size: 0.82rem;
     }
 
-    .timestamp { color: var(--ink-faint); }
+    .search-box span:first-child {
+      font: 780 0.72rem var(--mono);
+      color: var(--text-muted);
+    }
 
     .authority {
-      color: #cfe3d5;
-      font-weight: 720;
       text-align: right;
+      color: var(--text-muted);
+      font-size: 0.72rem;
+      line-height: 1.35;
     }
 
-    .trace-room, .workspace > section, .lane, .detail-drawer {
-      border: 1px solid var(--ledger-line);
-      background: rgba(17, 21, 20, 0.96);
-      box-shadow: var(--shadow);
-    }
-
-    .trace-room {
-      position: sticky;
-      top: 20px;
-      align-self: start;
-      max-height: calc(100vh - 124px);
-      overflow: auto;
-      border-radius: var(--radius);
-      padding: 16px;
-      border-left: 3px solid var(--review-amber);
-    }
-
-    .trace-room::-webkit-scrollbar, .detail-drawer::-webkit-scrollbar { width: 10px; }
-    .trace-room::-webkit-scrollbar-thumb, .detail-drawer::-webkit-scrollbar-thumb {
-      background: rgba(232, 228, 218, 0.18);
-      border-radius: 999px;
-      border: 3px solid transparent;
-      background-clip: content-box;
-    }
-
-    .section-kicker {
-      margin: 0;
-      color: var(--ink-faint);
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.66rem;
-      text-transform: uppercase;
-      letter-spacing: 0.11em;
-      font-weight: 760;
-    }
-
-    .trace-header {
-      display: flex;
-      align-items: start;
-      justify-content: space-between;
-      gap: 10px;
-      padding-bottom: 14px;
-      border-bottom: 1px solid var(--ledger-line);
-    }
-
-    .trace-header h2, .lane h2, .drawer-title {
-      margin: 4px 0 0;
-      color: var(--ink-strong);
-      font-size: 0.98rem;
-      letter-spacing: -0.025em;
-    }
-
-    .trace-actions { display: flex; gap: 8px; }
-
-    .icon-button, .filter-button, .card-button {
-      border: 1px solid var(--ledger-line-strong);
-      background: transparent;
-      color: var(--ink);
-      cursor: pointer;
-      transition: transform 140ms ease, border-color 140ms ease, background 140ms ease, color 140ms ease;
-    }
-
-    .icon-button {
-      min-width: 34px;
-      height: 34px;
-      border-radius: 4px;
-      padding: 0 10px;
-    }
-
-    .icon-button:hover, .filter-button:hover, .card-button:hover,
-    .icon-button:focus-visible, .filter-button:focus-visible, .card-button:focus-visible {
-      transform: translateY(-1px);
-      border-color: rgba(232, 228, 218, 0.48);
-      background: rgba(232, 228, 218, 0.045);
-      outline: none;
-    }
-
-    .trace-group { margin-top: 18px; }
-
-    .trace-date {
-      display: flex;
-      gap: 8px;
-      align-items: center;
-      margin-bottom: 13px;
-      color: #d8c5a2;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-weight: 780;
-      font-size: 0.7rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-
-    .trace-item {
-      position: relative;
-      display: grid;
-      grid-template-columns: 44px 1fr;
-      gap: 12px;
-      padding: 0 0 22px;
-    }
-
-    .trace-item::before {
-      content: "";
-      position: absolute;
-      left: 55px;
-      top: 24px;
-      bottom: 0;
-      width: 1px;
-      background: rgba(232, 228, 218, 0.18);
-    }
-
-    .trace-item:last-child::before { display: none; }
-
-    .trace-time {
-      padding-top: 5px;
-      color: var(--ink-faint);
-      font-size: 0.68rem;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      text-align: right;
-    }
-
-    .trace-card {
-      position: relative;
-      padding: 0 0 0 18px;
-    }
-
-    .trace-dot {
-      position: absolute;
-      left: -10px;
-      top: 3px;
-      width: 17px;
-      height: 17px;
-      border-radius: 999px;
-      border: 3px solid var(--surface);
-      background: var(--verified-moss);
-      box-shadow: 0 0 0 1px rgba(232, 228, 218, 0.28);
-    }
-
-    .trace-dot.critical { background: var(--stop-vermilion); }
-    .trace-dot.warning { background: var(--review-amber); }
-    .trace-dot.info { background: var(--telemetry-blue); }
-
-    .trace-title {
-      margin: 0 0 4px;
-      color: var(--ink-strong);
-      font-size: 0.9rem;
-      font-weight: 760;
-      letter-spacing: -0.018em;
-    }
-
-    .trace-copy {
-      margin: 0 0 8px;
-      color: var(--ink-muted);
-      font-size: 0.78rem;
-      line-height: 1.4;
-    }
-
-    .tags {
-      display: flex;
-      gap: 5px;
-      flex-wrap: wrap;
-    }
-
-    .tag {
-      display: inline-flex;
-      align-items: center;
-      border: 1px solid rgba(232, 228, 218, 0.18);
-      border-radius: 4px;
-      background: rgba(232, 228, 218, 0.028);
-      padding: 3px 6px;
-      color: #c5c1b7;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.6rem;
-      font-weight: 700;
-      white-space: nowrap;
+    .authority strong {
+      display: block;
+      color: var(--text-soft);
+      font-weight: 620;
     }
 
     .workspace {
       display: grid;
-      gap: 16px;
+      grid-template-columns: minmax(0, 1fr) 360px;
+      min-height: 0;
+    }
+
+    .main-board {
       min-width: 0;
+      padding: 22px;
+      overflow: auto;
     }
 
-    .overview {
-      border-radius: var(--radius);
+    .inspector {
       display: grid;
-      grid-template-columns: 1.28fr repeat(5, minmax(112px, 1fr));
-      overflow: hidden;
+      grid-template-rows: auto 1fr;
+      min-height: 0;
+      border-left: 1px solid var(--line);
+      background: #0b0f16;
     }
 
-    .overview-cell {
-      position: relative;
-      padding: 18px 20px;
-      border-right: 1px solid var(--ledger-line);
-      min-height: 104px;
+    .inspector-header {
+      padding: 22px;
+      border-bottom: 1px solid var(--line);
     }
-    .overview-cell:last-child { border-right: 0; }
-    .overview-cell:first-child { background: rgba(232, 228, 218, 0.025); }
 
-    .overview-label {
+    .inspector-body {
+      padding: 22px;
+      overflow: auto;
+    }
+
+    .section-head {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 16px;
+      align-items: end;
+      margin-bottom: 18px;
+    }
+
+    .eyebrow {
       margin: 0 0 7px;
-      color: #d6d0c2;
-      font-size: 0.82rem;
-      line-height: 1.32;
-    }
-
-    .overview-number {
-      display: inline-flex;
-      align-items: baseline;
-      gap: 8px;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 2.35rem;
-      font-weight: 760;
-      line-height: 1;
-      letter-spacing: -0.05em;
-    }
-
-    .overview-unit {
-      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      color: var(--ink-faint);
-      font-size: 0.74rem;
-      letter-spacing: -0.01em;
-      font-weight: 500;
-    }
-
-    .tone-critical { color: var(--stop-vermilion); }
-    .tone-warning { color: var(--review-amber); }
-    .tone-stable { color: var(--verified-moss); }
-    .tone-info { color: var(--telemetry-blue); }
-
-    .exceptions {
-      border-radius: var(--radius);
-      display: grid;
-      grid-template-columns: 0.95fr repeat(3, 1fr);
-      overflow: hidden;
-    }
-
-    .exception-intro, .exception-item {
-      padding: 18px 20px;
-      border-right: 1px solid var(--ledger-line);
-    }
-    .exception-item:last-child { border-right: 0; }
-
-    .exception-item {
-      position: relative;
-      display: grid;
-      grid-template-columns: 4px 1fr auto;
-      gap: 13px;
-      align-items: center;
-      color: var(--ink);
-      cursor: pointer;
-      text-align: left;
-      border-top: 0;
-      border-bottom: 0;
-      border-left: 0;
-      background: transparent;
-      transition: background 140ms ease;
-    }
-
-    .exception-item:hover, .exception-item:focus-visible {
-      background: rgba(232, 228, 218, 0.035);
-      outline: none;
-    }
-
-    .exception-rail {
-      width: 4px;
-      align-self: stretch;
-      border-radius: 999px;
-      background: var(--review-amber);
-    }
-    .exception-rail.critical { background: var(--stop-vermilion); }
-    .exception-rail.info { background: var(--telemetry-blue); }
-
-    .exception-label {
-      display: block;
-      margin: 0 0 5px;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.64rem;
+      color: var(--text-muted);
+      font: 720 0.7rem var(--mono);
       text-transform: uppercase;
-      letter-spacing: 0.1em;
-      font-weight: 820;
+      letter-spacing: 0.09em;
     }
 
-    .exception-title {
-      display: block;
+    .section-title {
       margin: 0;
-      color: var(--ink-strong);
-      font-weight: 760;
-      letter-spacing: -0.02em;
+      font-size: 1.9rem;
+      line-height: 1;
+      letter-spacing: -0.055em;
+      font-weight: 720;
     }
 
-    .exception-copy {
-      display: block;
-      margin: 5px 0 0;
-      color: var(--ink-muted);
-      font-size: 0.78rem;
-      line-height: 1.36;
+    .section-copy {
+      margin: 8px 0 0;
+      max-width: 680px;
+      color: var(--text-muted);
+      font-size: 0.88rem;
+      line-height: 1.45;
     }
 
     .filters {
       display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 12px;
-      flex-wrap: wrap;
-      padding: 0;
-    }
-
-    .filter-group {
-      display: flex;
       gap: 8px;
       flex-wrap: wrap;
+      justify-content: flex-end;
     }
 
     .filter-button {
-      border-radius: 4px;
-      padding: 8px 10px;
+      height: 32px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: transparent;
+      color: var(--text-muted);
+      padding: 0 10px;
       font-size: 0.76rem;
-      font-weight: 720;
+      cursor: pointer;
     }
 
-    .filter-button[aria-pressed="true"] {
-      background: #d8d0c2;
-      border-color: #d8d0c2;
-      color: #101413;
+    .filter-button[aria-pressed="true"],
+    .filter-button:hover,
+    .filter-button:focus-visible {
+      border-color: var(--line-strong);
+      background: var(--panel-2);
+      color: var(--text);
+      outline: none;
     }
 
-    .board {
+    .metrics-row {
       display: grid;
-      grid-template-columns: repeat(4, minmax(220px, 1fr));
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 10px;
+      margin-bottom: 18px;
+    }
+
+    .metric {
+      min-height: 76px;
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
+      background: rgba(20, 26, 37, 0.64);
+    }
+
+    .metric-value {
+      margin-top: 8px;
+      font-size: 1.6rem;
+      font-weight: 720;
+      letter-spacing: -0.045em;
+    }
+
+    .metric-label {
+      color: var(--text-muted);
+      font-size: 0.66rem;
+      text-transform: uppercase;
+    }
+
+    .ledger-shell {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      overflow: hidden;
+      background: rgba(16, 21, 31, 0.72);
+    }
+
+    .ledger-toolbar {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
       gap: 12px;
-      align-items: start;
+      align-items: center;
+      padding: 13px 14px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(13, 17, 25, 0.88);
+    }
+
+    .ledger-title {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-width: 0;
+      color: var(--text-soft);
+      font-size: 0.86rem;
+      font-weight: 680;
+    }
+
+    .progress-track {
+      width: 112px;
+      height: 4px;
+      border-radius: 999px;
+      background: rgba(174, 185, 207, 0.14);
+      overflow: hidden;
+    }
+
+    .progress-track span {
+      display: block;
+      width: 42%;
+      height: 100%;
+      background: var(--review);
+    }
+
+    .board-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(190px, 1fr));
+      gap: 0;
+      min-width: 920px;
     }
 
     .lane {
-      position: relative;
-      border-radius: var(--radius);
-      padding: 12px;
-      min-height: 448px;
-      overflow: hidden;
-      background: rgba(15, 19, 18, 0.98);
+      min-height: 560px;
+      border-right: 1px solid var(--line);
+      background: rgba(11, 16, 24, 0.38);
     }
 
-    .lane-header {
-      position: relative;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 12px;
-      margin-bottom: 10px;
-      padding-bottom: 11px;
-      border-bottom: 1px solid var(--ledger-line);
-    }
+    .lane:last-child { border-right: 0; }
 
-    .lane-title {
-      display: flex;
-      align-items: center;
-      gap: 9px;
-    }
-
-    .lane-glyph {
-      display: grid;
-      place-items: center;
-      min-width: 32px;
-      height: 26px;
-      border: 1px solid var(--ledger-line-strong);
-      border-radius: 4px;
-      padding: 0 7px;
-      font-size: 0.6rem;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-weight: 820;
-      color: #cfc7b9;
-      background: rgba(232, 228, 218, 0.025);
-    }
-
-    .count {
-      color: var(--ink-faint);
-      font-size: 0.76rem;
-      white-space: nowrap;
-    }
-
-    .work-card {
-      position: relative;
-      display: grid;
-      grid-template-columns: 5px 1fr;
-      margin: 10px 0;
-      border: 1px solid var(--ledger-line);
-      border-radius: var(--radius-soft);
-      background: rgba(232, 228, 218, 0.026);
-      overflow: hidden;
-      transition: transform 140ms ease, border-color 140ms ease, background 140ms ease;
-    }
-
-    .work-card:hover, .work-card:focus-within {
-      transform: translateY(-1px);
-      border-color: rgba(232, 228, 218, 0.34);
-      background: rgba(232, 228, 218, 0.04);
-    }
-
-    .source-rail { background: rgba(232, 228, 218, 0.24); }
-    .source-rail.critical { background: var(--stop-vermilion); }
-    .source-rail.warning { background: var(--review-amber); }
-    .source-rail.stable { background: var(--verified-moss); }
-    .source-rail.info { background: var(--telemetry-blue); }
-
-    .card-body { padding: 13px; }
-
-    .card-meta {
+    .lane-head {
+      position: sticky;
+      top: 0;
+      z-index: 2;
       display: flex;
       justify-content: space-between;
+      gap: 10px;
+      align-items: center;
+      padding: 13px 14px;
+      border-bottom: 1px solid var(--line);
+      background: #10151f;
+    }
+
+    .lane-name {
+      display: flex;
+      align-items: center;
       gap: 8px;
-      margin-bottom: 11px;
-      align-items: start;
-    }
-
-    .slice-id {
-      color: var(--ink-faint);
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.68rem;
-      font-weight: 760;
-    }
-
-    .status-chip {
-      border: 1px solid rgba(232, 228, 218, 0.14);
-      border-radius: 4px;
-      padding: 3px 6px;
-      background: transparent;
-      color: #cec7bb;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.56rem;
-      text-transform: uppercase;
-      letter-spacing: 0.07em;
-      font-weight: 820;
-      white-space: nowrap;
-    }
-    .status-chip.critical { border-color: rgba(216, 116, 101, 0.42); color: #e2a69d; }
-    .status-chip.warning { border-color: rgba(210, 161, 95, 0.42); color: #dfbf8b; }
-    .status-chip.stable { border-color: rgba(143, 185, 157, 0.42); color: #bad3c2; }
-    .status-chip.info { border-color: rgba(138, 179, 201, 0.42); color: #b4d1df; }
-
-    .card-title {
-      margin: 0 0 7px;
-      color: var(--ink-strong);
-      font-size: 0.98rem;
-      line-height: 1.22;
-      letter-spacing: -0.025em;
-    }
-
-    .card-copy {
-      margin: 0 0 12px;
-      color: var(--ink-muted);
+      min-width: 0;
       font-size: 0.82rem;
-      line-height: 1.44;
+      color: var(--text-soft);
+      font-weight: 680;
     }
 
-    .confidence-row {
-      display: grid;
-      grid-template-columns: 1fr auto;
-      gap: 8px;
-      align-items: center;
-      margin: 12px 0;
-      color: var(--ink-faint);
-      font-size: 0.74rem;
+    .lane-count {
+      color: var(--text-muted);
+      font-size: 0.75rem;
     }
 
-    .dots {
-      display: inline-flex;
-      gap: 5px;
-      align-items: center;
-    }
-
-    .dot {
+    .state-dot {
       width: 7px;
       height: 7px;
       border-radius: 999px;
-      border: 1px solid rgba(232, 228, 218, 0.28);
-      background: transparent;
-    }
-    .dot.on.critical { background: var(--stop-vermilion); border-color: var(--stop-vermilion); }
-    .dot.on.warning { background: var(--review-amber); border-color: var(--review-amber); }
-    .dot.on.stable { background: var(--verified-moss); border-color: var(--verified-moss); }
-    .dot.on.info { background: var(--telemetry-blue); border-color: var(--telemetry-blue); }
-
-    .source-strip {
-      display: flex;
-      gap: 5px;
-      flex-wrap: wrap;
-      padding-top: 10px;
-      border-top: 1px solid var(--ledger-line);
+      background: var(--text-muted);
+      flex: 0 0 auto;
     }
 
-    .card-button {
-      margin-top: 12px;
-      width: 100%;
-      border-radius: 4px;
-      padding: 8px 9px;
-      text-align: left;
-      color: #d8c5a2;
-      font-weight: 760;
-      background: rgba(210, 161, 95, 0.035);
-    }
+    .state-dot.critical { background: var(--critical); }
+    .state-dot.review { background: var(--review); }
+    .state-dot.stable { background: var(--stable); }
+    .state-dot.info { background: var(--info); }
 
-    .empty-slot {
+    .slice-list {
       display: grid;
-      place-items: center;
-      min-height: 82px;
-      border: 1px dashed rgba(232, 228, 218, 0.2);
-      border-radius: var(--radius-soft);
-      color: var(--ink-faint);
-      font-size: 0.74rem;
-      text-align: center;
-      padding: 14px;
-      margin-top: 10px;
-      background: transparent;
+      gap: 8px;
+      padding: 10px;
     }
 
-    .footer-note {
-      grid-column: 1 / -1;
+    .slice-card {
+      width: 100%;
+      display: grid;
+      gap: 10px;
+      text-align: left;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
+      background: rgba(24, 31, 43, 0.68);
+      padding: 12px;
+      cursor: pointer;
+      transition: border-color 140ms ease, background 140ms ease, transform 140ms ease;
+    }
+
+    .slice-card:hover,
+    .slice-card:focus-visible,
+    .slice-card.selected {
+      border-color: var(--line-strong);
+      background: rgba(28, 36, 50, 0.88);
+      outline: none;
+    }
+
+    .slice-card:hover { transform: translateY(-1px); }
+
+    .slice-card.selected {
+      box-shadow: inset 3px 0 0 var(--review);
+    }
+
+    .slice-card[data-tone="critical"].selected { box-shadow: inset 3px 0 0 var(--critical); }
+    .slice-card[data-tone="stable"].selected { box-shadow: inset 3px 0 0 var(--stable); }
+    .slice-card[data-tone="info"].selected { box-shadow: inset 3px 0 0 var(--info); }
+
+    .slice-meta {
       display: flex;
       justify-content: space-between;
-      gap: 16px;
-      padding: 12px 0 0;
-      color: var(--ink-faint);
-      font-size: 0.74rem;
-      border-top: 1px solid var(--ledger-line);
-    }
-
-    .legend {
-      display: flex;
-      gap: 14px;
-      flex-wrap: wrap;
+      gap: 8px;
       align-items: center;
+      color: var(--text-muted);
+      font: 680 0.66rem var(--mono);
     }
 
-    .legend-item {
-      display: inline-flex;
-      gap: 6px;
-      align-items: center;
+    .slice-title {
+      margin: 0;
+      color: var(--text);
+      font-size: 0.91rem;
+      line-height: 1.25;
+      letter-spacing: -0.018em;
+      font-weight: 700;
     }
 
-    .detail-drawer {
-      position: fixed;
-      right: 18px;
-      top: 18px;
-      bottom: 18px;
-      width: min(430px, calc(100vw - 36px));
-      border-radius: var(--radius);
-      padding: 20px;
-      transform: translateX(calc(100% + 32px));
-      transition: transform 210ms cubic-bezier(.2,.8,.2,1);
-      z-index: 10;
-      overflow: auto;
-      border-left: 3px solid var(--telemetry-blue);
-    }
-
-    .detail-drawer.open { transform: translateX(0); }
-
-    .drawer-backdrop {
-      position: fixed;
-      inset: 0;
-      background: rgba(0, 0, 0, 0.44);
-      opacity: 0;
-      pointer-events: none;
-      transition: opacity 160ms ease;
-      z-index: 9;
-    }
-    .drawer-backdrop.open { opacity: 1; pointer-events: auto; }
-
-    .drawer-header {
-      display: flex;
-      align-items: start;
-      justify-content: space-between;
-      gap: 12px;
-      padding-bottom: 16px;
-      border-bottom: 1px solid var(--ledger-line);
-    }
-
-    .drawer-section {
-      padding: 18px 0;
-      border-bottom: 1px solid var(--ledger-line);
-    }
-
-    .drawer-section h3 {
-      margin: 0 0 10px;
-      color: #d8d0c2;
+    .slice-copy {
+      margin: 0;
+      color: var(--text-muted);
       font-size: 0.76rem;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
+      line-height: 1.36;
     }
 
-    .drawer-section p {
+    .slice-footer {
+      display: flex;
+      justify-content: space-between;
+      gap: 10px;
+      align-items: center;
+      padding-top: 9px;
+      border-top: 1px solid var(--line);
+    }
+
+    .source-stack {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 5px;
+    }
+
+    .source-ref, .chip {
+      border: 1px solid rgba(174, 185, 207, 0.18);
+      border-radius: 5px;
+      padding: 3px 6px;
+      background: rgba(174, 185, 207, 0.04);
+      color: var(--text-soft);
+      font-size: 0.58rem;
+      white-space: nowrap;
+    }
+
+    .chip.critical { border-color: rgba(225, 112, 99, 0.38); color: #e8a9a0; }
+    .chip.review { border-color: rgba(214, 163, 94, 0.4); color: #dec08e; }
+    .chip.stable { border-color: rgba(132, 185, 154, 0.38); color: #b9d7c4; }
+    .chip.info { border-color: rgba(133, 183, 211, 0.38); color: #b5d3e4; }
+
+    .confidence {
+      color: var(--text-muted);
+      font: 680 0.62rem var(--mono);
+      white-space: nowrap;
+    }
+
+    .event-strip {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 10px;
+      margin-top: 18px;
+    }
+
+    .event-card {
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
+      background: rgba(16, 21, 31, 0.72);
+      padding: 13px;
+    }
+
+    .event-card p {
+      margin: 6px 0 0;
+      color: var(--text-muted);
+      font-size: 0.76rem;
+      line-height: 1.36;
+    }
+
+    .inspector-title {
+      margin: 6px 0 0;
+      font-size: 1.22rem;
+      line-height: 1.12;
+      letter-spacing: -0.035em;
+      font-weight: 720;
+    }
+
+    .inspector-copy {
+      margin: 10px 0 0;
+      color: var(--text-muted);
+      font-size: 0.82rem;
+      line-height: 1.45;
+    }
+
+    .inspector-section {
+      padding: 18px 0;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .inspector-section:first-child { padding-top: 0; }
+
+    .inspector-section h3 {
       margin: 0 0 10px;
-      color: var(--ink-muted);
-      line-height: 1.48;
-      font-size: 0.9rem;
+      color: var(--text-soft);
+      font-size: 0.78rem;
+      font-weight: 720;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+    }
+
+    .kv {
+      display: grid;
+      gap: 9px;
+    }
+
+    .kv-row {
+      display: grid;
+      grid-template-columns: 92px 1fr;
+      gap: 12px;
+      color: var(--text-soft);
+      font-size: 0.8rem;
+    }
+
+    .kv-row span:first-child {
+      color: var(--text-muted);
+      font-family: var(--mono);
+      font-size: 0.68rem;
+      text-transform: uppercase;
+    }
+
+    .trace-list {
+      display: grid;
+      gap: 12px;
+    }
+
+    .trace-item {
+      display: grid;
+      grid-template-columns: 42px 1fr;
+      gap: 10px;
+      color: var(--text-muted);
+      font-size: 0.76rem;
+      line-height: 1.35;
+    }
+
+    .trace-time {
+      color: var(--text-muted);
+      font: 680 0.66rem var(--mono);
+    }
+
+    .boundary-note {
+      border: 1px solid rgba(132, 185, 154, 0.26);
+      border-radius: var(--radius-sm);
+      background: rgba(132, 185, 154, 0.045);
+      padding: 12px;
+      color: #bdd7c7;
+      font-size: 0.78rem;
+      line-height: 1.42;
     }
 
     .hidden { display: none !important; }
 
     @media (prefers-reduced-motion: no-preference) {
-      .trace-room, .workspace > section, .filters, .board, .footer-note {
-        animation: surfaceIn 360ms ease both;
-      }
-      .workspace > section:nth-child(1) { animation-delay: 40ms; }
-      .workspace > section:nth-child(2) { animation-delay: 70ms; }
-      .filters { animation-delay: 95ms; }
-      .board { animation-delay: 120ms; }
-      .footer-note { animation-delay: 140ms; }
+      .mission-shell { animation: shellIn 360ms ease both; }
+      .slice-card { animation: itemIn 260ms ease both; }
     }
 
-    @keyframes surfaceIn {
-      from { opacity: 0; transform: translateY(4px); }
+    @keyframes shellIn {
+      from { opacity: 0; transform: translateY(6px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    @keyframes itemIn {
+      from { opacity: 0; transform: translateY(3px); }
       to { opacity: 1; transform: translateY(0); }
     }
 
     @media (max-width: 1180px) {
-      .app-shell { grid-template-columns: 1fr; }
-      .trace-room { position: static; max-height: none; }
-      .overview, .exceptions { grid-template-columns: repeat(2, 1fr); }
-      .board { grid-template-columns: repeat(2, minmax(240px, 1fr)); }
+      .mission-shell { grid-template-columns: 1fr; }
+      .side-rail { display: none; }
+      .workspace { grid-template-columns: 1fr; }
+      .inspector { border-left: 0; border-top: 1px solid var(--line); }
+      .metrics-row, .event-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+
+    @media (max-width: 760px) {
+      .stage { padding: 0; place-items: stretch; }
+      .mission-shell { min-height: 100vh; border: 0; border-radius: 0; }
       .topbar { grid-template-columns: 1fr; align-items: start; }
       .authority { text-align: left; }
-      h1 { white-space: normal; }
+      .section-head { grid-template-columns: 1fr; }
+      .filters { justify-content: flex-start; }
+      .metrics-row, .event-strip { grid-template-columns: 1fr; }
+      .main-board { padding: 16px; }
+      .board-grid { min-width: 760px; }
     }
-
-    @media (max-width: 720px) {
-      .app-shell { padding: 14px; }
-      .brand { align-items: start; flex-direction: column; }
-      .overview, .exceptions, .board { grid-template-columns: 1fr; }
-      .overview-cell, .exception-intro, .exception-item { border-right: 0; border-bottom: 1px solid var(--ledger-line); }
-      .overview-cell:last-child, .exception-item:last-child { border-bottom: 0; }
-      .footer-note { flex-direction: column; }
-      .detail-drawer { inset: 12px; width: auto; }
-      .confidence-row { grid-template-columns: 1fr; }
-    }
-
   </style>
 </head>
 <body>
-  <main class="app-shell" aria-label="AletheIA Mission Control static prototype">
-    <header class="topbar">
-      <div class="brand">
-        <h1>AletheIA Mission Control</h1>
-        <span class="pill">Read-only projection</span>
-      </div>
-      <div class="timestamp">Projected at 2026-06-16T16:30:00Z</div>
-      <div class="authority">Source records remain authoritative</div>
-    </header>
+  <div class="stage">
+    <main class="mission-shell" aria-label="AletheIA Mission Control static prototype">
+      <aside class="side-rail" aria-label="Mission Control navigation">
+        <div class="mark">AI</div>
+        <nav class="rail-stack" aria-label="Workspace views">
+          <button class="rail-button" type="button">OV</button>
+          <button class="rail-button active" type="button">EV</button>
+          <button class="rail-button" type="button">TR</button>
+          <button class="rail-button" type="button">SRC</button>
+        </nav>
+        <nav class="rail-stack" aria-label="Utility views">
+          <button class="rail-button" type="button">CFG</button>
+          <button class="rail-button" type="button">AUD</button>
+        </nav>
+      </aside>
 
-    <aside class="trace-room" aria-label="Evidence timeline">
-      <div class="trace-header">
-        <div>
-          <p class="section-kicker">Trace Room</p>
-          <h2>Evidence timeline</h2>
+      <section class="app">
+        <header class="topbar">
+          <div class="product-title">
+            <h1>AletheIA Mission Control</h1>
+            <span class="mode-label">Read-only projection</span>
+          </div>
+          <div class="search-box" aria-label="Static search placeholder"><span>⌕</span><span>Search work slices, source refs, traces</span></div>
+          <div class="authority"><strong>Source records remain authoritative</strong>Static prototype · mock data only</div>
+        </header>
+
+        <div class="workspace">
+          <section class="main-board" aria-label="Evidence ledger workspace">
+            <div class="section-head">
+              <div>
+                <p class="eyebrow">Evidence ledger</p>
+                <h2 class="section-title">Work slices by review posture</h2>
+                <p class="section-copy">A compact operational surface for seeing which derived states need review, which sources support them, and where evidence is unavailable.</p>
+              </div>
+              <nav class="filters" aria-label="Prototype filters">
+                <button class="filter-button" type="button" data-filter="all" aria-pressed="true">All</button>
+                <button class="filter-button" type="button" data-filter="attention" aria-pressed="false">Needs attention</button>
+                <button class="filter-button" type="button" data-filter="stable" aria-pressed="false">Stable</button>
+                <button class="filter-button" type="button" data-filter="unavailable" aria-pressed="false">Unavailable</button>
+              </nav>
+            </div>
+
+            <section class="metrics-row" aria-label="Derived posture summary">
+              <div class="metric"><div class="metric-label">Needs review</div><div class="metric-value" style="color: var(--review)">2</div></div>
+              <div class="metric"><div class="metric-label">Critical prompt</div><div class="metric-value" style="color: var(--critical)">1</div></div>
+              <div class="metric"><div class="metric-label">Source gaps</div><div class="metric-value" style="color: var(--info)">3</div></div>
+              <div class="metric"><div class="metric-label">Closed stable</div><div class="metric-value" style="color: var(--stable)">2</div></div>
+            </section>
+
+            <section class="ledger-shell" aria-label="Work Slice evidence board">
+              <div class="ledger-toolbar">
+                <div class="ledger-title"><span>Board confidence</span><span class="progress-track" aria-hidden="true"><span></span></span><span class="utility">42%</span></div>
+                <span class="utility">Lanes are derived presentation, not lifecycle</span>
+              </div>
+
+              <div class="board-grid">
+                <section class="lane" aria-label="Review lane">
+                  <header class="lane-head"><span class="lane-name"><span class="state-dot critical"></span>Review prompts</span><span class="lane-count">2</span></header>
+                  <div class="slice-list">
+                    <button class="slice-card selected" type="button" data-detail="human-review" data-status="attention" data-tone="critical">
+                      <span class="slice-meta"><span>WS-2026-0616-001</span><span class="chip critical">Human review</span></span>
+                      <strong class="slice-title">Critical risk signal</strong>
+                      <span class="slice-copy">Threshold breach detected. Human confirmation is required before trusting closure.</span>
+                      <span class="slice-footer"><span class="source-stack"><span class="source-ref">SRC-2147</span><span class="source-ref">PR-2.1</span></span><span class="confidence">Low</span></span>
+                    </button>
+                    <button class="slice-card" type="button" data-detail="conflict" data-status="attention" data-tone="review">
+                      <span class="slice-meta"><span>WS-2026-0616-002</span><span class="chip review">Conflict</span></span>
+                      <strong class="slice-title">Model output mismatch</strong>
+                      <span class="slice-copy">Validation sources disagree with the policy baseline and risk thresholds.</span>
+                      <span class="slice-footer"><span class="source-stack"><span class="source-ref">SRC-2149</span><span class="source-ref">Eval 3.2</span></span><span class="confidence">Medium</span></span>
+                    </button>
+                  </div>
+                </section>
+
+                <section class="lane" aria-label="Validation lane">
+                  <header class="lane-head"><span class="lane-name"><span class="state-dot review"></span>Validation</span><span class="lane-count">2</span></header>
+                  <div class="slice-list">
+                    <button class="slice-card" type="button" data-detail="validated" data-status="stable" data-tone="stable">
+                      <span class="slice-meta"><span>WS-2026-0615-006</span><span class="chip stable">Validated</span></span>
+                      <strong class="slice-title">Policy update impact check</strong>
+                      <span class="slice-copy">Evidence supports the validation posture for this static example.</span>
+                      <span class="slice-footer"><span class="source-stack"><span class="source-ref">SRC-2120</span><span class="source-ref">Eval 3.1</span></span><span class="confidence">High</span></span>
+                    </button>
+                    <button class="slice-card" type="button" data-detail="skill" data-status="stable" data-tone="stable">
+                      <span class="slice-meta"><span>WS-2026-0615-004</span><span class="chip stable">Skill traced</span></span>
+                      <strong class="slice-title">Adaptive skill activation</strong>
+                      <span class="slice-copy">Skill activation is visible as trace context, without gate or decision authority.</span>
+                      <span class="slice-footer"><span class="source-stack"><span class="source-ref">ACT-552</span><span class="source-ref">Trace</span></span><span class="confidence">High</span></span>
+                    </button>
+                  </div>
+                </section>
+
+                <section class="lane" aria-label="Reconcile lane">
+                  <header class="lane-head"><span class="lane-name"><span class="state-dot info"></span>Reconcile</span><span class="lane-count">1</span></header>
+                  <div class="slice-list">
+                    <button class="slice-card" type="button" data-detail="telemetry" data-status="unavailable" data-tone="info">
+                      <span class="slice-meta"><span>WS-2026-0616-003</span><span class="chip info">Unavailable</span></span>
+                      <strong class="slice-title">Resolve missing telemetry</strong>
+                      <span class="slice-copy">Runtime, token, and cost records were not exported for this docs-only slice.</span>
+                      <span class="slice-footer"><span class="source-stack"><span class="source-ref">Telemetry</span><span class="source-ref">R-556</span></span><span class="confidence">Unknown</span></span>
+                    </button>
+                  </div>
+                </section>
+
+                <section class="lane" aria-label="Closed lane">
+                  <header class="lane-head"><span class="lane-name"><span class="state-dot stable"></span>Closed stable</span><span class="lane-count">2</span></header>
+                  <div class="slice-list">
+                    <button class="slice-card" type="button" data-detail="closed-207" data-status="stable" data-tone="stable">
+                      <span class="slice-meta"><span>PR #207</span><span class="chip stable">Closed</span></span>
+                      <strong class="slice-title">Human-review source mapping</strong>
+                      <span class="slice-copy">Source supports closure; review source remains represented as unavailable.</span>
+                      <span class="slice-footer"><span class="source-stack"><span class="source-ref">PR #207</span><span class="source-ref">39f76cf</span></span><span class="confidence">High</span></span>
+                    </button>
+                    <button class="slice-card" type="button" data-detail="closed-201" data-status="stable" data-tone="stable">
+                      <span class="slice-meta"><span>PR #201</span><span class="chip stable">Closed</span></span>
+                      <strong class="slice-title">Dogfood evidence record</strong>
+                      <span class="slice-copy">Snapshot evidence supports closeout; human review absence remains visible.</span>
+                      <span class="slice-footer"><span class="source-stack"><span class="source-ref">Dogfood</span><span class="source-ref">Snapshot</span></span><span class="confidence">High</span></span>
+                    </button>
+                  </div>
+                </section>
+              </div>
+            </section>
+
+            <section class="event-strip" aria-label="Recent trace events">
+              <article class="event-card"><span class="kicker">10:18 · Review</span><p>Critical risk signal moved into review prompt from existing risk source.</p></article>
+              <article class="event-card"><span class="kicker">09:42 · Reconcile</span><p>Telemetry marked unavailable. No estimates were invented for token or cost fields.</p></article>
+              <article class="event-card"><span class="kicker">Yesterday · Closure</span><p>Closed posture derived from PR and CI records, not from a new lifecycle authority.</p></article>
+            </section>
+          </section>
+
+          <aside class="inspector" aria-label="Evidence inspector" id="evidence-inspector">
+            <header class="inspector-header">
+              <p class="eyebrow" id="inspector-kicker">Human review · confirmed</p>
+              <h2 class="inspector-title" id="inspector-title">Critical risk signal</h2>
+              <p class="inspector-copy" id="inspector-summary">A source says human review is required before trusting closure. This is a review prompt, not an automated decision.</p>
+            </header>
+            <div class="inspector-body">
+              <section class="inspector-section">
+                <h3>State posture</h3>
+                <div class="kv">
+                  <div class="kv-row"><span>Lane</span><strong id="inspector-lane">Review prompts</strong></div>
+                  <div class="kv-row"><span>Status</span><strong id="inspector-status">Pending human review</strong></div>
+                  <div class="kv-row"><span>Confidence</span><strong id="inspector-confidence">Low</strong></div>
+                </div>
+              </section>
+              <section class="inspector-section">
+                <h3>Source refs</h3>
+                <div class="source-stack" id="inspector-sources"><span class="source-ref">SRC-2147</span><span class="source-ref">Risk Policy PR-2.1</span><span class="source-ref">Rule R-7</span></div>
+              </section>
+              <section class="inspector-section">
+                <h3>Trace context</h3>
+                <div class="trace-list" id="inspector-trace">
+                  <div class="trace-item"><span class="trace-time">10:18</span><span>Risk threshold breach normalized into visual event.</span></div>
+                  <div class="trace-item"><span class="trace-time">10:22</span><span>Human review source required before closure posture can be trusted.</span></div>
+                </div>
+              </section>
+              <section class="inspector-section">
+                <h3>Boundary</h3>
+                <p class="boundary-note" id="inspector-boundary">Do not move this slice to closed without a resolving review source. The cockpit explains evidence; it does not authorize decisions.</p>
+              </section>
+            </div>
+          </aside>
         </div>
-        <div class="trace-actions" aria-label="Trace controls">
-          <button class="icon-button" type="button" aria-label="Filter trace">Filter</button>
-          <button class="icon-button" type="button" aria-label="Trace menu">Menu</button>
-        </div>
-      </div>
-
-      <div class="trace-group">
-        <div class="trace-date">Today · 2026-06-16</div>
-        <article class="trace-item" data-severity="critical">
-          <div class="trace-time">15:42</div>
-          <div class="trace-card">
-            <span class="trace-dot critical" aria-hidden="true"></span>
-            <h3 class="trace-title">Critical flagged</h3>
-            <p class="trace-copy">Slice WS-2026-0616-001 · threshold breach detected.</p>
-            <div class="tags"><span class="tag">SRC-2147</span><span class="tag">Risk Policy PR-2.1</span></div>
-          </div>
-        </article>
-        <article class="trace-item" data-severity="warning">
-          <div class="trace-time">14:28</div>
-          <div class="trace-card">
-            <span class="trace-dot warning" aria-hidden="true"></span>
-            <h3 class="trace-title">Conflicting results</h3>
-            <p class="trace-copy">Slice WS-2026-0616-002 · validation mismatch.</p>
-            <div class="tags"><span class="tag">Eval Report v3.2</span><span class="tag">Policy M-1.4</span></div>
-          </div>
-        </article>
-        <article class="trace-item" data-severity="info">
-          <div class="trace-time">11:07</div>
-          <div class="trace-card">
-            <span class="trace-dot info" aria-hidden="true"></span>
-            <h3 class="trace-title">Telemetry unavailable</h3>
-            <p class="trace-copy">Slice WS-2026-0616-003 · metrics collection unavailable.</p>
-            <div class="tags"><span class="tag">Telemetry Spec</span></div>
-          </div>
-        </article>
-        <article class="trace-item" data-severity="stable">
-          <div class="trace-time">09:31</div>
-          <div class="trace-card">
-            <span class="trace-dot" aria-hidden="true"></span>
-            <h3 class="trace-title">Review closed</h3>
-            <p class="trace-copy">Slice WS-2026-0616-000 · approved by human reviewer.</p>
-            <div class="tags"><span class="tag">Human Review H-7781</span></div>
-          </div>
-        </article>
-      </div>
-
-      <div class="trace-group">
-        <div class="trace-date">Yesterday · 2026-06-15</div>
-        <article class="trace-item" data-severity="warning">
-          <div class="trace-time">17:15</div>
-          <div class="trace-card">
-            <span class="trace-dot warning" aria-hidden="true"></span>
-            <h3 class="trace-title">Policy exception</h3>
-            <p class="trace-copy">Manual override applied to monitoring threshold.</p>
-            <div class="tags"><span class="tag">Policy M-1.4</span></div>
-          </div>
-        </article>
-        <article class="trace-item" data-severity="stable">
-          <div class="trace-time">16:02</div>
-          <div class="trace-card">
-            <span class="trace-dot" aria-hidden="true"></span>
-            <h3 class="trace-title">Review closed</h3>
-            <p class="trace-copy">Reconciled and accepted after source review.</p>
-            <div class="tags"><span class="tag">Reconcile R-556</span><span class="tag">SRC-2129</span></div>
-          </div>
-        </article>
-      </div>
-    </aside>
-
-    <div class="workspace">
-      <section class="overview" aria-label="Overview metrics">
-        <div class="overview-cell">
-          <p class="section-kicker">Overview</p>
-          <p class="overview-label">Current posture across work slices</p>
-        </div>
-        <div class="overview-cell"><p class="overview-label">Needs attention</p><div class="overview-number tone-warning">2 <span class="overview-unit">Slices</span></div></div>
-        <div class="overview-cell"><p class="overview-label">Critical alerts</p><div class="overview-number tone-critical">1 <span class="overview-unit">Slice</span></div></div>
-        <div class="overview-cell"><p class="overview-label">Conflicted</p><div class="overview-number tone-warning">1 <span class="overview-unit">Slice</span></div></div>
-        <div class="overview-cell"><p class="overview-label">Closed stable</p><div class="overview-number tone-stable">2 <span class="overview-unit">Slices</span></div></div>
-        <div class="overview-cell"><p class="overview-label">Unavailable signals</p><div class="overview-number tone-info">3 <span class="overview-unit">Fields</span></div></div>
       </section>
-
-      <section class="exceptions" aria-label="Exception strip">
-        <div class="exception-intro">
-          <p class="section-kicker">Exceptions</p>
-          <p class="overview-label">Active exceptions requiring awareness</p>
-        </div>
-        <button class="exception-item" type="button" data-detail="human-review">
-          <span class="exception-rail critical" aria-hidden="true"></span>
-          <span><span class="exception-label tone-critical">Critical</span><span class="exception-title">1 slice pending human review</span><span class="exception-copy">Action required to reduce risk exposure.</span></span>
-          <span class="utility">Open</span>
-        </button>
-        <button class="exception-item" type="button" data-detail="conflict">
-          <span class="exception-rail" aria-hidden="true"></span>
-          <span><span class="exception-label tone-warning">Warning</span><span class="exception-title">1 slice with conflicted validation</span><span class="exception-copy">Conflicting evidence requires reconciliation.</span></span>
-          <span class="utility">Open</span>
-        </button>
-        <button class="exception-item" type="button" data-detail="telemetry">
-          <span class="exception-rail info" aria-hidden="true"></span>
-          <span><span class="exception-label tone-info">Info</span><span class="exception-title">3 slices with telemetry unavailable</span><span class="exception-copy">Observability gap affects confidence.</span></span>
-          <span class="utility">Open</span>
-        </button>
-      </section>
-
-      <nav class="filters" aria-label="Prototype filters">
-        <div>
-          <p class="section-kicker">Board lanes</p>
-          <span class="utility">Sorted by attention priority · read-only</span>
-        </div>
-        <div class="filter-group">
-          <button class="filter-button" type="button" data-filter="all" aria-pressed="true">All</button>
-          <button class="filter-button" type="button" data-filter="attention" aria-pressed="false">Needs attention</button>
-          <button class="filter-button" type="button" data-filter="stable" aria-pressed="false">Stable</button>
-          <button class="filter-button" type="button" id="toggle-empty" aria-pressed="true">Show empty lanes</button>
-        </div>
-      </nav>
-
-      <section class="board" aria-label="Work Slice board">
-        <section class="lane" data-lane="validation">
-          <div class="lane-header"><div class="lane-title"><span class="lane-glyph">VAL</span><h2>Validation</h2></div><span class="count">2 slices</span></div>
-          <article class="work-card" data-status="attention" data-detail="conflict" tabindex="0">
-            <div class="source-rail warning"></div>
-            <div class="card-body">
-              <div class="card-meta"><span class="slice-id">WS-2026-0616-002</span><span class="status-chip warning">Conflicted</span></div>
-              <h3 class="card-title">Model output mismatch</h3>
-              <p class="card-copy">Results conflict with policy baseline and risk thresholds.</p>
-              <div class="confidence-row"><span>Confidence</span><span class="dots"><i class="dot on warning"></i><i class="dot on warning"></i><i class="dot"></i><i class="dot"></i><span>Medium</span></span></div>
-              <div class="source-strip"><span class="tag">SRC-2149</span><span class="tag">Eval Report v3.2</span><span class="tag">Policy M-1.4</span></div>
-              <button class="card-button" type="button" data-detail="conflict">Compare source refs</button>
-            </div>
-          </article>
-          <article class="work-card" data-status="stable" data-detail="validated" tabindex="0">
-            <div class="source-rail stable"></div>
-            <div class="card-body">
-              <div class="card-meta"><span class="slice-id">WS-2026-0615-006</span><span class="status-chip stable">Validated</span></div>
-              <h3 class="card-title">Policy update impact check</h3>
-              <p class="card-copy">Outputs within expected bounds.</p>
-              <div class="confidence-row"><span>Confidence</span><span class="dots"><i class="dot on stable"></i><i class="dot on stable"></i><i class="dot"></i><i class="dot"></i><span>High</span></span></div>
-              <div class="source-strip"><span class="tag">SRC-2120</span><span class="tag">Eval v3.1</span></div>
-            </div>
-          </article>
-        </section>
-
-        <section class="lane" data-lane="human-review">
-          <div class="lane-header"><div class="lane-title"><span class="lane-glyph">HR</span><h2>Human review</h2></div><span class="count">1 slice</span></div>
-          <article class="work-card" data-status="attention" data-detail="human-review" tabindex="0">
-            <div class="source-rail critical"></div>
-            <div class="card-body">
-              <div class="card-meta"><span class="slice-id">WS-2026-0616-001</span><span class="status-chip critical">Pending · critical</span></div>
-              <h3 class="card-title">Critical risk signal</h3>
-              <p class="card-copy">Threshold breach detected. Human review required.</p>
-              <div class="confidence-row"><span>Confidence</span><span class="dots"><i class="dot on critical"></i><i class="dot on critical"></i><i class="dot on critical"></i><i class="dot"></i><span>Low</span></span></div>
-              <div class="source-strip"><span class="tag">SRC-2147</span><span class="tag">Risk Policy PR-2.1</span><span class="tag">Rule R-7</span></div>
-              <button class="card-button" type="button" data-detail="human-review">Open review question</button>
-            </div>
-          </article>
-          <div class="empty-slot">No other slices in this lane.</div>
-        </section>
-
-        <section class="lane" data-lane="reconcile">
-          <div class="lane-header"><div class="lane-title"><span class="lane-glyph">REC</span><h2>Reconcile</h2></div><span class="count">1 slice</span></div>
-          <article class="work-card" data-status="attention" data-detail="telemetry" tabindex="0">
-            <div class="source-rail info"></div>
-            <div class="card-body">
-              <div class="card-meta"><span class="slice-id">WS-2026-0616-003</span><span class="status-chip info">Telemetry unavailable</span></div>
-              <h3 class="card-title">Resolve missing telemetry</h3>
-              <p class="card-copy">Runtime and cost records were not exported for this docs-only slice.</p>
-              <div class="confidence-row"><span>Confidence</span><span class="dots"><i class="dot on info"></i><i class="dot"></i><i class="dot"></i><span>Unavailable</span></span></div>
-              <div class="source-strip"><span class="tag">Telemetry Spec</span><span class="tag">Closeout R-556</span></div>
-              <button class="card-button" type="button" data-detail="telemetry">Review unavailable fields</button>
-            </div>
-          </article>
-          <div class="empty-slot">No other slices in this lane.</div>
-        </section>
-
-        <section class="lane" data-lane="closed">
-          <div class="lane-header"><div class="lane-title"><span class="lane-glyph">CLS</span><h2>Closed</h2></div><span class="count">2 slices</span></div>
-          <article class="work-card" data-status="stable" data-detail="closed-207" tabindex="0">
-            <div class="source-rail stable"></div>
-            <div class="card-body">
-              <div class="card-meta"><span class="slice-id">PR #207</span><span class="status-chip stable">Stable</span></div>
-              <h3 class="card-title">Human-review source mapping</h3>
-              <p class="card-copy">Source supports closure; review source remains unavailable.</p>
-              <div class="confidence-row"><span>Confidence</span><span class="dots"><i class="dot on stable"></i><i class="dot on stable"></i><i class="dot on stable"></i><i class="dot"></i><span>High</span></span></div>
-              <div class="source-strip"><span class="tag">PR #207</span><span class="tag">CI 27626141953</span><span class="tag">Merge 39f76cf</span></div>
-            </div>
-          </article>
-          <article class="work-card" data-status="stable" data-detail="closed-201" tabindex="0">
-            <div class="source-rail stable"></div>
-            <div class="card-body">
-              <div class="card-meta"><span class="slice-id">PR #201</span><span class="status-chip stable">Stable</span></div>
-              <h3 class="card-title">Dogfood evidence record</h3>
-              <p class="card-copy">Snapshot supports closeout; human review unavailable stays visible.</p>
-              <div class="confidence-row"><span>Confidence</span><span class="dots"><i class="dot on stable"></i><i class="dot on stable"></i><i class="dot"></i><i class="dot"></i><span>High</span></span></div>
-              <div class="source-strip"><span class="tag">PR #201</span><span class="tag">Dogfood snapshot</span></div>
-            </div>
-          </article>
-        </section>
-      </section>
-    </div>
-
-    <footer class="footer-note">
-      <span>This is a read-only static prototype. All data is mock data derived from Visual Operations examples.</span>
-      <span class="legend"><span class="legend-item"><i class="dot on critical"></i>Critical</span><span class="legend-item"><i class="dot on warning"></i>Review</span><span class="legend-item"><i class="dot on stable"></i>Stable</span><span class="legend-item"><i class="dot on info"></i>Unavailable</span></span>
-    </footer>
-  </main>
-
-  <div class="drawer-backdrop" id="drawer-backdrop" hidden></div>
-  <aside class="detail-drawer" id="detail-drawer" aria-label="Source detail" aria-hidden="true">
-    <div class="drawer-header">
-      <div>
-        <p class="section-kicker" id="drawer-kicker">Source detail</p>
-        <h2 class="drawer-title" id="drawer-title">Select a card</h2>
-      </div>
-      <button class="icon-button" type="button" id="close-drawer" aria-label="Close detail">Close</button>
-    </div>
-    <div class="drawer-section">
-      <h3>What this means</h3>
-      <p id="drawer-meaning">Open a card or exception to inspect the read-only evidence summary.</p>
-    </div>
-    <div class="drawer-section">
-      <h3>Source refs</h3>
-      <div class="tags" id="drawer-sources"></div>
-    </div>
-    <div class="drawer-section">
-      <h3>Boundary</h3>
-      <p id="drawer-boundary">This prototype never changes source records. It only explains what the mock projection says.</p>
-    </div>
-  </aside>
+    </main>
+  </div>
 
   <script>
     const details = {
       "human-review": {
         kicker: "Human review · confirmed",
         title: "Critical risk signal",
-        meaning: "A source says human review is required before trusting closure. This is a review prompt, not an automated decision.",
+        summary: "A source says human review is required before trusting closure. This is a review prompt, not an automated decision.",
+        lane: "Review prompts",
+        status: "Pending human review",
+        confidence: "Low",
         sources: ["SRC-2147", "Risk Policy PR-2.1", "Rule R-7"],
-        boundary: "Do not move this slice to closed without a resolving review source."
+        trace: [["10:18", "Risk threshold breach normalized into visual event."], ["10:22", "Human review source required before closure posture can be trusted."]],
+        boundary: "Do not move this slice to closed without a resolving review source. The cockpit explains evidence; it does not authorize decisions."
       },
       conflict: {
         kicker: "Validation · conflicted",
         title: "Model output mismatch",
-        meaning: "Validation sources disagree. The cockpit should surface conflict and preserve both source refs instead of choosing the convenient truth.",
+        summary: "Validation sources disagree. The ledger preserves both source refs instead of choosing the convenient truth.",
+        lane: "Review prompts",
+        status: "Conflicted validation",
+        confidence: "Medium",
         sources: ["SRC-2149", "Eval Report v3.2", "Policy M-1.4"],
-        boundary: "Conflicted lane confidence is stronger than the lane label itself."
+        trace: [["10:05", "Evaluation output diverged from policy baseline."], ["10:11", "Conflict surfaced as review posture, not an automated decision."]],
+        boundary: "Conflicted confidence is stronger than the lane label itself. Reconcile before treating this as stable."
       },
       telemetry: {
-        kicker: "Reconcile · inferred",
-        title: "Telemetry unavailable",
-        meaning: "Optional runtime, token, or cost telemetry was not exported. This is a neutral source gap, not a failed slice.",
+        kicker: "Reconcile · unavailable",
+        title: "Resolve missing telemetry",
+        summary: "Optional runtime, token, or cost telemetry was not exported. This is a neutral source gap, not a failed slice.",
+        lane: "Reconcile",
+        status: "Telemetry unavailable",
+        confidence: "Unknown",
         sources: ["Telemetry Spec", "Closeout R-556"],
-        boundary: "Do not invent estimates just to complete the card."
+        trace: [["09:42", "Token and cost fields marked unavailable."], ["09:44", "No estimates generated because source origin is missing."]],
+        boundary: "Do not invent estimates just to complete the card. Use unavailable until a durable source exists."
       },
       validated: {
         kicker: "Validation · stable",
         title: "Policy update impact check",
-        meaning: "Evidence supports the validation posture for this static example.",
+        summary: "Evidence supports the validation posture for this static example.",
+        lane: "Validation",
+        status: "Validated",
+        confidence: "High",
         sources: ["SRC-2120", "Eval v3.1"],
-        boundary: "A stable card still links to source refs for verification."
+        trace: [["08:52", "Evaluation source attached."], ["08:58", "Policy impact check remained inside expected bounds."]],
+        boundary: "Stable still links to source refs for verification. Stability is derived, not authoritative."
+      },
+      skill: {
+        kicker: "Skill activation · traced",
+        title: "Adaptive skill activation",
+        summary: "Skill activation is visible as trace context, without gate or decision authority.",
+        lane: "Validation",
+        status: "Activation tracked",
+        confidence: "High",
+        sources: ["ACT-552", "Trace Event", "Skill Registry"],
+        trace: [["08:31", "Skill activation normalized into trace context."], ["08:35", "No readiness gate was changed by the activation."]],
+        boundary: "Skills appear as activations. They do not approve gates, close slices, or override source records."
       },
       "closed-207": {
         kicker: "Closed · confirmed",
         title: "Human-review source mapping",
-        meaning: "Source records support closure, while human_review remains unavailable because no durable review source was supplied.",
+        summary: "Source records support closure while human_review remains unavailable because no durable review source was supplied.",
+        lane: "Closed stable",
+        status: "Closed derived posture",
+        confidence: "High",
         sources: ["PR #207", "CI 27626141953", "Merge 39f76cf"],
+        trace: [["2026-06-16", "PR merged after governance and test checks."], ["2026-06-16", "Review source absence preserved as unavailable metadata."]],
         boundary: "Closed is a presentation posture derived from sources, not a new authority."
       },
       "closed-201": {
         kicker: "Closed · confirmed",
         title: "Dogfood evidence record",
-        meaning: "Snapshot evidence supports closeout. Human review unavailable remains visible as honest absence of source authority.",
+        summary: "Snapshot evidence supports closeout. Human review unavailable remains visible as honest absence of source authority.",
+        lane: "Closed stable",
+        status: "Closed derived posture",
+        confidence: "High",
         sources: ["PR #201", "Dogfood snapshot"],
+        trace: [["2026-06-15", "Dogfood snapshot recorded."], ["2026-06-15", "Closeout posture reconstructed from source refs."]],
         boundary: "Unavailable is not failure; it is absence of authoritative source."
       }
     };
 
-    const drawer = document.getElementById('detail-drawer');
-    const backdrop = document.getElementById('drawer-backdrop');
-    const sources = document.getElementById('drawer-sources');
+    const fields = {
+      kicker: document.getElementById('inspector-kicker'),
+      title: document.getElementById('inspector-title'),
+      summary: document.getElementById('inspector-summary'),
+      lane: document.getElementById('inspector-lane'),
+      status: document.getElementById('inspector-status'),
+      confidence: document.getElementById('inspector-confidence'),
+      sources: document.getElementById('inspector-sources'),
+      trace: document.getElementById('inspector-trace'),
+      boundary: document.getElementById('inspector-boundary')
+    };
 
-    function openDetail(key) {
-      const data = details[key] || details.conflict;
-      document.getElementById('drawer-kicker').textContent = data.kicker;
-      document.getElementById('drawer-title').textContent = data.title;
-      document.getElementById('drawer-meaning').textContent = data.meaning;
-      document.getElementById('drawer-boundary').textContent = data.boundary;
-      sources.innerHTML = data.sources.map(source => `<span class="tag">${source}</span>`).join('');
-      drawer.classList.add('open');
-      backdrop.classList.add('open');
-      drawer.setAttribute('aria-hidden', 'false');
-      backdrop.hidden = false;
+    function renderInspector(key) {
+      const data = details[key] || details['human-review'];
+      fields.kicker.textContent = data.kicker;
+      fields.title.textContent = data.title;
+      fields.summary.textContent = data.summary;
+      fields.lane.textContent = data.lane;
+      fields.status.textContent = data.status;
+      fields.confidence.textContent = data.confidence;
+      fields.sources.innerHTML = data.sources.map(source => `<span class="source-ref">${source}</span>`).join('');
+      fields.trace.innerHTML = data.trace.map(([time, copy]) => `<div class="trace-item"><span class="trace-time">${time}</span><span>${copy}</span></div>`).join('');
+      fields.boundary.textContent = data.boundary;
     }
 
-    function closeDetail() {
-      drawer.classList.remove('open');
-      backdrop.classList.remove('open');
-      drawer.setAttribute('aria-hidden', 'true');
-      setTimeout(() => { backdrop.hidden = true; }, 180);
-    }
-
-    document.querySelectorAll('[data-detail]').forEach(element => {
-      element.addEventListener('click', event => {
-        event.stopPropagation();
-        openDetail(element.dataset.detail);
+    document.querySelectorAll('.slice-card').forEach(card => {
+      card.addEventListener('click', () => {
+        document.querySelectorAll('.slice-card').forEach(item => item.classList.remove('selected'));
+        card.classList.add('selected');
+        renderInspector(card.dataset.detail);
       });
-      element.addEventListener('keydown', event => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          openDetail(element.dataset.detail);
-        }
-      });
-    });
-
-    document.getElementById('close-drawer').addEventListener('click', closeDetail);
-    backdrop.addEventListener('click', closeDetail);
-    document.addEventListener('keydown', event => {
-      if (event.key === 'Escape') closeDetail();
     });
 
     document.querySelectorAll('[data-filter]').forEach(button => {
       button.addEventListener('click', () => {
-        document.querySelectorAll('[data-filter]').forEach(btn => btn.setAttribute('aria-pressed', 'false'));
+        document.querySelectorAll('[data-filter]').forEach(item => item.setAttribute('aria-pressed', 'false'));
         button.setAttribute('aria-pressed', 'true');
         const filter = button.dataset.filter;
-        document.querySelectorAll('.work-card').forEach(card => {
+        document.querySelectorAll('.slice-card').forEach(card => {
           card.classList.toggle('hidden', filter !== 'all' && card.dataset.status !== filter);
         });
       });
-    });
-
-    document.getElementById('toggle-empty').addEventListener('click', event => {
-      const pressed = event.currentTarget.getAttribute('aria-pressed') === 'true';
-      event.currentTarget.setAttribute('aria-pressed', String(!pressed));
-      document.querySelectorAll('.empty-slot').forEach(slot => slot.classList.toggle('hidden', pressed));
     });
   </script>
 </body>

--- a/examples/visual-operations/prototype/mission-control-static.html
+++ b/examples/visual-operations/prototype/mission-control-static.html
@@ -23,6 +23,7 @@
       --violet: #8b6ee8;
       --radius: 14px;
       --radius-sm: 9px;
+      --rail-width: 72px;
       --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       --sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       color-scheme: dark;
@@ -35,6 +36,7 @@
     body {
       margin: 0;
       min-height: 100vh;
+      overflow: hidden;
       background: var(--bg);
       color: var(--text);
       font-family: var(--sans);
@@ -50,36 +52,46 @@
 
     .stage {
       min-height: 100vh;
-      display: grid;
-      place-items: center;
-      padding: clamp(18px, 3vw, 42px);
+      padding: 0;
     }
 
     .mission-shell {
-      width: min(1540px, 100%);
-      min-height: min(900px, calc(100vh - 48px));
+      width: 100vw;
+      height: 100vh;
       display: grid;
-      grid-template-columns: 64px minmax(0, 1fr);
-      border: 1px solid var(--line-strong);
-      border-radius: 22px;
+      grid-template-columns: var(--rail-width) minmax(0, 1fr);
       background: var(--shell);
       overflow: hidden;
-      box-shadow: 0 24px 80px rgba(0, 0, 0, 0.34);
     }
+
+    .mission-shell.nav-expanded { --rail-width: 238px; }
 
     .side-rail {
       display: grid;
       grid-template-rows: auto 1fr auto;
       gap: 18px;
-      padding: 18px 10px;
+      padding: 16px 10px;
       border-right: 1px solid var(--line);
       background: #0a0e15;
+      min-width: 0;
+      transition: width 180ms ease;
+    }
+
+    .rail-top {
+      display: grid;
+      gap: 12px;
+    }
+
+    .mark-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-width: 0;
     }
 
     .mark {
-      width: 34px;
-      height: 34px;
-      margin: 0 auto;
+      width: 38px;
+      height: 38px;
       display: grid;
       place-items: center;
       border: 1px solid rgba(139, 110, 232, 0.42);
@@ -87,26 +99,85 @@
       color: #c9bcff;
       font: 800 0.75rem var(--mono);
       background: rgba(139, 110, 232, 0.08);
+      flex: 0 0 auto;
     }
+
+    .rail-brand {
+      display: none;
+      min-width: 0;
+    }
+
+    .nav-expanded .rail-brand { display: block; }
+
+    .rail-brand strong {
+      display: block;
+      color: var(--text);
+      font-size: 0.84rem;
+      line-height: 1.1;
+    }
+
+    .rail-brand span {
+      display: block;
+      margin-top: 2px;
+      color: var(--text-muted);
+      font: 680 0.62rem var(--mono);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .nav-toggle {
+      width: 100%;
+      height: 34px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 9px;
+      background: transparent;
+      color: var(--text-muted);
+      cursor: pointer;
+      font: 720 0.68rem var(--mono);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .nav-toggle:hover,
+    .nav-toggle:focus-visible {
+      color: var(--text);
+      background: var(--panel-2);
+      outline: none;
+    }
+
+    .nav-toggle-label { display: none; }
+    .nav-expanded .nav-toggle-label { display: inline; }
 
     .rail-stack {
       display: grid;
-      gap: 10px;
+      gap: 8px;
       align-content: start;
-      justify-items: center;
+      min-width: 0;
     }
 
     .rail-button {
-      width: 38px;
+      width: 100%;
       height: 38px;
-      display: grid;
-      place-items: center;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
       border-radius: 11px;
       background: transparent;
       color: var(--text-muted);
       font: 760 0.66rem var(--mono);
       cursor: pointer;
+      text-align: left;
     }
+
+    .nav-expanded .rail-button { justify-content: flex-start; padding: 0 10px; }
+
+    .rail-button-label { display: none; }
+    .nav-expanded .rail-button-label { display: inline; font-family: var(--sans); font-size: 0.82rem; font-weight: 640; letter-spacing: -0.01em; }
 
     .rail-button.active,
     .rail-button:hover,
@@ -120,15 +191,16 @@
       display: grid;
       grid-template-rows: auto 1fr;
       min-width: 0;
+      min-height: 0;
     }
 
     .topbar {
       display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(240px, 410px) auto;
+      grid-template-columns: minmax(0, 1fr) minmax(240px, 500px) auto;
       gap: 16px;
       align-items: center;
-      min-height: 74px;
-      padding: 16px 22px;
+      min-height: 72px;
+      padding: 14px 24px;
       border-bottom: 1px solid var(--line);
       background: rgba(13, 17, 25, 0.98);
     }
@@ -191,28 +263,82 @@
     }
 
     .workspace {
+      position: relative;
       display: grid;
-      grid-template-columns: minmax(0, 1fr) 360px;
+      grid-template-columns: minmax(0, 1fr);
       min-height: 0;
+      overflow: hidden;
     }
 
     .main-board {
       min-width: 0;
-      padding: 22px;
+      min-height: 0;
+      padding: 24px;
       overflow: auto;
     }
 
+    .inspector-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 19;
+      background: rgba(0, 0, 0, 0.28);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 160ms ease;
+    }
+
+    .inspector-backdrop.open {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
     .inspector {
+      position: fixed;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      z-index: 20;
+      width: min(430px, 100vw);
       display: grid;
       grid-template-rows: auto 1fr;
       min-height: 0;
-      border-left: 1px solid var(--line);
+      border-left: 1px solid var(--line-strong);
       background: #0b0f16;
+      transform: translateX(100%);
+      transition: transform 210ms cubic-bezier(.2,.8,.2,1);
+      box-shadow: -24px 0 70px rgba(0, 0, 0, 0.38);
     }
+
+    .inspector.open { transform: translateX(0); }
 
     .inspector-header {
       padding: 22px;
       border-bottom: 1px solid var(--line);
+    }
+
+    .inspector-title-row {
+      display: flex;
+      align-items: start;
+      justify-content: space-between;
+      gap: 14px;
+    }
+
+    .sheet-close {
+      width: 34px;
+      height: 34px;
+      border: 1px solid var(--line);
+      border-radius: 9px;
+      background: transparent;
+      color: var(--text-muted);
+      cursor: pointer;
+      flex: 0 0 auto;
+    }
+
+    .sheet-close:hover,
+    .sheet-close:focus-visible {
+      color: var(--text);
+      background: var(--panel-2);
+      outline: none;
     }
 
     .inspector-body {
@@ -246,7 +372,7 @@
 
     .section-copy {
       margin: 8px 0 0;
-      max-width: 680px;
+      max-width: 760px;
       color: var(--text-muted);
       font-size: 0.88rem;
       line-height: 1.45;
@@ -351,13 +477,13 @@
 
     .board-grid {
       display: grid;
-      grid-template-columns: repeat(4, minmax(190px, 1fr));
+      grid-template-columns: repeat(4, minmax(220px, 1fr));
       gap: 0;
-      min-width: 920px;
+      min-width: 960px;
     }
 
     .lane {
-      min-height: 560px;
+      min-height: calc(100vh - 392px);
       border-right: 1px solid var(--line);
       background: rgba(11, 16, 24, 0.38);
     }
@@ -434,10 +560,7 @@
 
     .slice-card:hover { transform: translateY(-1px); }
 
-    .slice-card.selected {
-      box-shadow: inset 3px 0 0 var(--review);
-    }
-
+    .slice-card.selected { box-shadow: inset 3px 0 0 var(--review); }
     .slice-card[data-tone="critical"].selected { box-shadow: inset 3px 0 0 var(--critical); }
     .slice-card[data-tone="stable"].selected { box-shadow: inset 3px 0 0 var(--stable); }
     .slice-card[data-tone="info"].selected { box-shadow: inset 3px 0 0 var(--info); }
@@ -607,13 +730,13 @@
     .hidden { display: none !important; }
 
     @media (prefers-reduced-motion: no-preference) {
-      .mission-shell { animation: shellIn 360ms ease both; }
-      .slice-card { animation: itemIn 260ms ease both; }
+      .mission-shell { animation: shellIn 260ms ease both; }
+      .slice-card { animation: itemIn 220ms ease both; }
     }
 
     @keyframes shellIn {
-      from { opacity: 0; transform: translateY(6px); }
-      to { opacity: 1; transform: translateY(0); }
+      from { opacity: 0; }
+      to { opacity: 1; }
     }
 
     @keyframes itemIn {
@@ -622,40 +745,48 @@
     }
 
     @media (max-width: 1180px) {
-      .mission-shell { grid-template-columns: 1fr; }
-      .side-rail { display: none; }
-      .workspace { grid-template-columns: 1fr; }
-      .inspector { border-left: 0; border-top: 1px solid var(--line); }
+      .mission-shell.nav-expanded { --rail-width: 220px; }
       .metrics-row, .event-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .topbar { grid-template-columns: 1fr; align-items: start; }
+      .authority { text-align: left; }
     }
 
     @media (max-width: 760px) {
-      .stage { padding: 0; place-items: stretch; }
-      .mission-shell { min-height: 100vh; border: 0; border-radius: 0; }
-      .topbar { grid-template-columns: 1fr; align-items: start; }
-      .authority { text-align: left; }
+      .mission-shell, .mission-shell.nav-expanded { --rail-width: 58px; }
+      .side-rail { padding: 12px 8px; }
+      .rail-brand, .nav-toggle-label, .rail-button-label { display: none !important; }
+      .mark { width: 34px; height: 34px; }
       .section-head { grid-template-columns: 1fr; }
       .filters { justify-content: flex-start; }
       .metrics-row, .event-strip { grid-template-columns: 1fr; }
       .main-board { padding: 16px; }
       .board-grid { min-width: 760px; }
+      .inspector { width: min(390px, 100vw); }
+      .product-title { flex-direction: column; align-items: flex-start; gap: 6px; }
     }
+
   </style>
 </head>
 <body>
   <div class="stage">
-    <main class="mission-shell" aria-label="AletheIA Mission Control static prototype">
+    <main class="mission-shell" id="mission-shell" aria-label="AletheIA Mission Control static prototype">
       <aside class="side-rail" aria-label="Mission Control navigation">
-        <div class="mark">AI</div>
+        <div class="rail-top">
+          <div class="mark-row">
+            <div class="mark">AI</div>
+            <div class="rail-brand"><strong>AletheIA</strong><span>Mission Control</span></div>
+          </div>
+          <button class="nav-toggle" type="button" id="nav-toggle" aria-expanded="false" aria-controls="mission-shell"><span>⇄</span><span class="nav-toggle-label">Collapse menu</span></button>
+        </div>
         <nav class="rail-stack" aria-label="Workspace views">
-          <button class="rail-button" type="button">OV</button>
-          <button class="rail-button active" type="button">EV</button>
-          <button class="rail-button" type="button">TR</button>
-          <button class="rail-button" type="button">SRC</button>
+          <button class="rail-button" type="button"><span>OV</span><span class="rail-button-label">Overview</span></button>
+          <button class="rail-button active" type="button"><span>EV</span><span class="rail-button-label">Evidence ledger</span></button>
+          <button class="rail-button" type="button"><span>TR</span><span class="rail-button-label">Trace context</span></button>
+          <button class="rail-button" type="button"><span>SRC</span><span class="rail-button-label">Source records</span></button>
         </nav>
         <nav class="rail-stack" aria-label="Utility views">
-          <button class="rail-button" type="button">CFG</button>
-          <button class="rail-button" type="button">AUD</button>
+          <button class="rail-button" type="button"><span>CFG</span><span class="rail-button-label">Configuration</span></button>
+          <button class="rail-button" type="button"><span>AUD</span><span class="rail-button-label">Audit view</span></button>
         </nav>
       </aside>
 
@@ -774,10 +905,16 @@
             </section>
           </section>
 
-          <aside class="inspector" aria-label="Evidence inspector" id="evidence-inspector">
+          <div class="inspector-backdrop open" id="inspector-backdrop"></div>
+          <aside class="inspector open" aria-label="Evidence inspector" id="evidence-inspector" aria-hidden="false">
             <header class="inspector-header">
-              <p class="eyebrow" id="inspector-kicker">Human review · confirmed</p>
-              <h2 class="inspector-title" id="inspector-title">Critical risk signal</h2>
+              <div class="inspector-title-row">
+                <div>
+                  <p class="eyebrow" id="inspector-kicker">Human review · confirmed</p>
+                  <h2 class="inspector-title" id="inspector-title">Critical risk signal</h2>
+                </div>
+                <button class="sheet-close" type="button" id="sheet-close" aria-label="Close evidence inspector">×</button>
+              </div>
               <p class="inspector-copy" id="inspector-summary">A source says human review is required before trusting closure. This is a review prompt, not an automated decision.</p>
             </header>
             <div class="inspector-body">
@@ -892,6 +1029,12 @@
       }
     };
 
+    const shell = document.getElementById('mission-shell');
+    const navToggle = document.getElementById('nav-toggle');
+    const inspector = document.getElementById('evidence-inspector');
+    const inspectorBackdrop = document.getElementById('inspector-backdrop');
+    const sheetClose = document.getElementById('sheet-close');
+
     const fields = {
       kicker: document.getElementById('inspector-kicker'),
       title: document.getElementById('inspector-title'),
@@ -904,6 +1047,18 @@
       boundary: document.getElementById('inspector-boundary')
     };
 
+    function openInspector() {
+      inspector.classList.add('open');
+      inspectorBackdrop.classList.add('open');
+      inspector.setAttribute('aria-hidden', 'false');
+    }
+
+    function closeInspector() {
+      inspector.classList.remove('open');
+      inspectorBackdrop.classList.remove('open');
+      inspector.setAttribute('aria-hidden', 'true');
+    }
+
     function renderInspector(key) {
       const data = details[key] || details['human-review'];
       fields.kicker.textContent = data.kicker;
@@ -915,7 +1070,20 @@
       fields.sources.innerHTML = data.sources.map(source => `<span class="source-ref">${source}</span>`).join('');
       fields.trace.innerHTML = data.trace.map(([time, copy]) => `<div class="trace-item"><span class="trace-time">${time}</span><span>${copy}</span></div>`).join('');
       fields.boundary.textContent = data.boundary;
+      openInspector();
     }
+
+    navToggle.addEventListener('click', () => {
+      const expanded = shell.classList.toggle('nav-expanded');
+      navToggle.setAttribute('aria-expanded', String(expanded));
+      navToggle.querySelector('.nav-toggle-label').textContent = expanded ? 'Collapse menu' : 'Expand menu';
+    });
+
+    sheetClose.addEventListener('click', closeInspector);
+    inspectorBackdrop.addEventListener('click', closeInspector);
+    document.addEventListener('keydown', event => {
+      if (event.key === 'Escape') closeInspector();
+    });
 
     document.querySelectorAll('.slice-card').forEach(card => {
       card.addEventListener('click', () => {

--- a/examples/visual-operations/prototype/mission-control-static.html
+++ b/examples/visual-operations/prototype/mission-control-static.html
@@ -6,121 +6,164 @@
   <title>AletheIA Mission Control — Static Prototype</title>
   <style>
     :root {
-      --ledger-ink: #18201f;
-      --muted-ink: #5d625d;
-      --evidence-paper: #f6f3ec;
-      --panel: #fbfaf6;
-      --source-line: #c7bfaf;
-      --source-line-soft: #e2dccf;
-      --verified-moss: #3e6b55;
-      --review-amber: #b8762b;
-      --stop-vermilion: #b84233;
-      --telemetry-blue: #49677c;
-      --shadow: 0 14px 40px rgba(24, 32, 31, 0.08);
-      --radius: 14px;
-      color-scheme: light;
+      --ink: #f4efe3;
+      --ink-strong: #fff8e8;
+      --ink-muted: #a9acaa;
+      --ink-faint: #6f7774;
+      --void: #070909;
+      --surface: #101413;
+      --surface-2: #151b19;
+      --surface-3: #1d2522;
+      --ledger-line: rgba(235, 221, 190, 0.16);
+      --ledger-line-strong: rgba(235, 221, 190, 0.34);
+      --verified-moss: #75b98f;
+      --review-amber: #e2a64e;
+      --stop-vermilion: #ee6a58;
+      --telemetry-blue: #7cb7d8;
+      --source-glow: rgba(226, 166, 78, 0.18);
+      --shadow: 0 26px 80px rgba(0, 0, 0, 0.42);
+      --shadow-tight: 0 16px 42px rgba(0, 0, 0, 0.26);
+      --radius: 18px;
+      --radius-soft: 12px;
+      color-scheme: dark;
     }
 
     * { box-sizing: border-box; }
+
+    html { background: var(--void); }
 
     body {
       margin: 0;
       min-height: 100vh;
       background:
-        linear-gradient(90deg, rgba(199, 191, 175, 0.13) 1px, transparent 1px),
-        linear-gradient(180deg, rgba(199, 191, 175, 0.12) 1px, transparent 1px),
-        var(--evidence-paper);
-      background-size: 44px 44px;
-      color: var(--ledger-ink);
-      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      letter-spacing: -0.01em;
+        radial-gradient(circle at 18% 12%, rgba(226, 166, 78, 0.16), transparent 30vw),
+        radial-gradient(circle at 82% 8%, rgba(124, 183, 216, 0.12), transparent 28vw),
+        linear-gradient(90deg, rgba(235, 221, 190, 0.045) 1px, transparent 1px),
+        linear-gradient(180deg, rgba(235, 221, 190, 0.035) 1px, transparent 1px),
+        linear-gradient(135deg, #070909 0%, #0d1110 44%, #111816 100%);
+      background-size: auto, auto, 52px 52px, 52px 52px, auto;
+      color: var(--ink);
+      font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: -0.012em;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      background:
+        linear-gradient(90deg, rgba(7, 9, 9, 0.18), transparent 18%, transparent 78%, rgba(7, 9, 9, 0.34)),
+        repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.018) 0 1px, transparent 1px 4px);
+      mix-blend-mode: screen;
+      opacity: 0.55;
     }
 
     button, input { font: inherit; }
 
     .app-shell {
+      position: relative;
       display: grid;
-      grid-template-columns: minmax(270px, 320px) minmax(0, 1fr);
-      gap: 18px;
+      grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
+      gap: 20px;
       min-height: 100vh;
-      padding: 22px;
+      padding: 24px;
+      isolation: isolate;
     }
 
     .topbar {
       grid-column: 1 / -1;
       display: grid;
-      grid-template-columns: 1fr auto auto;
-      gap: 18px;
-      align-items: center;
-      padding: 4px 2px 8px;
+      grid-template-columns: minmax(0, 1fr) auto auto;
+      gap: 20px;
+      align-items: end;
+      padding: 4px 2px 12px;
+      border-bottom: 1px solid var(--ledger-line);
     }
 
     .brand {
       display: flex;
-      align-items: baseline;
-      gap: 16px;
+      align-items: end;
+      gap: 18px;
       min-width: 0;
     }
 
     h1 {
       margin: 0;
+      color: var(--ink-strong);
       font-family: Georgia, "Times New Roman", serif;
-      font-size: clamp(2.3rem, 4.4vw, 4.9rem);
-      line-height: 0.88;
-      letter-spacing: -0.065em;
+      font-size: clamp(2.55rem, 5vw, 6.2rem);
+      line-height: 0.82;
+      letter-spacing: -0.085em;
       white-space: nowrap;
+      text-shadow: 0 12px 48px rgba(226, 166, 78, 0.14);
     }
 
     .pill {
       display: inline-flex;
       align-items: center;
       gap: 8px;
-      border: 1px solid color-mix(in srgb, var(--verified-moss), black 8%);
+      border: 1px solid rgba(117, 185, 143, 0.42);
       border-radius: 999px;
-      color: #153f2f;
-      background: rgba(255, 255, 255, 0.36);
-      padding: 10px 18px;
-      font-weight: 700;
-      font-size: 0.9rem;
+      color: #dff8e8;
+      background: rgba(117, 185, 143, 0.08);
+      padding: 10px 16px;
+      font-weight: 760;
+      font-size: 0.82rem;
       white-space: nowrap;
+      box-shadow: inset 0 0 22px rgba(117, 185, 143, 0.06);
     }
 
     .timestamp, .authority, .utility {
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.78rem;
-      color: var(--muted-ink);
+      font-size: 0.74rem;
+      color: var(--ink-muted);
     }
 
+    .timestamp { color: var(--ink-faint); }
+
     .authority {
-      color: var(--verified-moss);
-      font-weight: 700;
+      color: #d7f4df;
+      font-weight: 780;
       text-align: right;
     }
 
     .trace-room, .workspace > section, .lane, .detail-drawer {
-      border: 1px solid var(--source-line);
-      background: rgba(251, 250, 246, 0.78);
-      box-shadow: var(--shadow);
-      backdrop-filter: blur(6px);
+      border: 1px solid var(--ledger-line);
+      background:
+        linear-gradient(180deg, rgba(255, 248, 232, 0.035), rgba(255, 248, 232, 0.012)),
+        rgba(16, 20, 19, 0.78);
+      box-shadow: var(--shadow-tight);
+      backdrop-filter: blur(16px) saturate(1.08);
     }
 
     .trace-room {
       position: sticky;
       top: 20px;
       align-self: start;
-      max-height: calc(100vh - 122px);
+      max-height: calc(100vh - 132px);
       overflow: auto;
       border-radius: var(--radius);
       padding: 18px;
+      box-shadow: var(--shadow), inset 3px 0 0 rgba(226, 166, 78, 0.68);
+    }
+
+    .trace-room::-webkit-scrollbar, .detail-drawer::-webkit-scrollbar { width: 10px; }
+    .trace-room::-webkit-scrollbar-thumb, .detail-drawer::-webkit-scrollbar-thumb {
+      background: rgba(235, 221, 190, 0.22);
+      border-radius: 999px;
+      border: 3px solid transparent;
+      background-clip: content-box;
     }
 
     .section-kicker {
       margin: 0;
-      color: var(--muted-ink);
+      color: var(--review-amber);
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.72rem;
+      font-size: 0.68rem;
       text-transform: uppercase;
-      letter-spacing: 0.08em;
+      letter-spacing: 0.12em;
+      font-weight: 820;
     }
 
     .trace-header {
@@ -128,27 +171,25 @@
       align-items: start;
       justify-content: space-between;
       gap: 10px;
-      padding-bottom: 14px;
-      border-bottom: 1px solid var(--source-line-soft);
+      padding-bottom: 16px;
+      border-bottom: 1px solid var(--ledger-line);
     }
 
     .trace-header h2, .lane h2, .drawer-title {
       margin: 4px 0 0;
-      font-size: 1.05rem;
-      letter-spacing: -0.03em;
+      color: var(--ink-strong);
+      font-size: 1.02rem;
+      letter-spacing: -0.035em;
     }
 
-    .trace-actions {
-      display: flex;
-      gap: 8px;
-    }
+    .trace-actions { display: flex; gap: 8px; }
 
     .icon-button, .filter-button, .card-button {
-      border: 1px solid var(--source-line);
-      background: rgba(255, 255, 255, 0.38);
-      color: var(--ledger-ink);
+      border: 1px solid var(--ledger-line-strong);
+      background: rgba(255, 248, 232, 0.035);
+      color: var(--ink);
       cursor: pointer;
-      transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+      transition: transform 170ms ease, border-color 170ms ease, background 170ms ease, color 170ms ease, box-shadow 170ms ease;
     }
 
     .icon-button {
@@ -161,23 +202,24 @@
     .icon-button:hover, .filter-button:hover, .card-button:hover,
     .icon-button:focus-visible, .filter-button:focus-visible, .card-button:focus-visible {
       transform: translateY(-1px);
-      border-color: var(--ledger-ink);
+      border-color: rgba(226, 166, 78, 0.78);
+      background: rgba(226, 166, 78, 0.08);
+      box-shadow: 0 0 0 4px rgba(226, 166, 78, 0.08);
       outline: none;
     }
 
-    .trace-group {
-      margin-top: 18px;
-    }
+    .trace-group { margin-top: 20px; }
 
     .trace-date {
       display: flex;
       gap: 8px;
       align-items: center;
-      margin-bottom: 12px;
-      color: #1f4b39;
-      font-weight: 800;
-      font-size: 0.78rem;
-      letter-spacing: 0.04em;
+      margin-bottom: 14px;
+      color: #f2d39b;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-weight: 850;
+      font-size: 0.72rem;
+      letter-spacing: 0.08em;
       text-transform: uppercase;
     }
 
@@ -185,63 +227,64 @@
       position: relative;
       display: grid;
       grid-template-columns: 44px 1fr;
-      gap: 10px;
-      padding: 0 0 22px;
+      gap: 12px;
+      padding: 0 0 24px;
     }
 
     .trace-item::before {
       content: "";
       position: absolute;
-      left: 54px;
+      left: 55px;
       top: 26px;
       bottom: 0;
       width: 1px;
-      background: var(--source-line-soft);
+      background: linear-gradient(180deg, rgba(226, 166, 78, 0.55), rgba(235, 221, 190, 0.1));
     }
 
     .trace-item:last-child::before { display: none; }
 
     .trace-time {
       padding-top: 6px;
-      color: var(--muted-ink);
-      font-size: 0.72rem;
+      color: var(--ink-faint);
+      font-size: 0.7rem;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       text-align: right;
     }
 
     .trace-card {
       position: relative;
-      padding-left: 18px;
+      padding: 2px 0 0 18px;
     }
 
     .trace-dot {
       position: absolute;
-      left: -10px;
-      top: 4px;
+      left: -11px;
+      top: 3px;
       width: 20px;
       height: 20px;
       border-radius: 999px;
-      border: 3px solid var(--panel);
+      border: 4px solid #101413;
       background: var(--verified-moss);
-      box-shadow: 0 0 0 1px var(--source-line);
+      box-shadow: 0 0 0 1px rgba(235, 221, 190, 0.3), 0 0 22px rgba(117, 185, 143, 0.26);
     }
 
-    .trace-dot.critical { background: var(--stop-vermilion); }
-    .trace-dot.warning { background: var(--review-amber); }
-    .trace-dot.info { background: var(--telemetry-blue); }
+    .trace-dot.critical { background: var(--stop-vermilion); box-shadow: 0 0 0 1px rgba(235, 221, 190, 0.3), 0 0 22px rgba(238, 106, 88, 0.32); }
+    .trace-dot.warning { background: var(--review-amber); box-shadow: 0 0 0 1px rgba(235, 221, 190, 0.3), 0 0 22px rgba(226, 166, 78, 0.32); }
+    .trace-dot.info { background: var(--telemetry-blue); box-shadow: 0 0 0 1px rgba(235, 221, 190, 0.3), 0 0 22px rgba(124, 183, 216, 0.30); }
 
     .trace-title {
       margin: 0 0 4px;
-      font-size: 0.93rem;
-      font-weight: 850;
+      color: var(--ink-strong);
+      font-size: 0.92rem;
+      font-weight: 820;
       letter-spacing: -0.025em;
     }
 
     .trace-copy {
-      margin: 0 0 8px;
-      color: var(--muted-ink);
-      font-size: 0.8rem;
-      line-height: 1.35;
+      margin: 0 0 9px;
+      color: var(--ink-muted);
+      font-size: 0.79rem;
+      line-height: 1.4;
     }
 
     .tags {
@@ -253,14 +296,14 @@
     .tag {
       display: inline-flex;
       align-items: center;
-      border: 1px solid var(--source-line);
-      border-radius: 5px;
-      background: rgba(255, 255, 255, 0.44);
-      padding: 3px 7px;
-      color: #46504b;
+      border: 1px solid rgba(235, 221, 190, 0.22);
+      border-radius: 999px;
+      background: rgba(255, 248, 232, 0.045);
+      padding: 4px 8px;
+      color: #c7c5bb;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.66rem;
-      font-weight: 700;
+      font-size: 0.62rem;
+      font-weight: 760;
       white-space: nowrap;
     }
 
@@ -273,21 +316,24 @@
     .overview {
       border-radius: var(--radius);
       display: grid;
-      grid-template-columns: 1.4fr repeat(5, minmax(112px, 1fr));
+      grid-template-columns: 1.36fr repeat(5, minmax(112px, 1fr));
       overflow: hidden;
     }
 
     .overview-cell {
+      position: relative;
       padding: 20px 22px;
-      border-right: 1px solid var(--source-line-soft);
-      min-height: 108px;
+      border-right: 1px solid var(--ledger-line);
+      min-height: 112px;
     }
     .overview-cell:last-child { border-right: 0; }
+    .overview-cell:first-child { background: linear-gradient(180deg, rgba(226, 166, 78, 0.08), transparent); }
 
     .overview-label {
-      margin: 0 0 6px;
-      font-size: 0.88rem;
-      color: #1f2927;
+      margin: 0 0 7px;
+      color: #dad3c3;
+      font-size: 0.84rem;
+      line-height: 1.32;
     }
 
     .overview-number {
@@ -295,15 +341,15 @@
       align-items: baseline;
       gap: 8px;
       font-family: Georgia, "Times New Roman", serif;
-      font-size: 3.1rem;
-      line-height: 1;
-      letter-spacing: -0.06em;
+      font-size: 3.25rem;
+      line-height: 0.95;
+      letter-spacing: -0.072em;
     }
 
     .overview-unit {
       font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      color: var(--muted-ink);
-      font-size: 0.82rem;
+      color: var(--ink-faint);
+      font-size: 0.78rem;
       letter-spacing: -0.01em;
     }
 
@@ -315,13 +361,14 @@
     .exceptions {
       border-radius: var(--radius);
       display: grid;
-      grid-template-columns: 1.05fr repeat(3, 1fr);
+      grid-template-columns: 0.95fr repeat(3, 1fr);
       overflow: hidden;
+      box-shadow: var(--shadow-tight), inset 0 0 0 1px rgba(238, 106, 88, 0.035);
     }
 
     .exception-intro, .exception-item {
       padding: 20px 22px;
-      border-right: 1px solid var(--source-line-soft);
+      border-right: 1px solid var(--ledger-line);
     }
     .exception-item:last-child { border-right: 0; }
 
@@ -331,7 +378,20 @@
       grid-template-columns: 5px 1fr auto;
       gap: 14px;
       align-items: center;
+      color: var(--ink);
       cursor: pointer;
+      text-align: left;
+      border-top: 0;
+      border-bottom: 0;
+      border-left: 0;
+      background: transparent;
+      transition: background 170ms ease, transform 170ms ease;
+    }
+
+    .exception-item:hover, .exception-item:focus-visible {
+      background: rgba(255, 248, 232, 0.045);
+      transform: translateY(-1px);
+      outline: none;
     }
 
     .exception-rail {
@@ -339,29 +399,35 @@
       align-self: stretch;
       border-radius: 999px;
       background: var(--review-amber);
+      box-shadow: 0 0 18px rgba(226, 166, 78, 0.28);
     }
-    .exception-rail.critical { background: var(--stop-vermilion); }
-    .exception-rail.info { background: var(--telemetry-blue); }
+    .exception-rail.critical { background: var(--stop-vermilion); box-shadow: 0 0 18px rgba(238, 106, 88, 0.30); }
+    .exception-rail.info { background: var(--telemetry-blue); box-shadow: 0 0 18px rgba(124, 183, 216, 0.25); }
 
     .exception-label {
+      display: block;
       margin: 0 0 5px;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.7rem;
+      font-size: 0.66rem;
       text-transform: uppercase;
-      letter-spacing: 0.08em;
+      letter-spacing: 0.1em;
       font-weight: 900;
     }
 
     .exception-title {
+      display: block;
       margin: 0;
-      font-weight: 850;
-      letter-spacing: -0.025em;
+      color: var(--ink-strong);
+      font-weight: 820;
+      letter-spacing: -0.03em;
     }
 
     .exception-copy {
-      margin: 4px 0 0;
-      color: var(--muted-ink);
-      font-size: 0.84rem;
+      display: block;
+      margin: 5px 0 0;
+      color: var(--ink-muted);
+      font-size: 0.8rem;
+      line-height: 1.36;
     }
 
     .filters {
@@ -370,7 +436,7 @@
       justify-content: space-between;
       gap: 12px;
       flex-wrap: wrap;
-      padding: 0 2px;
+      padding: 2px 2px 0;
     }
 
     .filter-group {
@@ -382,14 +448,15 @@
     .filter-button {
       border-radius: 999px;
       padding: 9px 13px;
-      font-size: 0.82rem;
-      font-weight: 750;
+      font-size: 0.78rem;
+      font-weight: 760;
     }
 
     .filter-button[aria-pressed="true"] {
-      background: var(--ledger-ink);
-      border-color: var(--ledger-ink);
-      color: var(--evidence-paper);
+      background: var(--ink-strong);
+      border-color: var(--ink-strong);
+      color: #0b0e0d;
+      box-shadow: 0 12px 32px rgba(255, 248, 232, 0.10);
     }
 
     .board {
@@ -400,17 +467,31 @@
     }
 
     .lane {
+      position: relative;
       border-radius: var(--radius);
       padding: 14px;
-      min-height: 440px;
+      min-height: 448px;
+      overflow: hidden;
+    }
+
+    .lane::before {
+      content: "";
+      position: absolute;
+      inset: 0 0 auto;
+      height: 72px;
+      background: linear-gradient(180deg, rgba(255, 248, 232, 0.04), transparent);
+      pointer-events: none;
     }
 
     .lane-header {
+      position: relative;
       display: flex;
       align-items: center;
       justify-content: space-between;
       gap: 12px;
       margin-bottom: 12px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid var(--ledger-line);
     }
 
     .lane-title {
@@ -422,19 +503,20 @@
     .lane-glyph {
       display: grid;
       place-items: center;
-      width: 30px;
-      height: 30px;
-      border: 1px solid var(--source-line);
-      border-radius: 8px;
-      font-size: 0.68rem;
+      width: 32px;
+      height: 32px;
+      border: 1px solid var(--ledger-line-strong);
+      border-radius: 999px;
+      font-size: 0.64rem;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       font-weight: 900;
-      color: var(--muted-ink);
+      color: #d8d0c0;
+      background: rgba(255, 248, 232, 0.035);
     }
 
     .count {
-      color: var(--muted-ink);
-      font-size: 0.82rem;
+      color: var(--ink-faint);
+      font-size: 0.78rem;
       white-space: nowrap;
     }
 
@@ -443,30 +525,31 @@
       display: grid;
       grid-template-columns: 7px 1fr;
       margin: 12px 0;
-      border: 1px solid var(--source-line-soft);
-      border-radius: 12px;
-      background: rgba(255, 255, 255, 0.43);
+      border: 1px solid var(--ledger-line);
+      border-radius: var(--radius-soft);
+      background:
+        linear-gradient(180deg, rgba(255, 248, 232, 0.045), rgba(255, 248, 232, 0.018)),
+        rgba(9, 12, 11, 0.28);
       overflow: hidden;
-      transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+      transition: transform 170ms ease, border-color 170ms ease, background 170ms ease, box-shadow 170ms ease;
     }
 
     .work-card:hover, .work-card:focus-within {
-      transform: translateY(-2px);
-      border-color: color-mix(in srgb, var(--ledger-ink), var(--source-line) 55%);
-      background: rgba(255, 255, 255, 0.62);
+      transform: translateY(-3px);
+      border-color: rgba(235, 221, 190, 0.36);
+      background:
+        linear-gradient(180deg, rgba(255, 248, 232, 0.07), rgba(255, 248, 232, 0.026)),
+        rgba(9, 12, 11, 0.46);
+      box-shadow: 0 18px 44px rgba(0, 0, 0, 0.26);
     }
 
-    .source-rail {
-      background: var(--source-line);
-    }
-    .source-rail.critical { background: var(--stop-vermilion); }
-    .source-rail.warning { background: var(--review-amber); }
-    .source-rail.stable { background: var(--verified-moss); }
-    .source-rail.info { background: var(--telemetry-blue); }
+    .source-rail { background: rgba(235, 221, 190, 0.25); }
+    .source-rail.critical { background: var(--stop-vermilion); box-shadow: 0 0 24px rgba(238, 106, 88, 0.36); }
+    .source-rail.warning { background: var(--review-amber); box-shadow: 0 0 24px rgba(226, 166, 78, 0.34); }
+    .source-rail.stable { background: var(--verified-moss); box-shadow: 0 0 24px rgba(117, 185, 143, 0.28); }
+    .source-rail.info { background: var(--telemetry-blue); box-shadow: 0 0 24px rgba(124, 183, 216, 0.26); }
 
-    .card-body {
-      padding: 14px;
-    }
+    .card-body { padding: 14px; }
 
     .card-meta {
       display: flex;
@@ -477,41 +560,43 @@
     }
 
     .slice-id {
-      color: var(--muted-ink);
+      color: var(--ink-faint);
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.72rem;
+      font-size: 0.69rem;
       font-weight: 800;
     }
 
     .status-chip {
+      border: 1px solid rgba(235, 221, 190, 0.12);
       border-radius: 999px;
       padding: 4px 8px;
-      background: rgba(199, 191, 175, 0.25);
-      color: #43504a;
+      background: rgba(255, 248, 232, 0.055);
+      color: #d2c9b9;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.62rem;
+      font-size: 0.58rem;
       text-transform: uppercase;
-      letter-spacing: 0.055em;
+      letter-spacing: 0.07em;
       font-weight: 900;
       white-space: nowrap;
     }
-    .status-chip.critical { background: rgba(184, 66, 51, 0.12); color: var(--stop-vermilion); }
-    .status-chip.warning { background: rgba(184, 118, 43, 0.12); color: #8f5717; }
-    .status-chip.stable { background: rgba(62, 107, 85, 0.13); color: var(--verified-moss); }
-    .status-chip.info { background: rgba(73, 103, 124, 0.12); color: var(--telemetry-blue); }
+    .status-chip.critical { background: rgba(238, 106, 88, 0.10); border-color: rgba(238, 106, 88, 0.28); color: #ffb4aa; }
+    .status-chip.warning { background: rgba(226, 166, 78, 0.10); border-color: rgba(226, 166, 78, 0.30); color: #f1ca88; }
+    .status-chip.stable { background: rgba(117, 185, 143, 0.10); border-color: rgba(117, 185, 143, 0.28); color: #b8e7c7; }
+    .status-chip.info { background: rgba(124, 183, 216, 0.10); border-color: rgba(124, 183, 216, 0.28); color: #b6dcf2; }
 
     .card-title {
       margin: 0 0 7px;
+      color: var(--ink-strong);
       font-size: 1rem;
       line-height: 1.2;
-      letter-spacing: -0.03em;
+      letter-spacing: -0.035em;
     }
 
     .card-copy {
       margin: 0 0 12px;
-      color: #3f4743;
-      font-size: 0.86rem;
-      line-height: 1.42;
+      color: var(--ink-muted);
+      font-size: 0.83rem;
+      line-height: 1.44;
     }
 
     .confidence-row {
@@ -520,8 +605,8 @@
       gap: 8px;
       align-items: center;
       margin: 12px 0;
-      color: var(--muted-ink);
-      font-size: 0.78rem;
+      color: var(--ink-faint);
+      font-size: 0.76rem;
     }
 
     .dots {
@@ -534,44 +619,45 @@
       width: 8px;
       height: 8px;
       border-radius: 999px;
-      border: 1px solid var(--source-line);
+      border: 1px solid rgba(235, 221, 190, 0.28);
       background: transparent;
     }
-    .dot.on.critical { background: var(--stop-vermilion); border-color: var(--stop-vermilion); }
-    .dot.on.warning { background: var(--review-amber); border-color: var(--review-amber); }
-    .dot.on.stable { background: var(--verified-moss); border-color: var(--verified-moss); }
-    .dot.on.info { background: var(--telemetry-blue); border-color: var(--telemetry-blue); }
+    .dot.on.critical { background: var(--stop-vermilion); border-color: var(--stop-vermilion); box-shadow: 0 0 14px rgba(238, 106, 88, 0.34); }
+    .dot.on.warning { background: var(--review-amber); border-color: var(--review-amber); box-shadow: 0 0 14px rgba(226, 166, 78, 0.32); }
+    .dot.on.stable { background: var(--verified-moss); border-color: var(--verified-moss); box-shadow: 0 0 14px rgba(117, 185, 143, 0.26); }
+    .dot.on.info { background: var(--telemetry-blue); border-color: var(--telemetry-blue); box-shadow: 0 0 14px rgba(124, 183, 216, 0.24); }
 
     .source-strip {
       display: flex;
       gap: 6px;
       flex-wrap: wrap;
       padding-top: 10px;
-      border-top: 1px solid var(--source-line-soft);
+      border-top: 1px solid var(--ledger-line);
     }
 
     .card-button {
       margin-top: 12px;
       width: 100%;
-      border-radius: 9px;
-      padding: 8px 10px;
+      border-radius: 10px;
+      padding: 9px 10px;
       text-align: left;
-      color: #274238;
-      font-weight: 800;
-      background: rgba(246, 243, 236, 0.64);
+      color: #f0d39c;
+      font-weight: 820;
+      background: rgba(226, 166, 78, 0.055);
     }
 
     .empty-slot {
       display: grid;
       place-items: center;
       min-height: 86px;
-      border: 1px dashed var(--source-line);
-      border-radius: 12px;
-      color: var(--muted-ink);
-      font-size: 0.78rem;
+      border: 1px dashed rgba(235, 221, 190, 0.22);
+      border-radius: var(--radius-soft);
+      color: var(--ink-faint);
+      font-size: 0.76rem;
       text-align: center;
       padding: 16px;
       margin-top: 12px;
+      background: rgba(255, 248, 232, 0.018);
     }
 
     .footer-note {
@@ -580,9 +666,9 @@
       justify-content: space-between;
       gap: 16px;
       padding: 12px 4px 0;
-      color: var(--muted-ink);
-      font-size: 0.78rem;
-      border-top: 1px solid var(--source-line-soft);
+      color: var(--ink-faint);
+      font-size: 0.76rem;
+      border-top: 1px solid var(--ledger-line);
     }
 
     .legend {
@@ -604,12 +690,13 @@
       top: 18px;
       bottom: 18px;
       width: min(430px, calc(100vw - 36px));
-      border-radius: 18px;
+      border-radius: 22px;
       padding: 20px;
       transform: translateX(calc(100% + 32px));
-      transition: transform 220ms ease;
+      transition: transform 240ms cubic-bezier(.2,.8,.2,1);
       z-index: 10;
       overflow: auto;
+      box-shadow: var(--shadow), inset 3px 0 0 rgba(124, 183, 216, 0.58);
     }
 
     .detail-drawer.open { transform: translateX(0); }
@@ -617,11 +704,12 @@
     .drawer-backdrop {
       position: fixed;
       inset: 0;
-      background: rgba(24, 32, 31, 0.08);
+      background: rgba(0, 0, 0, 0.38);
       opacity: 0;
       pointer-events: none;
-      transition: opacity 180ms ease;
+      transition: opacity 190ms ease;
       z-index: 9;
+      backdrop-filter: blur(2px);
     }
     .drawer-backdrop.open { opacity: 1; pointer-events: auto; }
 
@@ -631,48 +719,77 @@
       justify-content: space-between;
       gap: 12px;
       padding-bottom: 16px;
-      border-bottom: 1px solid var(--source-line-soft);
+      border-bottom: 1px solid var(--ledger-line);
     }
 
     .drawer-section {
       padding: 18px 0;
-      border-bottom: 1px solid var(--source-line-soft);
+      border-bottom: 1px solid var(--ledger-line);
     }
 
     .drawer-section h3 {
       margin: 0 0 10px;
-      font-size: 0.88rem;
+      color: #e8dec9;
+      font-size: 0.78rem;
       text-transform: uppercase;
-      letter-spacing: 0.07em;
+      letter-spacing: 0.1em;
     }
 
     .drawer-section p {
       margin: 0 0 10px;
-      color: #3f4743;
-      line-height: 1.45;
-      font-size: 0.92rem;
+      color: var(--ink-muted);
+      line-height: 1.48;
+      font-size: 0.9rem;
     }
 
     .hidden { display: none !important; }
+
+    @media (prefers-reduced-motion: no-preference) {
+      .trace-room, .workspace > section, .filters, .board, .footer-note {
+        animation: surfaceIn 520ms cubic-bezier(.2,.8,.2,1) both;
+      }
+      .workspace > section:nth-child(1) { animation-delay: 70ms; }
+      .workspace > section:nth-child(2) { animation-delay: 120ms; }
+      .filters { animation-delay: 160ms; }
+      .board { animation-delay: 200ms; }
+      .footer-note { animation-delay: 240ms; }
+      .work-card { animation: cardIn 420ms cubic-bezier(.2,.8,.2,1) both; }
+      .lane:nth-child(2) .work-card { animation-delay: 70ms; }
+      .lane:nth-child(3) .work-card { animation-delay: 110ms; }
+      .lane:nth-child(4) .work-card { animation-delay: 150ms; }
+    }
+
+    @keyframes surfaceIn {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    @keyframes cardIn {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
 
     @media (max-width: 1180px) {
       .app-shell { grid-template-columns: 1fr; }
       .trace-room { position: static; max-height: none; }
       .overview, .exceptions { grid-template-columns: repeat(2, 1fr); }
       .board { grid-template-columns: repeat(2, minmax(240px, 1fr)); }
-      .topbar { grid-template-columns: 1fr; }
+      .topbar { grid-template-columns: 1fr; align-items: start; }
       .authority { text-align: left; }
       h1 { white-space: normal; }
     }
 
     @media (max-width: 720px) {
       .app-shell { padding: 14px; }
+      .brand { align-items: start; flex-direction: column; }
       .overview, .exceptions, .board { grid-template-columns: 1fr; }
-      .overview-cell, .exception-intro, .exception-item { border-right: 0; border-bottom: 1px solid var(--source-line-soft); }
+      .overview-cell, .exception-intro, .exception-item { border-right: 0; border-bottom: 1px solid var(--ledger-line); }
       .overview-cell:last-child, .exception-item:last-child { border-bottom: 0; }
       .footer-note { flex-direction: column; }
-      .brand { align-items: flex-start; flex-direction: column; }
+      .detail-drawer { inset: 12px; width: auto; }
+      .confidence-row { grid-template-columns: 1fr; }
     }
+
   </style>
 </head>
 <body>

--- a/examples/visual-operations/prototype/mission-control-static.html
+++ b/examples/visual-operations/prototype/mission-control-static.html
@@ -6,25 +6,23 @@
   <title>AletheIA Mission Control — Static Prototype</title>
   <style>
     :root {
-      --ink: #f4efe3;
-      --ink-strong: #fff8e8;
-      --ink-muted: #a9acaa;
-      --ink-faint: #6f7774;
-      --void: #070909;
-      --surface: #101413;
-      --surface-2: #151b19;
-      --surface-3: #1d2522;
-      --ledger-line: rgba(235, 221, 190, 0.16);
-      --ledger-line-strong: rgba(235, 221, 190, 0.34);
-      --verified-moss: #75b98f;
-      --review-amber: #e2a64e;
-      --stop-vermilion: #ee6a58;
-      --telemetry-blue: #7cb7d8;
-      --source-glow: rgba(226, 166, 78, 0.18);
-      --shadow: 0 26px 80px rgba(0, 0, 0, 0.42);
-      --shadow-tight: 0 16px 42px rgba(0, 0, 0, 0.26);
-      --radius: 18px;
-      --radius-soft: 12px;
+      --ink: #e8e4da;
+      --ink-strong: #f8f3e8;
+      --ink-muted: #a7aaa6;
+      --ink-faint: #707872;
+      --void: #0a0d0c;
+      --surface: #111514;
+      --surface-2: #151a18;
+      --surface-3: #1b211f;
+      --ledger-line: rgba(232, 228, 218, 0.14);
+      --ledger-line-strong: rgba(232, 228, 218, 0.28);
+      --verified-moss: #8fb99d;
+      --review-amber: #d2a15f;
+      --stop-vermilion: #d87465;
+      --telemetry-blue: #8ab3c9;
+      --shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+      --radius: 8px;
+      --radius-soft: 6px;
       color-scheme: dark;
     }
 
@@ -36,39 +34,23 @@
       margin: 0;
       min-height: 100vh;
       background:
-        radial-gradient(circle at 18% 12%, rgba(226, 166, 78, 0.16), transparent 30vw),
-        radial-gradient(circle at 82% 8%, rgba(124, 183, 216, 0.12), transparent 28vw),
-        linear-gradient(90deg, rgba(235, 221, 190, 0.045) 1px, transparent 1px),
-        linear-gradient(180deg, rgba(235, 221, 190, 0.035) 1px, transparent 1px),
-        linear-gradient(135deg, #070909 0%, #0d1110 44%, #111816 100%);
-      background-size: auto, auto, 52px 52px, 52px 52px, auto;
+        linear-gradient(90deg, rgba(232, 228, 218, 0.035) 1px, transparent 1px),
+        linear-gradient(180deg, rgba(232, 228, 218, 0.028) 1px, transparent 1px),
+        #0a0d0c;
+      background-size: 56px 56px;
       color: var(--ink);
       font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      letter-spacing: -0.012em;
-    }
-
-    body::before {
-      content: "";
-      position: fixed;
-      inset: 0;
-      pointer-events: none;
-      background:
-        linear-gradient(90deg, rgba(7, 9, 9, 0.18), transparent 18%, transparent 78%, rgba(7, 9, 9, 0.34)),
-        repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.018) 0 1px, transparent 1px 4px);
-      mix-blend-mode: screen;
-      opacity: 0.55;
+      letter-spacing: -0.01em;
     }
 
     button, input { font: inherit; }
 
     .app-shell {
-      position: relative;
       display: grid;
-      grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
-      gap: 20px;
+      grid-template-columns: minmax(310px, 360px) minmax(0, 1fr);
+      gap: 18px;
       min-height: 100vh;
-      padding: 24px;
-      isolation: isolate;
+      padding: 22px;
     }
 
     .topbar {
@@ -77,80 +59,77 @@
       grid-template-columns: minmax(0, 1fr) auto auto;
       gap: 20px;
       align-items: end;
-      padding: 4px 2px 12px;
-      border-bottom: 1px solid var(--ledger-line);
+      padding: 0 0 14px;
+      border-bottom: 1px solid var(--ledger-line-strong);
     }
 
     .brand {
       display: flex;
       align-items: end;
-      gap: 18px;
+      gap: 14px;
       min-width: 0;
     }
 
     h1 {
       margin: 0;
       color: var(--ink-strong);
-      font-family: Georgia, "Times New Roman", serif;
-      font-size: clamp(2.55rem, 5vw, 6.2rem);
-      line-height: 0.82;
-      letter-spacing: -0.085em;
+      font-size: clamp(2rem, 3.2vw, 3.8rem);
+      line-height: 0.92;
+      letter-spacing: -0.055em;
       white-space: nowrap;
-      text-shadow: 0 12px 48px rgba(226, 166, 78, 0.14);
+      font-weight: 820;
     }
 
     .pill {
       display: inline-flex;
       align-items: center;
-      gap: 8px;
-      border: 1px solid rgba(117, 185, 143, 0.42);
-      border-radius: 999px;
-      color: #dff8e8;
-      background: rgba(117, 185, 143, 0.08);
-      padding: 10px 16px;
+      border: 1px solid rgba(143, 185, 157, 0.42);
+      border-radius: 4px;
+      color: #cfe3d5;
+      background: rgba(143, 185, 157, 0.055);
+      padding: 8px 10px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       font-weight: 760;
-      font-size: 0.82rem;
+      font-size: 0.68rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
       white-space: nowrap;
-      box-shadow: inset 0 0 22px rgba(117, 185, 143, 0.06);
     }
 
     .timestamp, .authority, .utility {
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.74rem;
+      font-size: 0.72rem;
       color: var(--ink-muted);
     }
 
     .timestamp { color: var(--ink-faint); }
 
     .authority {
-      color: #d7f4df;
-      font-weight: 780;
+      color: #cfe3d5;
+      font-weight: 720;
       text-align: right;
     }
 
     .trace-room, .workspace > section, .lane, .detail-drawer {
       border: 1px solid var(--ledger-line);
-      background:
-        linear-gradient(180deg, rgba(255, 248, 232, 0.035), rgba(255, 248, 232, 0.012)),
-        rgba(16, 20, 19, 0.78);
-      box-shadow: var(--shadow-tight);
-      backdrop-filter: blur(16px) saturate(1.08);
+      background: rgba(17, 21, 20, 0.96);
+      box-shadow: var(--shadow);
     }
 
     .trace-room {
       position: sticky;
       top: 20px;
       align-self: start;
-      max-height: calc(100vh - 132px);
+      max-height: calc(100vh - 124px);
       overflow: auto;
       border-radius: var(--radius);
-      padding: 18px;
-      box-shadow: var(--shadow), inset 3px 0 0 rgba(226, 166, 78, 0.68);
+      padding: 16px;
+      border-left: 3px solid var(--review-amber);
     }
 
     .trace-room::-webkit-scrollbar, .detail-drawer::-webkit-scrollbar { width: 10px; }
     .trace-room::-webkit-scrollbar-thumb, .detail-drawer::-webkit-scrollbar-thumb {
-      background: rgba(235, 221, 190, 0.22);
+      background: rgba(232, 228, 218, 0.18);
       border-radius: 999px;
       border: 3px solid transparent;
       background-clip: content-box;
@@ -158,12 +137,12 @@
 
     .section-kicker {
       margin: 0;
-      color: var(--review-amber);
+      color: var(--ink-faint);
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.68rem;
+      font-size: 0.66rem;
       text-transform: uppercase;
-      letter-spacing: 0.12em;
-      font-weight: 820;
+      letter-spacing: 0.11em;
+      font-weight: 760;
     }
 
     .trace-header {
@@ -171,54 +150,53 @@
       align-items: start;
       justify-content: space-between;
       gap: 10px;
-      padding-bottom: 16px;
+      padding-bottom: 14px;
       border-bottom: 1px solid var(--ledger-line);
     }
 
     .trace-header h2, .lane h2, .drawer-title {
       margin: 4px 0 0;
       color: var(--ink-strong);
-      font-size: 1.02rem;
-      letter-spacing: -0.035em;
+      font-size: 0.98rem;
+      letter-spacing: -0.025em;
     }
 
     .trace-actions { display: flex; gap: 8px; }
 
     .icon-button, .filter-button, .card-button {
       border: 1px solid var(--ledger-line-strong);
-      background: rgba(255, 248, 232, 0.035);
+      background: transparent;
       color: var(--ink);
       cursor: pointer;
-      transition: transform 170ms ease, border-color 170ms ease, background 170ms ease, color 170ms ease, box-shadow 170ms ease;
+      transition: transform 140ms ease, border-color 140ms ease, background 140ms ease, color 140ms ease;
     }
 
     .icon-button {
       min-width: 34px;
       height: 34px;
-      border-radius: 999px;
+      border-radius: 4px;
       padding: 0 10px;
     }
 
     .icon-button:hover, .filter-button:hover, .card-button:hover,
     .icon-button:focus-visible, .filter-button:focus-visible, .card-button:focus-visible {
       transform: translateY(-1px);
-      border-color: rgba(226, 166, 78, 0.78);
-      background: rgba(226, 166, 78, 0.08);
-      box-shadow: 0 0 0 4px rgba(226, 166, 78, 0.08);
+      border-color: rgba(232, 228, 218, 0.48);
+      background: rgba(232, 228, 218, 0.045);
       outline: none;
     }
 
-    .trace-group { margin-top: 20px; }
+    .trace-group { margin-top: 18px; }
 
     .trace-date {
       display: flex;
       gap: 8px;
       align-items: center;
-      margin-bottom: 14px;
-      color: #f2d39b;
+      margin-bottom: 13px;
+      color: #d8c5a2;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-weight: 850;
-      font-size: 0.72rem;
+      font-weight: 780;
+      font-size: 0.7rem;
       letter-spacing: 0.08em;
       text-transform: uppercase;
     }
@@ -228,111 +206,111 @@
       display: grid;
       grid-template-columns: 44px 1fr;
       gap: 12px;
-      padding: 0 0 24px;
+      padding: 0 0 22px;
     }
 
     .trace-item::before {
       content: "";
       position: absolute;
       left: 55px;
-      top: 26px;
+      top: 24px;
       bottom: 0;
       width: 1px;
-      background: linear-gradient(180deg, rgba(226, 166, 78, 0.55), rgba(235, 221, 190, 0.1));
+      background: rgba(232, 228, 218, 0.18);
     }
 
     .trace-item:last-child::before { display: none; }
 
     .trace-time {
-      padding-top: 6px;
+      padding-top: 5px;
       color: var(--ink-faint);
-      font-size: 0.7rem;
+      font-size: 0.68rem;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       text-align: right;
     }
 
     .trace-card {
       position: relative;
-      padding: 2px 0 0 18px;
+      padding: 0 0 0 18px;
     }
 
     .trace-dot {
       position: absolute;
-      left: -11px;
+      left: -10px;
       top: 3px;
-      width: 20px;
-      height: 20px;
+      width: 17px;
+      height: 17px;
       border-radius: 999px;
-      border: 4px solid #101413;
+      border: 3px solid var(--surface);
       background: var(--verified-moss);
-      box-shadow: 0 0 0 1px rgba(235, 221, 190, 0.3), 0 0 22px rgba(117, 185, 143, 0.26);
+      box-shadow: 0 0 0 1px rgba(232, 228, 218, 0.28);
     }
 
-    .trace-dot.critical { background: var(--stop-vermilion); box-shadow: 0 0 0 1px rgba(235, 221, 190, 0.3), 0 0 22px rgba(238, 106, 88, 0.32); }
-    .trace-dot.warning { background: var(--review-amber); box-shadow: 0 0 0 1px rgba(235, 221, 190, 0.3), 0 0 22px rgba(226, 166, 78, 0.32); }
-    .trace-dot.info { background: var(--telemetry-blue); box-shadow: 0 0 0 1px rgba(235, 221, 190, 0.3), 0 0 22px rgba(124, 183, 216, 0.30); }
+    .trace-dot.critical { background: var(--stop-vermilion); }
+    .trace-dot.warning { background: var(--review-amber); }
+    .trace-dot.info { background: var(--telemetry-blue); }
 
     .trace-title {
       margin: 0 0 4px;
       color: var(--ink-strong);
-      font-size: 0.92rem;
-      font-weight: 820;
-      letter-spacing: -0.025em;
+      font-size: 0.9rem;
+      font-weight: 760;
+      letter-spacing: -0.018em;
     }
 
     .trace-copy {
-      margin: 0 0 9px;
+      margin: 0 0 8px;
       color: var(--ink-muted);
-      font-size: 0.79rem;
+      font-size: 0.78rem;
       line-height: 1.4;
     }
 
     .tags {
       display: flex;
-      gap: 6px;
+      gap: 5px;
       flex-wrap: wrap;
     }
 
     .tag {
       display: inline-flex;
       align-items: center;
-      border: 1px solid rgba(235, 221, 190, 0.22);
-      border-radius: 999px;
-      background: rgba(255, 248, 232, 0.045);
-      padding: 4px 8px;
-      color: #c7c5bb;
+      border: 1px solid rgba(232, 228, 218, 0.18);
+      border-radius: 4px;
+      background: rgba(232, 228, 218, 0.028);
+      padding: 3px 6px;
+      color: #c5c1b7;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.62rem;
-      font-weight: 760;
+      font-size: 0.6rem;
+      font-weight: 700;
       white-space: nowrap;
     }
 
     .workspace {
       display: grid;
-      gap: 18px;
+      gap: 16px;
       min-width: 0;
     }
 
     .overview {
       border-radius: var(--radius);
       display: grid;
-      grid-template-columns: 1.36fr repeat(5, minmax(112px, 1fr));
+      grid-template-columns: 1.28fr repeat(5, minmax(112px, 1fr));
       overflow: hidden;
     }
 
     .overview-cell {
       position: relative;
-      padding: 20px 22px;
+      padding: 18px 20px;
       border-right: 1px solid var(--ledger-line);
-      min-height: 112px;
+      min-height: 104px;
     }
     .overview-cell:last-child { border-right: 0; }
-    .overview-cell:first-child { background: linear-gradient(180deg, rgba(226, 166, 78, 0.08), transparent); }
+    .overview-cell:first-child { background: rgba(232, 228, 218, 0.025); }
 
     .overview-label {
       margin: 0 0 7px;
-      color: #dad3c3;
-      font-size: 0.84rem;
+      color: #d6d0c2;
+      font-size: 0.82rem;
       line-height: 1.32;
     }
 
@@ -340,17 +318,19 @@
       display: inline-flex;
       align-items: baseline;
       gap: 8px;
-      font-family: Georgia, "Times New Roman", serif;
-      font-size: 3.25rem;
-      line-height: 0.95;
-      letter-spacing: -0.072em;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 2.35rem;
+      font-weight: 760;
+      line-height: 1;
+      letter-spacing: -0.05em;
     }
 
     .overview-unit {
       font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       color: var(--ink-faint);
-      font-size: 0.78rem;
+      font-size: 0.74rem;
       letter-spacing: -0.01em;
+      font-weight: 500;
     }
 
     .tone-critical { color: var(--stop-vermilion); }
@@ -363,11 +343,10 @@
       display: grid;
       grid-template-columns: 0.95fr repeat(3, 1fr);
       overflow: hidden;
-      box-shadow: var(--shadow-tight), inset 0 0 0 1px rgba(238, 106, 88, 0.035);
     }
 
     .exception-intro, .exception-item {
-      padding: 20px 22px;
+      padding: 18px 20px;
       border-right: 1px solid var(--ledger-line);
     }
     .exception-item:last-child { border-right: 0; }
@@ -375,8 +354,8 @@
     .exception-item {
       position: relative;
       display: grid;
-      grid-template-columns: 5px 1fr auto;
-      gap: 14px;
+      grid-template-columns: 4px 1fr auto;
+      gap: 13px;
       align-items: center;
       color: var(--ink);
       cursor: pointer;
@@ -385,48 +364,46 @@
       border-bottom: 0;
       border-left: 0;
       background: transparent;
-      transition: background 170ms ease, transform 170ms ease;
+      transition: background 140ms ease;
     }
 
     .exception-item:hover, .exception-item:focus-visible {
-      background: rgba(255, 248, 232, 0.045);
-      transform: translateY(-1px);
+      background: rgba(232, 228, 218, 0.035);
       outline: none;
     }
 
     .exception-rail {
-      width: 5px;
+      width: 4px;
       align-self: stretch;
       border-radius: 999px;
       background: var(--review-amber);
-      box-shadow: 0 0 18px rgba(226, 166, 78, 0.28);
     }
-    .exception-rail.critical { background: var(--stop-vermilion); box-shadow: 0 0 18px rgba(238, 106, 88, 0.30); }
-    .exception-rail.info { background: var(--telemetry-blue); box-shadow: 0 0 18px rgba(124, 183, 216, 0.25); }
+    .exception-rail.critical { background: var(--stop-vermilion); }
+    .exception-rail.info { background: var(--telemetry-blue); }
 
     .exception-label {
       display: block;
       margin: 0 0 5px;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.66rem;
+      font-size: 0.64rem;
       text-transform: uppercase;
       letter-spacing: 0.1em;
-      font-weight: 900;
+      font-weight: 820;
     }
 
     .exception-title {
       display: block;
       margin: 0;
       color: var(--ink-strong);
-      font-weight: 820;
-      letter-spacing: -0.03em;
+      font-weight: 760;
+      letter-spacing: -0.02em;
     }
 
     .exception-copy {
       display: block;
       margin: 5px 0 0;
       color: var(--ink-muted);
-      font-size: 0.8rem;
+      font-size: 0.78rem;
       line-height: 1.36;
     }
 
@@ -436,7 +413,7 @@
       justify-content: space-between;
       gap: 12px;
       flex-wrap: wrap;
-      padding: 2px 2px 0;
+      padding: 0;
     }
 
     .filter-group {
@@ -446,41 +423,32 @@
     }
 
     .filter-button {
-      border-radius: 999px;
-      padding: 9px 13px;
-      font-size: 0.78rem;
-      font-weight: 760;
+      border-radius: 4px;
+      padding: 8px 10px;
+      font-size: 0.76rem;
+      font-weight: 720;
     }
 
     .filter-button[aria-pressed="true"] {
-      background: var(--ink-strong);
-      border-color: var(--ink-strong);
-      color: #0b0e0d;
-      box-shadow: 0 12px 32px rgba(255, 248, 232, 0.10);
+      background: #d8d0c2;
+      border-color: #d8d0c2;
+      color: #101413;
     }
 
     .board {
       display: grid;
       grid-template-columns: repeat(4, minmax(220px, 1fr));
-      gap: 14px;
+      gap: 12px;
       align-items: start;
     }
 
     .lane {
       position: relative;
       border-radius: var(--radius);
-      padding: 14px;
+      padding: 12px;
       min-height: 448px;
       overflow: hidden;
-    }
-
-    .lane::before {
-      content: "";
-      position: absolute;
-      inset: 0 0 auto;
-      height: 72px;
-      background: linear-gradient(180deg, rgba(255, 248, 232, 0.04), transparent);
-      pointer-events: none;
+      background: rgba(15, 19, 18, 0.98);
     }
 
     .lane-header {
@@ -489,8 +457,8 @@
       align-items: center;
       justify-content: space-between;
       gap: 12px;
-      margin-bottom: 12px;
-      padding-bottom: 12px;
+      margin-bottom: 10px;
+      padding-bottom: 11px;
       border-bottom: 1px solid var(--ledger-line);
     }
 
@@ -503,99 +471,95 @@
     .lane-glyph {
       display: grid;
       place-items: center;
-      width: 32px;
-      height: 32px;
+      min-width: 32px;
+      height: 26px;
       border: 1px solid var(--ledger-line-strong);
-      border-radius: 999px;
-      font-size: 0.64rem;
+      border-radius: 4px;
+      padding: 0 7px;
+      font-size: 0.6rem;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-weight: 900;
-      color: #d8d0c0;
-      background: rgba(255, 248, 232, 0.035);
+      font-weight: 820;
+      color: #cfc7b9;
+      background: rgba(232, 228, 218, 0.025);
     }
 
     .count {
       color: var(--ink-faint);
-      font-size: 0.78rem;
+      font-size: 0.76rem;
       white-space: nowrap;
     }
 
     .work-card {
       position: relative;
       display: grid;
-      grid-template-columns: 7px 1fr;
-      margin: 12px 0;
+      grid-template-columns: 5px 1fr;
+      margin: 10px 0;
       border: 1px solid var(--ledger-line);
       border-radius: var(--radius-soft);
-      background:
-        linear-gradient(180deg, rgba(255, 248, 232, 0.045), rgba(255, 248, 232, 0.018)),
-        rgba(9, 12, 11, 0.28);
+      background: rgba(232, 228, 218, 0.026);
       overflow: hidden;
-      transition: transform 170ms ease, border-color 170ms ease, background 170ms ease, box-shadow 170ms ease;
+      transition: transform 140ms ease, border-color 140ms ease, background 140ms ease;
     }
 
     .work-card:hover, .work-card:focus-within {
-      transform: translateY(-3px);
-      border-color: rgba(235, 221, 190, 0.36);
-      background:
-        linear-gradient(180deg, rgba(255, 248, 232, 0.07), rgba(255, 248, 232, 0.026)),
-        rgba(9, 12, 11, 0.46);
-      box-shadow: 0 18px 44px rgba(0, 0, 0, 0.26);
+      transform: translateY(-1px);
+      border-color: rgba(232, 228, 218, 0.34);
+      background: rgba(232, 228, 218, 0.04);
     }
 
-    .source-rail { background: rgba(235, 221, 190, 0.25); }
-    .source-rail.critical { background: var(--stop-vermilion); box-shadow: 0 0 24px rgba(238, 106, 88, 0.36); }
-    .source-rail.warning { background: var(--review-amber); box-shadow: 0 0 24px rgba(226, 166, 78, 0.34); }
-    .source-rail.stable { background: var(--verified-moss); box-shadow: 0 0 24px rgba(117, 185, 143, 0.28); }
-    .source-rail.info { background: var(--telemetry-blue); box-shadow: 0 0 24px rgba(124, 183, 216, 0.26); }
+    .source-rail { background: rgba(232, 228, 218, 0.24); }
+    .source-rail.critical { background: var(--stop-vermilion); }
+    .source-rail.warning { background: var(--review-amber); }
+    .source-rail.stable { background: var(--verified-moss); }
+    .source-rail.info { background: var(--telemetry-blue); }
 
-    .card-body { padding: 14px; }
+    .card-body { padding: 13px; }
 
     .card-meta {
       display: flex;
       justify-content: space-between;
       gap: 8px;
-      margin-bottom: 12px;
+      margin-bottom: 11px;
       align-items: start;
     }
 
     .slice-id {
       color: var(--ink-faint);
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.69rem;
-      font-weight: 800;
+      font-size: 0.68rem;
+      font-weight: 760;
     }
 
     .status-chip {
-      border: 1px solid rgba(235, 221, 190, 0.12);
-      border-radius: 999px;
-      padding: 4px 8px;
-      background: rgba(255, 248, 232, 0.055);
-      color: #d2c9b9;
+      border: 1px solid rgba(232, 228, 218, 0.14);
+      border-radius: 4px;
+      padding: 3px 6px;
+      background: transparent;
+      color: #cec7bb;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.58rem;
+      font-size: 0.56rem;
       text-transform: uppercase;
       letter-spacing: 0.07em;
-      font-weight: 900;
+      font-weight: 820;
       white-space: nowrap;
     }
-    .status-chip.critical { background: rgba(238, 106, 88, 0.10); border-color: rgba(238, 106, 88, 0.28); color: #ffb4aa; }
-    .status-chip.warning { background: rgba(226, 166, 78, 0.10); border-color: rgba(226, 166, 78, 0.30); color: #f1ca88; }
-    .status-chip.stable { background: rgba(117, 185, 143, 0.10); border-color: rgba(117, 185, 143, 0.28); color: #b8e7c7; }
-    .status-chip.info { background: rgba(124, 183, 216, 0.10); border-color: rgba(124, 183, 216, 0.28); color: #b6dcf2; }
+    .status-chip.critical { border-color: rgba(216, 116, 101, 0.42); color: #e2a69d; }
+    .status-chip.warning { border-color: rgba(210, 161, 95, 0.42); color: #dfbf8b; }
+    .status-chip.stable { border-color: rgba(143, 185, 157, 0.42); color: #bad3c2; }
+    .status-chip.info { border-color: rgba(138, 179, 201, 0.42); color: #b4d1df; }
 
     .card-title {
       margin: 0 0 7px;
       color: var(--ink-strong);
-      font-size: 1rem;
-      line-height: 1.2;
-      letter-spacing: -0.035em;
+      font-size: 0.98rem;
+      line-height: 1.22;
+      letter-spacing: -0.025em;
     }
 
     .card-copy {
       margin: 0 0 12px;
       color: var(--ink-muted);
-      font-size: 0.83rem;
+      font-size: 0.82rem;
       line-height: 1.44;
     }
 
@@ -606,7 +570,7 @@
       align-items: center;
       margin: 12px 0;
       color: var(--ink-faint);
-      font-size: 0.76rem;
+      font-size: 0.74rem;
     }
 
     .dots {
@@ -616,20 +580,20 @@
     }
 
     .dot {
-      width: 8px;
-      height: 8px;
+      width: 7px;
+      height: 7px;
       border-radius: 999px;
-      border: 1px solid rgba(235, 221, 190, 0.28);
+      border: 1px solid rgba(232, 228, 218, 0.28);
       background: transparent;
     }
-    .dot.on.critical { background: var(--stop-vermilion); border-color: var(--stop-vermilion); box-shadow: 0 0 14px rgba(238, 106, 88, 0.34); }
-    .dot.on.warning { background: var(--review-amber); border-color: var(--review-amber); box-shadow: 0 0 14px rgba(226, 166, 78, 0.32); }
-    .dot.on.stable { background: var(--verified-moss); border-color: var(--verified-moss); box-shadow: 0 0 14px rgba(117, 185, 143, 0.26); }
-    .dot.on.info { background: var(--telemetry-blue); border-color: var(--telemetry-blue); box-shadow: 0 0 14px rgba(124, 183, 216, 0.24); }
+    .dot.on.critical { background: var(--stop-vermilion); border-color: var(--stop-vermilion); }
+    .dot.on.warning { background: var(--review-amber); border-color: var(--review-amber); }
+    .dot.on.stable { background: var(--verified-moss); border-color: var(--verified-moss); }
+    .dot.on.info { background: var(--telemetry-blue); border-color: var(--telemetry-blue); }
 
     .source-strip {
       display: flex;
-      gap: 6px;
+      gap: 5px;
       flex-wrap: wrap;
       padding-top: 10px;
       border-top: 1px solid var(--ledger-line);
@@ -638,26 +602,26 @@
     .card-button {
       margin-top: 12px;
       width: 100%;
-      border-radius: 10px;
-      padding: 9px 10px;
+      border-radius: 4px;
+      padding: 8px 9px;
       text-align: left;
-      color: #f0d39c;
-      font-weight: 820;
-      background: rgba(226, 166, 78, 0.055);
+      color: #d8c5a2;
+      font-weight: 760;
+      background: rgba(210, 161, 95, 0.035);
     }
 
     .empty-slot {
       display: grid;
       place-items: center;
-      min-height: 86px;
-      border: 1px dashed rgba(235, 221, 190, 0.22);
+      min-height: 82px;
+      border: 1px dashed rgba(232, 228, 218, 0.2);
       border-radius: var(--radius-soft);
       color: var(--ink-faint);
-      font-size: 0.76rem;
+      font-size: 0.74rem;
       text-align: center;
-      padding: 16px;
-      margin-top: 12px;
-      background: rgba(255, 248, 232, 0.018);
+      padding: 14px;
+      margin-top: 10px;
+      background: transparent;
     }
 
     .footer-note {
@@ -665,9 +629,9 @@
       display: flex;
       justify-content: space-between;
       gap: 16px;
-      padding: 12px 4px 0;
+      padding: 12px 0 0;
       color: var(--ink-faint);
-      font-size: 0.76rem;
+      font-size: 0.74rem;
       border-top: 1px solid var(--ledger-line);
     }
 
@@ -690,13 +654,13 @@
       top: 18px;
       bottom: 18px;
       width: min(430px, calc(100vw - 36px));
-      border-radius: 22px;
+      border-radius: var(--radius);
       padding: 20px;
       transform: translateX(calc(100% + 32px));
-      transition: transform 240ms cubic-bezier(.2,.8,.2,1);
+      transition: transform 210ms cubic-bezier(.2,.8,.2,1);
       z-index: 10;
       overflow: auto;
-      box-shadow: var(--shadow), inset 3px 0 0 rgba(124, 183, 216, 0.58);
+      border-left: 3px solid var(--telemetry-blue);
     }
 
     .detail-drawer.open { transform: translateX(0); }
@@ -704,12 +668,11 @@
     .drawer-backdrop {
       position: fixed;
       inset: 0;
-      background: rgba(0, 0, 0, 0.38);
+      background: rgba(0, 0, 0, 0.44);
       opacity: 0;
       pointer-events: none;
-      transition: opacity 190ms ease;
+      transition: opacity 160ms ease;
       z-index: 9;
-      backdrop-filter: blur(2px);
     }
     .drawer-backdrop.open { opacity: 1; pointer-events: auto; }
 
@@ -729,8 +692,8 @@
 
     .drawer-section h3 {
       margin: 0 0 10px;
-      color: #e8dec9;
-      font-size: 0.78rem;
+      color: #d8d0c2;
+      font-size: 0.76rem;
       text-transform: uppercase;
       letter-spacing: 0.1em;
     }
@@ -746,26 +709,17 @@
 
     @media (prefers-reduced-motion: no-preference) {
       .trace-room, .workspace > section, .filters, .board, .footer-note {
-        animation: surfaceIn 520ms cubic-bezier(.2,.8,.2,1) both;
+        animation: surfaceIn 360ms ease both;
       }
-      .workspace > section:nth-child(1) { animation-delay: 70ms; }
-      .workspace > section:nth-child(2) { animation-delay: 120ms; }
-      .filters { animation-delay: 160ms; }
-      .board { animation-delay: 200ms; }
-      .footer-note { animation-delay: 240ms; }
-      .work-card { animation: cardIn 420ms cubic-bezier(.2,.8,.2,1) both; }
-      .lane:nth-child(2) .work-card { animation-delay: 70ms; }
-      .lane:nth-child(3) .work-card { animation-delay: 110ms; }
-      .lane:nth-child(4) .work-card { animation-delay: 150ms; }
+      .workspace > section:nth-child(1) { animation-delay: 40ms; }
+      .workspace > section:nth-child(2) { animation-delay: 70ms; }
+      .filters { animation-delay: 95ms; }
+      .board { animation-delay: 120ms; }
+      .footer-note { animation-delay: 140ms; }
     }
 
     @keyframes surfaceIn {
-      from { opacity: 0; transform: translateY(10px); }
-      to { opacity: 1; transform: translateY(0); }
-    }
-
-    @keyframes cardIn {
-      from { opacity: 0; transform: translateY(8px); }
+      from { opacity: 0; transform: translateY(4px); }
       to { opacity: 1; transform: translateY(0); }
     }
 


### PR DESCRIPTION
## What changed
- Replaced the static Mission Control prototype composition with an Evidence Ledger + Inspector direction.
- Shifted away from the previous board/cockpit treatment toward a sober full-browser operational shell inspired by the supplied dark references.
- Added a collapsible left navigation rail, central Work Slice evidence ledger, right-side inspector side sheet, and integrated trace events.
- Updated the prototype README to describe the full-browser shell, collapsible navigation, side sheet, and review criteria.

## Why it changed
- User review accepted the Evidence Ledger + Inspector direction and clarified that the product UI should occupy the full browser, not sit inside a centered presentation frame.
- The selected reference direction was Image 2 + Image 3: sober operational density, wide breathing room, contextual inspection, and product-like layout behavior.
- This preserves read-only semantics while making the artifact feel closer to a real operational surface.

## How to validate
- Open `examples/visual-operations/prototype/mission-control-static.html` locally.
- Confirm the shell fills the browser viewport.
- Confirm the left navigation expands/collapses.
- Confirm selecting a Work Slice opens the right-side evidence inspector sheet and that it can close via close button, backdrop, or Escape.
- `git diff --check`
- static prototype sanity check for read-only/interface markers and full-browser behavior
- diff-scope check confirming only `examples/visual-operations/prototype/` changed
- `pnpm check:governance`
- `pnpm test`
- `./scripts/check-visual-ops-snapshots.sh`

## Risks, assumptions or follow-ups
- Static prototype only; no app runtime, backend, collector, schema, policy engine, or Adaptive Skills integration.
- The prototype uses mock data only and remains a read-only projection.
- `plans/` remains untracked and untouched.
