### PR TITLE
docs(visual-ops): compare Pulso tokens for prototype

### DIFF
--- a/examples/visual-operations/prototype/README.md
+++ b/examples/visual-operations/prototype/README.md
@@ -57,6 +57,7 @@ Design intent:
 - [Prototype iteration plan](iteration-plan.md)
 - [Prototype visual QA pass](visual-qa-pass.md)
 - [Pulso Design System bridge](pulso-design-system-bridge.md)
+- [Pulso token comparison pass](pulso-token-comparison.md)
 - [Refined visual mock](../cockpit-refined-visual-mock.md)
 - [Light wireframe spec](../cockpit-light-wireframe-spec.md)
 - [Static board composition](../cockpit-static-board-composition.md)

--- a/examples/visual-operations/prototype/iteration-plan.md
+++ b/examples/visual-operations/prototype/iteration-plan.md
@@ -23,14 +23,15 @@ This baseline should remain the reference point unless a later design review exp
 
 The first slice has a docs-first QA artifact: [Mission Control Prototype Visual QA Pass](visual-qa-pass.md).
 
-Pulso Design System may be used as a design acceleration reference for future prototype passes. The boundary and recommended adoption path are recorded in [Pulso Design System Bridge](pulso-design-system-bridge.md).
+Pulso Design System may be used as a design acceleration reference for future prototype passes. The boundary and recommended adoption path are recorded in [Pulso Design System Bridge](pulso-design-system-bridge.md), followed by the docs-first [Pulso token comparison pass](pulso-token-comparison.md).
 
 | Slice | Goal | Must preserve | Not included |
 |---|---|---|---|
 | 1. Visual QA pass | Tighten spacing, hierarchy, empty states, responsive behavior, and interaction clarity. | Full-browser shell, side sheet, read-only semantics. | Runtime data, backend, schemas, collectors. |
-| 2. Observability preview | Explore a small Resource Observatory preview for sourced operational signals. | `unknown`/`unavailable` for missing sources; provenance on every metric. | Real telemetry collection or generated estimates. |
-| 3. Source detail depth | Improve inspector treatment for source refs, trace, confidence, and boundary copy. | Metadata-first privacy and source authority. | Prompt bodies, secrets, restricted content. |
-| 4. Review workflow readability | Clarify how human review, conflicts, and unavailable telemetry are scanned. | Alerts as review prompts, not decisions. | Approve/reject commands or lifecycle mutation. |
+| 2. Pulso token alignment | Align prototype CSS vocabulary with Pulso tokens before deeper UI changes. | Static HTML, local aliases, Mission Control-specific governance semantics. | Pulso package import, app build step, shared dependency. |
+| 3. Observability preview | Explore a small Resource Observatory preview for sourced operational signals. | `unknown`/`unavailable` for missing sources; provenance on every metric. | Real telemetry collection or generated estimates. |
+| 4. Source detail depth | Improve inspector treatment for source refs, trace, confidence, and boundary copy. | Metadata-first privacy and source authority. | Prompt bodies, secrets, restricted content. |
+| 5. Review workflow readability | Clarify how human review, conflicts, and unavailable telemetry are scanned. | Alerts as review prompts, not decisions. | Approve/reject commands or lifecycle mutation. |
 
 ## Operational intelligence candidates
 

--- a/examples/visual-operations/prototype/pulso-design-system-bridge.md
+++ b/examples/visual-operations/prototype/pulso-design-system-bridge.md
@@ -71,3 +71,5 @@ The next safe slice is a **Pulso token comparison pass**:
 - list which ones match the current Mission Control prototype;
 - document any gaps where Mission Control needs a stricter governance-specific treatment;
 - avoid changing the HTML until the mapping is clear.
+
+That comparison is recorded in [Pulso token comparison pass](pulso-token-comparison.md).

