### PR TITLE
docs(visual-ops): add prototype visual qa pass

### DIFF
--- a/examples/visual-operations/prototype/README.md
+++ b/examples/visual-operations/prototype/README.md
@@ -55,6 +55,7 @@ Design intent:
 ## Source design artifacts
 
 - [Prototype iteration plan](iteration-plan.md)
+- [Prototype visual QA pass](visual-qa-pass.md)
 - [Refined visual mock](../cockpit-refined-visual-mock.md)
 - [Light wireframe spec](../cockpit-light-wireframe-spec.md)
 - [Static board composition](../cockpit-static-board-composition.md)

--- a/examples/visual-operations/prototype/iteration-plan.md
+++ b/examples/visual-operations/prototype/iteration-plan.md
@@ -21,6 +21,8 @@ This baseline should remain the reference point unless a later design review exp
 
 ## Next visual slices
 
+The first slice has a docs-first QA artifact: [Mission Control Prototype Visual QA Pass](visual-qa-pass.md).
+
 | Slice | Goal | Must preserve | Not included |
 |---|---|---|---|
 | 1. Visual QA pass | Tighten spacing, hierarchy, empty states, responsive behavior, and interaction clarity. | Full-browser shell, side sheet, read-only semantics. | Runtime data, backend, schemas, collectors. |

--- a/examples/visual-operations/prototype/visual-qa-pass.md
+++ b/examples/visual-operations/prototype/visual-qa-pass.md
@@ -1,0 +1,64 @@
+# Mission Control Prototype Visual QA Pass
+
+## Purpose
+
+Review the accepted **Evidence Ledger + Inspector** prototype as a visual product surface before adding new prototype features.
+
+This pass is intentionally docs-first. It does not change the HTML prototype, introduce runtime data, add a backend, create schemas, wire collectors, or integrate Adaptive Skills.
+
+## Current verdict
+
+The prototype direction is accepted as the current baseline.
+
+It successfully moved from a centered mock presentation into a full-browser operational surface with:
+
+- a collapsible left navigation rail;
+- a central Evidence Ledger workspace;
+- a right-side inspector side sheet;
+- narrow interactions for filtering, navigation focus, and inspection;
+- read-only/source-authority language visible in the UI.
+
+## Visual strengths to preserve
+
+| Area | Keep |
+|---|---|
+| Composition | Full-browser shell, not a framed mockup. |
+| Workspace | Evidence Ledger remains the central working surface. |
+| Detail | Inspector opens on demand as a side sheet, avoiding permanent workspace loss. |
+| Tone | Dark, sober, operational, and lower-polish than generic AI dashboards. |
+| Color | State color reserved for evidence posture: critical, review, stable, unavailable. |
+| Copy | Interface language explains source posture and boundaries, not marketing claims. |
+
+## QA focus for the next prototype edit
+
+| Focus | What to check | Acceptance signal |
+|---|---|---|
+| Spacing | Topbar, ledger, lane headers, and side sheet spacing at desktop and narrow widths. | Dense but not cramped; no region feels ornamental. |
+| Hierarchy | First scan should reveal review prompts, source gaps, and inspector meaning. | A reviewer knows what to inspect next within a few seconds. |
+| Empty states | Lanes with no visible matching cards after filters need neutral explanation. | Empty does not look broken or like missing data. |
+| Responsive behavior | Full-browser shell should remain usable when the ledger scrolls horizontally. | Navigation, filters, ledger, and side sheet remain reachable. |
+| Side sheet behavior | Opening and closing detail should feel like inspection, not mutation. | Close button, backdrop, and Escape keep the interaction reversible. |
+| Source visibility | Source refs should invite verification without overwhelming card scan. | Every claim can be traced, but the card remains readable. |
+| Unavailable state | Missing telemetry or source gaps should be neutral. | `unavailable` does not look failed, critical, or complete. |
+
+## Non-goals
+
+Do not use this QA pass to add:
+
+- real telemetry;
+- runtime data;
+- token or cost calculations;
+- drag/drop board behavior;
+- approve/reject commands;
+- backend, persistence, collector, schema, policy engine, or Adaptive Skills integration.
+
+## Recommended next slice
+
+If the next edit changes the prototype HTML, start with a small **Visual QA implementation pass**:
+
+1. add neutral empty states for filtered lanes;
+2. tune responsive spacing for full-browser behavior;
+3. improve inspector affordance copy and close behavior if needed;
+4. keep all data mocked and all source claims provenance-aware.
+
+A Resource Observatory preview should come after this QA implementation pass, not before it.


### PR DESCRIPTION
## What changed
- Added a docs-first Visual QA pass for the accepted Evidence Ledger + Inspector prototype.
- Linked the QA pass from the prototype README and iteration plan.
- Captured visual strengths to preserve, QA focus areas, non-goals, and the recommended next HTML edit slice.

## Why it changed
- The iteration plan identified Visual QA as the next safe slice before adding observability previews or new prototype features.
- This creates a designer-readable checkpoint for spacing, hierarchy, empty states, responsive behavior, side sheet behavior, source visibility, and unavailable states.

## How to validate
- `git diff --check`
- visual QA marker check
- `pnpm check:governance`
- `pnpm test`
- `./scripts/check-visual-ops-snapshots.sh`

## Risks, assumptions or follow-ups
- Docs/examples only; no HTML prototype changes in this slice.
- No runtime, backend, schema, collector, policy engine, or Adaptive Skills integration.
- Resource Observatory preview should come after this QA pass.
- `plans/` remains untracked and untouched.
