### PR TITLE
docs(visual-ops): add prototype iteration plan

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -65,6 +65,7 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
   - mock visual versionado do Mission Control, escolhendo Trace Room + Evidence Desk como direção inicial
   - mock visual refinado de tela única, agora tratado como precursor visual
   - protótipo frontend estático e read-only do Mission Control com mock data, aceito como Evidence Ledger + Inspector full-browser
+  - roteiro de iteração visual do protótipo, preservando read-only e source authority
 
 ---
 

--- a/examples/visual-operations/prototype/README.md
+++ b/examples/visual-operations/prototype/README.md
@@ -54,6 +54,7 @@ Design intent:
 
 ## Source design artifacts
 
+- [Prototype iteration plan](iteration-plan.md)
 - [Refined visual mock](../cockpit-refined-visual-mock.md)
 - [Light wireframe spec](../cockpit-light-wireframe-spec.md)
 - [Static board composition](../cockpit-static-board-composition.md)

--- a/examples/visual-operations/prototype/iteration-plan.md
+++ b/examples/visual-operations/prototype/iteration-plan.md
@@ -1,0 +1,57 @@
+# Mission Control Prototype Iteration Plan
+
+## Purpose
+
+Record the next safe evolution path for the accepted **Evidence Ledger + Inspector** static prototype.
+
+This is not an implementation plan for a backend, collector, runtime, schema, policy engine, or Adaptive Skills integration. It only defines how future visual prototype slices should evolve without breaking the read-only projection boundary.
+
+## Current accepted baseline
+
+The current baseline is the full-browser **Evidence Ledger + Inspector** prototype:
+
+- collapsible left navigation;
+- central Work Slice evidence ledger;
+- right-side evidence inspector side sheet;
+- integrated trace/event context;
+- mock data only;
+- source records remain authoritative.
+
+This baseline should remain the reference point unless a later design review explicitly replaces it.
+
+## Next visual slices
+
+| Slice | Goal | Must preserve | Not included |
+|---|---|---|---|
+| 1. Visual QA pass | Tighten spacing, hierarchy, empty states, responsive behavior, and interaction clarity. | Full-browser shell, side sheet, read-only semantics. | Runtime data, backend, schemas, collectors. |
+| 2. Observability preview | Explore a small Resource Observatory preview for sourced operational signals. | `unknown`/`unavailable` for missing sources; provenance on every metric. | Real telemetry collection or generated estimates. |
+| 3. Source detail depth | Improve inspector treatment for source refs, trace, confidence, and boundary copy. | Metadata-first privacy and source authority. | Prompt bodies, secrets, restricted content. |
+| 4. Review workflow readability | Clarify how human review, conflicts, and unavailable telemetry are scanned. | Alerts as review prompts, not decisions. | Approve/reject commands or lifecycle mutation. |
+
+## Operational intelligence candidates
+
+Future Resource Observatory views may monitor:
+
+- context tokens;
+- token/cost spend;
+- retry waste;
+- runtime fit;
+- review effort;
+- quality signals;
+- active threads;
+- skills usage;
+- agent usage.
+
+A signal can appear visually only when it has a source reference and provenance. If no durable source exists, the visual state must be `unknown` or `unavailable`.
+
+## Acceptance criteria for future slices
+
+A future prototype slice is acceptable only if:
+
+- the screen still feels like an operational evidence tool, not a generic dashboard;
+- the central ledger remains the main workspace;
+- details appear on demand through the inspector or side sheet;
+- every status, metric, alert, and source claim has source refs or explicit absence;
+- `unavailable` remains neutral rather than failure-colored;
+- no interaction mutates Work Slice truth;
+- no new backend, runtime, collector, schema, policy engine, or Adaptive Skills integration is introduced.


### PR DESCRIPTION
## What changed
- Added a Mission Control prototype iteration plan for the accepted Evidence Ledger + Inspector baseline.
- Linked the plan from the prototype README and examples index.
- Defined safe future visual slices: visual QA, observability preview, source detail depth, and review workflow readability.

## Why it changed
- After merging the accepted prototype direction and future observability candidates, the next step needed a bounded visual evolution path.
- This prevents future work from jumping directly into runtime/backend/collector implementation before the static prototype is reviewed further.

## How to validate
- `git diff --check`
- iteration-plan marker check
- `pnpm check:governance`
- `pnpm test`
- `./scripts/check-visual-ops-snapshots.sh`

## Risks, assumptions or follow-ups
- Docs/examples only; no runtime, backend, schema, collector, policy engine, or Adaptive Skills integration.
- Future observability metrics remain candidates and require source/provenance before display.
- `plans/` remains untracked and untouched.
