### PR TITLE
docs(visual-ops): record Pulso design system bridge

### DIFF
--- a/examples/visual-operations/prototype/README.md
+++ b/examples/visual-operations/prototype/README.md
@@ -56,6 +56,7 @@ Design intent:
 
 - [Prototype iteration plan](iteration-plan.md)
 - [Prototype visual QA pass](visual-qa-pass.md)
+- [Pulso Design System bridge](pulso-design-system-bridge.md)
 - [Refined visual mock](../cockpit-refined-visual-mock.md)
 - [Light wireframe spec](../cockpit-light-wireframe-spec.md)
 - [Static board composition](../cockpit-static-board-composition.md)

--- a/examples/visual-operations/prototype/iteration-plan.md
+++ b/examples/visual-operations/prototype/iteration-plan.md
@@ -23,6 +23,8 @@ This baseline should remain the reference point unless a later design review exp
 
 The first slice has a docs-first QA artifact: [Mission Control Prototype Visual QA Pass](visual-qa-pass.md).
 
+Pulso Design System may be used as a design acceleration reference for future prototype passes. The boundary and recommended adoption path are recorded in [Pulso Design System Bridge](pulso-design-system-bridge.md).
+
 | Slice | Goal | Must preserve | Not included |
 |---|---|---|---|
 | 1. Visual QA pass | Tighten spacing, hierarchy, empty states, responsive behavior, and interaction clarity. | Full-browser shell, side sheet, read-only semantics. | Runtime data, backend, schemas, collectors. |
@@ -51,6 +53,7 @@ A signal can appear visually only when it has a source reference and provenance.
 A future prototype slice is acceptable only if:
 
 - the screen still feels like an operational evidence tool, not a generic dashboard;
+- Pulso alignment, when used, supports operational clarity rather than adding decorative UI polish;
 - the central ledger remains the main workspace;
 - details appear on demand through the inspector or side sheet;
 - every status, metric, alert, and source claim has source refs or explicit absence;

--- a/examples/visual-operations/prototype/pulso-design-system-bridge.md
+++ b/examples/visual-operations/prototype/pulso-design-system-bridge.md
@@ -1,0 +1,73 @@
+# Pulso Design System Bridge
+
+## Purpose
+
+Record how the Mission Control static prototype can use **Pulso Design System** as a visual acceleration reference without changing the prototype boundary.
+
+This is a design-system bridge note, not an implementation dependency.
+
+## Why Pulso helps
+
+Pulso can reduce rework by giving future Mission Control passes a shared basis for:
+
+- spacing rhythm;
+- typography scale;
+- surface and border treatment;
+- state color discipline;
+- component naming;
+- interaction affordances for navigation, filters, cards, and side sheets.
+
+For a designer, this means the next visual passes can focus less on inventing UI primitives and more on the actual Mission Control problem: evidence, source posture, review prompts, and traceability.
+
+## Boundary
+
+Using Pulso as a reference must not introduce:
+
+- a frontend app;
+- a build step;
+- package dependency;
+- runtime data;
+- backend;
+- collector;
+- schema;
+- policy engine;
+- Adaptive Skills integration.
+
+The current prototype remains static HTML/CSS/JS with mock data only.
+
+## Recommended approach
+
+Use Pulso in three gradual steps:
+
+1. **Vocabulary alignment**
+   - Map existing prototype regions to Pulso-like primitives: shell, rail, topbar, card, badge, side sheet, table/ledger row, empty state.
+   - Keep Mission Control names where they carry governance meaning: Work Slice, source refs, trace context, review prompt, unavailable.
+
+2. **Token alignment**
+   - Compare the prototype CSS variables with Pulso tokens for spacing, radius, typography, border, surface, and state color.
+   - Only adopt tokens that preserve the sober operational tone.
+   - Do not import Pulso code in this phase.
+
+3. **Component migration candidate**
+   - If a later phase creates a real frontend prototype, Pulso can become the component source for reusable primitives.
+   - That future step should be a separate implementation plan and PR.
+
+## Mission Control-specific rules
+
+Pulso can standardize the interface, but it must not dilute these rules:
+
+- source records remain authoritative;
+- Mission Control is a read-only projection;
+- lanes are derived presentation, not lifecycle;
+- `unavailable` is neutral;
+- alerts are review prompts, not decisions;
+- every status, alert, metric, and evidence claim needs source refs or explicit absence.
+
+## First practical follow-up
+
+The next safe slice is a **Pulso token comparison pass**:
+
+- inspect Pulso token names and visual primitives;
+- list which ones match the current Mission Control prototype;
+- document any gaps where Mission Control needs a stricter governance-specific treatment;
+- avoid changing the HTML until the mapping is clear.


### PR DESCRIPTION
## What changed
- Added a docs-first Pulso Design System bridge note for the Mission Control prototype.
- Linked the bridge from the prototype README and iteration plan.
- Defined Pulso as a visual acceleration reference, not a dependency or implementation change.

## Why it changed
- The prototype can benefit from Pulso's spacing, typography, surface, state, and component vocabulary.
- Recording the boundary now prevents accidental scope creep into a frontend app, build step, runtime, or dependency.

## How to validate
- Read `examples/visual-operations/prototype/pulso-design-system-bridge.md`.
- Confirm links from `examples/visual-operations/prototype/README.md` and `examples/visual-operations/prototype/iteration-plan.md` resolve.
- `git diff --check`
- `pnpm check:governance`
- `pnpm test`
- `./scripts/check-visual-ops-snapshots.sh`

## Risks, assumptions or follow-ups
- This does not import Pulso code or tokens yet.
- This does not add a frontend app, backend, runtime, collector, schema, policy engine, or Adaptive Skills integration.
- Recommended follow-up: a Pulso token comparison pass before changing prototype HTML.
- `plans/` remains untracked and untouched.
