### PR TITLE
docs(visual-ops): record accepted prototype direction

### DIFF
--- a/docs/guides/visual-operations-cockpit-visual-model.md
+++ b/docs/guides/visual-operations-cockpit-visual-model.md
@@ -189,6 +189,21 @@ This model may justify future design artifacts or prototypes, but it does not by
 Those require separate Work Slices with evidence that static Markdown/JSON is insufficient for a real
 cadence.
 
+## Accepted static prototype direction
+
+The current accepted prototype baseline is **Evidence Ledger + Inspector**. It preserves the
+read-only/source-first rules of Trace Room + Evidence Desk, but changes the screen composition into a
+full-browser product shell:
+
+- collapsible left navigation for workspace focus;
+- central evidence ledger for derived Work Slice posture;
+- right-side evidence inspector as a side sheet;
+- trace events integrated as context rather than a dominant decorative rail;
+- no backend, runtime, collector, schema, policy engine, or Adaptive Skills integration.
+
+Use this as the visual baseline for future static prototype iterations unless a later design review
+replaces it.
+
 ## Related
 
 - [Mission Control static prototype](../../examples/visual-operations/prototype/README.md)

--- a/docs/guides/visual-operations-cockpit-visual-model.md
+++ b/docs/guides/visual-operations-cockpit-visual-model.md
@@ -204,6 +204,28 @@ full-browser product shell:
 Use this as the visual baseline for future static prototype iterations unless a later design review
 replaces it.
 
+## Future operational intelligence signals
+
+Future prototype iterations may add a Resource Observatory layer, but only as a projection of sourced
+observability records. These signals are candidates, not required fields for the current static
+prototype.
+
+| Candidate signal | Visual purpose | Source/provenance rule |
+|---|---|---|
+| Context tokens | Show context-load pressure over time. | Use reported token telemetry when available; otherwise show `unavailable`. |
+| Token/cost spend | Make cost trend visible without inventing finance data. | Mark origin as `reported`, `estimated`, or `unavailable`. |
+| Retry waste | Expose repeated attempts or failed loops. | Derive only from execution/retry logs with source refs. |
+| Runtime fit | Show whether runtime/model choice matched task needs. | Use evaluation or run metadata; do not infer fit from outcome alone. |
+| Review effort | Indicate human review time or burden. | Use review records or explicit time metadata; otherwise `unknown`. |
+| Quality signals | Summarize validation quality and evidence health. | Link to validation, CI, eval, or audit sources. |
+| Active threads | Show concurrent work/agent context pressure. | Use thread/session records, never private conversation content. |
+| Skills usage | Show traced skill activations. | Skills remain trace context, not governance authority. |
+| Agent usage | Show agent participation or runtime usage. | Use agent/run metadata with privacy-safe identifiers only. |
+
+If an observability bus such as **APOB** is introduced later, it should remain an input/source layer
+for events, logs, metrics, and correlated signals. It must not become a new authority for readiness,
+review, closure, or policy decisions.
+
 ## Related
 
 - [Mission Control static prototype](../../examples/visual-operations/prototype/README.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -63,8 +63,8 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
   - composição estática de board com lanes, contagens e exceções antes de wireframe/UI
   - wireframe leve/documental do Mission Control, com direção visual e hierarquia de tela
   - mock visual versionado do Mission Control, escolhendo Trace Room + Evidence Desk como direção inicial
-  - mock visual refinado de tela única para orientar um futuro protótipo estático
-  - protótipo frontend estático e read-only do Mission Control com mock data
+  - mock visual refinado de tela única, agora tratado como precursor visual
+  - protótipo frontend estático e read-only do Mission Control com mock data, aceito como Evidence Ledger + Inspector full-browser
 
 ---
 

--- a/examples/visual-operations/cockpit-refined-visual-mock.md
+++ b/examples/visual-operations/cockpit-refined-visual-mock.md
@@ -11,9 +11,13 @@ backend, collector, runtime, schema, policy engine, or Adaptive Skills integrati
 
 **Trace Room + Evidence Desk**
 
-This refined mock narrows the previous three-option exploration into one screen direction: a
+This refined mock narrowed the previous three-option exploration into one screen direction: a
 trace-led, evidence-first cockpit that keeps source confidence visible while preserving a calm,
-editorial operating surface.
+editorial operating surface. It is now a precursor artifact, not the latest prototype target.
+
+The accepted static prototype direction is **Evidence Ledger + Inspector**, which keeps the same
+source-first intent but changes the composition into a full-browser operational shell with a central
+evidence ledger, collapsible navigation, and a right-side evidence side sheet.
 
 ![AletheIA Mission Control refined visual mock](assets/mission-control-trace-room-evidence-desk-refined.png)
 
@@ -71,7 +75,9 @@ This refined mock follows:
 - [Cockpit static board composition](cockpit-static-board-composition.md)
 - [Cockpit card state examples](cockpit-card-state-examples.md)
 
-It should be treated as the current visual target for any future static prototype with mock data.
+It should be treated as the precursor visual target that informed the current static prototype.
+The latest accepted artifact is the [Mission Control static prototype](prototype/README.md), using
+the **Evidence Ledger + Inspector** composition.
 
 ## Boundaries
 
@@ -97,6 +103,6 @@ Do not use this mock to justify:
 
 ## Next step
 
-If accepted, the next bounded slice can be a static frontend prototype with mock data only, using this
-refined mock as the visual target and preserving read-only semantics. See the
-[Mission Control static prototype](prototype/README.md).
+This mock has been carried forward into the static prototype. The accepted next visual baseline is
+the [Mission Control static prototype](prototype/README.md), which uses the **Evidence Ledger +
+Inspector** composition while preserving read-only semantics.


### PR DESCRIPTION
## What changed
- Recorded Evidence Ledger + Inspector as the accepted static prototype direction after PR #216.
- Marked the Trace Room + Evidence Desk refined mock as a precursor artifact rather than the latest target.
- Updated the examples index and cockpit visual model with the accepted full-browser prototype baseline.
- Added future Resource Observatory / operational intelligence signal candidates: context tokens, token/cost spend, retry waste, runtime fit, review effort, quality signals, active threads, skills usage, and agent usage.

## Why it changed
- The prototype evolved from a trace-led board mock into a full-browser Evidence Ledger + Inspector surface.
- The docs needed to reflect the accepted direction so future iterations do not treat older mock imagery as the current source of truth.
- The new observability notes capture useful future monitoring ideas without adding them to the current prototype or inventing unsupported metrics.

## How to validate
- `git diff --check`
- accepted-direction marker check across changed docs
- operational-intelligence marker check in the cockpit visual model
- `pnpm check:governance`
- `pnpm test`
- `./scripts/check-visual-ops-snapshots.sh`

## Risks, assumptions or follow-ups
- Docs/examples only; no runtime, backend, schema, collector, policy engine, or Adaptive Skills integration.
- Operational intelligence signals are future candidates only and require source/provenance before display.
- APOB, if introduced later, remains an input/source layer and not a governance authority.
- `plans/` remains untracked and untouched.