--- a/examples/visual-operations/prototype/pulso-token-comparison.md
+++ b/examples/visual-operations/prototype/pulso-token-comparison.md
@@ -1,0 +1,110 @@
+# Pulso Token Comparison Pass
+
+## Purpose
+
+Compare the current Mission Control static prototype with **Pulso Design System v3** before changing the prototype HTML/CSS.
+
+This pass is intentionally docs-first. It does not import Pulso, add a build step, introduce a package dependency, or turn the static prototype into a frontend app.
+
+## Sources reviewed
+
+- Pulso `DESIGN.md`
+- Pulso `src/app/globals.css`
+- Mission Control `examples/visual-operations/prototype/mission-control-static.html`
+
+## Current prototype token posture
+
+The prototype currently uses a small local token set:
+
+| Area | Current prototype posture |
+|---|---|
+| Typography | Inter/system sans plus local monospace stack. |
+| Surfaces | Dark operational palette: `--bg`, `--shell`, `--panel`, `--panel-2`, `--panel-3`. |
+| Lines | Blue-gray translucent borders: `--line`, `--line-strong`. |
+| State colors | Local evidence colors: `--critical`, `--review`, `--stable`, `--info`, `--violet`. |
+| Radius | Larger product-shell radius: `14px`; smaller card radius: `9px`. |
+| Layout | Static full-browser shell with collapsible rail and side sheet. |
+
+This local system is useful for speed, but it is not yet aligned to the broader design language.
+
+## Pulso tokens that fit Mission Control
+
+| Pulso area | Tokens / rules | Fit for Mission Control | Recommendation |
+|---|---|---|---|
+| Type families | `--font-pulso-sans`, `--font-pulso-mono` | Good fit. Manrope + IBM Plex Mono can make the prototype feel more systemized and less generic. | Adopt in a future HTML pass if local font loading is acceptable. |
+| Type scale | `--text-display`, `--text-h1`, `--text-h2`, `--text-body`, `--text-support`, `--text-label`, `--text-micro` | Strong fit. The prototype already uses hierarchy similar to Pulso. | Map local sizes to Pulso names before changing values. |
+| Kicker tracking | `--tracking-kicker: 0.12em` | Strong fit for labels like `Evidence Ledger`, `Human Review`, `Source Refs`. | Adopt. |
+| Radius | `--radius-sm`, `--radius-md`, `--radius-lg`, `--radius-xl` | Good fit, but Mission Control should stay slightly sharper than commercial SaaS. | Prefer `md/lg`; avoid over-rounded surfaces. |
+| Spacing | `--space-3`, `--space-4`, `--space-5`, `--space-6` | Good fit for card, rail, and inspector spacing. | Adopt selectively. |
+| Rhythm | `--rhythm-cadence-tight`, `--rhythm-cadence-beat`, `--rhythm-cadence-breath` | Strong fit for designer-facing consistency. | Use to tune sections, not to create hero spacing. |
+| Density | `compact`, `comfortable`, `spacious` density tokens | Strong fit. Mission Control needs dense but readable operational mode. | Use `compact` or a Mission Control-specific compact derivative. |
+| Borders | `--border`, `--border-strong`, sidebar border tokens | Strong fit with current line-based design. | Adopt border discipline before adding shadows. |
+| Shadows | nearly invisible Pulso shadows | Good fit. Current prototype should remain low-glow. | Keep borders as primary structure. |
+| AI markers | `--ai-marker-border`, `--ai-marker-bg-mix` | Conditional fit. Useful for AI-assisted/source-derived content, but can imply AI authority if overused. | Use only where provenance is explicit. |
+
+## Pulso tokens that need caution
+
+| Area | Why caution is needed | Mission Control rule |
+|---|---|---|
+| Brand purple | Pulso primary can make the screen look like branded SaaS if over-applied. | Use as focus/navigation accent only, not as evidence state. |
+| Light theme defaults | Mission Control’s accepted direction is dark, sober, and operational. | Do not switch the prototype to Pulso light defaults in this phase. |
+| AI marker styling | AI-origin decoration can be mistaken for trust or automation authority. | AI markers must mean “source/activation trace exists,” not “AI decided.” |
+| Success color | Green can imply approval or completion. | Use stable/closed carefully; never imply a gate passed without source refs. |
+| Warning/destructive colors | Can make `unavailable` look like failure. | `unavailable` remains neutral. |
+| Large display typography | Pulso display tokens can create too much hero energy. | Keep titles compact and operational. |
+
+## Proposed token mapping
+
+| Mission Control local token | Pulso-aligned candidate | Notes |
+|---|---|---|
+| `--sans` | `--font-pulso-sans` | Improves DS alignment; keep fallback stack. |
+| `--mono` | `--font-pulso-mono` | Useful for source refs, trace IDs, event timestamps. |
+| title sizes | `--text-display`, `--text-h1` | Avoid `--text-display-lg` for cockpit title. |
+| card title/body/meta | `--text-h2`, `--text-body`, `--text-support`, `--text-micro` | Good direct mapping. |
+| label tracking | `--tracking-kicker` | Good direct mapping. |
+| `--radius-sm` | `--radius-md` or `--radius-lg` | Current card radius is close to Pulso `lg`; review visually. |
+| `--radius` | `--radius-xl` | Shell can keep larger radius; avoid adding extra rounding inside. |
+| card padding | `--density-pad-card` compact derivative | Mission Control likely needs compact density. |
+| row/metadata spacing | `--density-pad-row`, `--space-3`, `--space-4` | Good for ledger rows and inspector sections. |
+| section spacing | `--rhythm-cadence-beat` | Good for grouping within ledger and inspector. |
+| `--line` | Pulso `--border` adapted to current dark palette | Border-first structure should remain. |
+| `--line-strong` | Pulso `--border-strong` adapted to current dark palette | Use for active card and side sheet edges. |
+| `--violet` | Pulso `--primary` | Navigation/focus only. |
+| `--critical` | Pulso destructive/critical family | Review carefully for accessibility and alarm fatigue. |
+| `--review` | Pulso warning/attention family | Alerts are review prompts, not decisions. |
+| `--stable` | Pulso success/stable family | Stable must still show source refs. |
+| `--info` | Pulso evidence/info family | Best candidate for source refs and trace metadata. |
+
+## Mission Control-specific gaps
+
+Pulso does not fully answer these Mission Control semantics yet:
+
+- `unavailable` as a neutral state, not warning/error;
+- source-authority treatment for evidence refs;
+- derived-lane treatment for Work Slice posture;
+- review prompt vs decision distinction;
+- confidence/provenance labels that avoid scoring theater;
+- side-sheet inspection language for read-only evidence.
+
+These should remain Mission Control-specific tokens or component rules until Pulso has explicit primitives for them.
+
+## Recommended HTML pass after this
+
+The next prototype edit can safely:
+
+1. rename local CSS variables toward Pulso vocabulary;
+2. introduce Pulso type and spacing aliases locally inside the static file;
+3. keep the current dark palette unless a designer chooses a Pulso-derived dark palette;
+4. preserve evidence-state colors and neutral `unavailable`;
+5. avoid importing any package or external build pipeline.
+
+## Non-goals
+
+This pass does not:
+
+- import Pulso code;
+- add Tailwind;
+- add fonts as a runtime dependency;
+- create a shared package;
+- change prototype HTML behavior;
+- add backend, runtime, collector, schema, policy engine, or Adaptive Skills integration.


### PR DESCRIPTION
## What changed
- Added a docs-first Pulso token comparison pass for the Mission Control static prototype.
- Mapped current prototype tokens to Pulso v3 candidates for typography, spacing, radius, borders, density, state color, and AI markers.
- Documented caution areas where Pulso should not dilute Mission Control governance semantics.
- Updated the prototype README, iteration plan, and Pulso bridge note with links to the comparison.

## Why it changed
- Pulso can help reduce visual rework, but the prototype needs a clear boundary before adopting tokens or components.
- This gives designers and reviewers a shared map for what can be aligned safely and what must remain Mission Control-specific.

## How to validate
- Read `examples/visual-operations/prototype/pulso-token-comparison.md`.
- Confirm links from the prototype README, iteration plan, and Pulso bridge resolve.
- `git diff --check`
- `pnpm check:governance`
- `pnpm test`
- `./scripts/check-visual-ops-snapshots.sh`

## Risks, assumptions or follow-ups
- This does not change the prototype UI yet.
- This does not import Pulso code, Tailwind, fonts, packages, or a build step.
- Follow-up: apply local Pulso-style aliases inside `mission-control-static.html` while preserving static/read-only boundaries.
- `plans/` remains untracked and untouched.
