### PR TITLE
docs(visual-ops): add Pulso local aliases to prototype

### DIFF
--- a/examples/visual-operations/prototype/mission-control-static.html
+++ b/examples/visual-operations/prototype/mission-control-static.html
@@ -6,26 +6,67 @@
   <title>AletheIA Mission Control — Static Prototype</title>
   <style>
     :root {
-      --bg: #090c12;
-      --shell: #0d1119;
-      --panel: #10151f;
-      --panel-2: #141a25;
-      --panel-3: #181f2b;
-      --line: rgba(174, 185, 207, 0.14);
-      --line-strong: rgba(174, 185, 207, 0.24);
-      --text: #e7ebf2;
-      --text-soft: #b3bac8;
-      --text-muted: #727b8e;
-      --critical: #e17063;
-      --review: #d6a35e;
-      --stable: #84b99a;
-      --info: #85b7d3;
-      --violet: #8b6ee8;
-      --radius: 14px;
-      --radius-sm: 9px;
+      /* Pulso-inspired local aliases: static prototype only, no package import. */
+      --font-pulso-sans: Manrope, Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --font-pulso-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      --text-display: 1.36rem;
+      --text-h1: 1.22rem;
+      --text-h2: 0.91rem;
+      --text-body: 0.82rem;
+      --text-support: 0.76rem;
+      --text-label: 0.68rem;
+      --text-micro: 0.62rem;
+      --tracking-kicker: 0.12em;
+      --space-2: 8px;
+      --space-3: 12px;
+      --space-4: 16px;
+      --space-5: 20px;
+      --space-6: 24px;
+      --rhythm-cadence-tight: 12px;
+      --rhythm-cadence-beat: 20px;
+      --rhythm-cadence-breath: 40px;
+      --radius-md: 8px;
+      --radius-lg: 10px;
+      --radius-xl: 14px;
+
+      /* Mission Control semantic aliases. */
+      --mc-surface-page: #090c12;
+      --mc-surface-shell: #0d1119;
+      --mc-surface-panel: #10151f;
+      --mc-surface-panel-raised: #141a25;
+      --mc-surface-panel-strong: #181f2b;
+      --mc-border: rgba(174, 185, 207, 0.14);
+      --mc-border-strong: rgba(174, 185, 207, 0.24);
+      --mc-text: #e7ebf2;
+      --mc-text-support: #b3bac8;
+      --mc-text-muted: #727b8e;
+      --mc-critical: #e17063;
+      --mc-review: #d6a35e;
+      --mc-stable: #84b99a;
+      --mc-evidence: #85b7d3;
+      --mc-primary: #8b6ee8;
+
+      /* Backward-compatible prototype tokens. */
+      --bg: var(--mc-surface-page);
+      --shell: var(--mc-surface-shell);
+      --panel: var(--mc-surface-panel);
+      --panel-2: var(--mc-surface-panel-raised);
+      --panel-3: var(--mc-surface-panel-strong);
+      --line: var(--mc-border);
+      --line-strong: var(--mc-border-strong);
+      --text: var(--mc-text);
+      --text-soft: var(--mc-text-support);
+      --text-muted: var(--mc-text-muted);
+      --critical: var(--mc-critical);
+      --review: var(--mc-review);
+      --stable: var(--mc-stable);
+      --info: var(--mc-evidence);
+      --violet: var(--mc-primary);
+      --radius: var(--radius-xl);
+      --radius-sm: var(--radius-lg);
       --rail-width: 72px;
-      --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      --sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --mono: var(--font-pulso-mono);
+      --sans: var(--font-pulso-sans);
       color-scheme: dark;
     }
 
@@ -69,8 +110,8 @@
     .side-rail {
       display: grid;
       grid-template-rows: auto 1fr auto;
-      gap: 18px;
-      padding: 16px 10px;
+      gap: var(--rhythm-cadence-beat);
+      padding: var(--space-4) var(--space-3);
       border-right: 1px solid var(--line);
       background: #0a0e15;
       min-width: 0;
@@ -79,13 +120,13 @@
 
     .rail-top {
       display: grid;
-      gap: 12px;
+      gap: var(--space-3);
     }
 
     .mark-row {
       display: flex;
       align-items: center;
-      gap: 10px;
+      gap: var(--space-3);
       min-width: 0;
     }
 
@@ -95,9 +136,9 @@
       display: grid;
       place-items: center;
       border: 1px solid rgba(139, 110, 232, 0.42);
-      border-radius: 10px;
+      border-radius: var(--radius-lg);
       color: #c9bcff;
-      font: 800 0.75rem var(--mono);
+      font: 800 var(--text-label) var(--mono);
       background: rgba(139, 110, 232, 0.08);
       flex: 0 0 auto;
     }
@@ -112,7 +153,7 @@
     .rail-brand strong {
       display: block;
       color: var(--text);
-      font-size: 0.84rem;
+      font-size: var(--text-body);
       line-height: 1.1;
     }
 
@@ -120,7 +161,7 @@
       display: block;
       margin-top: 2px;
       color: var(--text-muted);
-      font: 680 0.62rem var(--mono);
+      font: 680 var(--text-micro) var(--mono);
       text-transform: uppercase;
       letter-spacing: 0.08em;
     }
@@ -131,13 +172,13 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 8px;
+      gap: var(--space-2);
       border: 1px solid var(--line);
-      border-radius: 9px;
+      border-radius: var(--radius-lg);
       background: transparent;
       color: var(--text-muted);
       cursor: pointer;
-      font: 720 0.68rem var(--mono);
+      font: 720 var(--text-label) var(--mono);
       text-transform: uppercase;
       letter-spacing: 0.05em;
     }
@@ -154,7 +195,7 @@
 
     .rail-stack {
       display: grid;
-      gap: 8px;
+      gap: var(--space-2);
       align-content: start;
       min-width: 0;
     }
@@ -165,19 +206,19 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 10px;
-      border-radius: 11px;
+      gap: var(--space-3);
+      border-radius: var(--radius-lg);
       background: transparent;
       color: var(--text-muted);
-      font: 760 0.66rem var(--mono);
+      font: 760 var(--text-label) var(--mono);
       cursor: pointer;
       text-align: left;
     }
 
-    .nav-expanded .rail-button { justify-content: flex-start; padding: 0 10px; }
+    .nav-expanded .rail-button { justify-content: flex-start; padding: 0 var(--space-3); }
 
     .rail-button-label { display: none; }
-    .nav-expanded .rail-button-label { display: inline; font-family: var(--sans); font-size: 0.82rem; font-weight: 640; letter-spacing: -0.01em; }
+    .nav-expanded .rail-button-label { display: inline; font-family: var(--sans); font-size: var(--text-body); font-weight: 640; letter-spacing: -0.01em; }
 
     .rail-button.active,
     .rail-button:hover,
@@ -197,10 +238,10 @@
     .topbar {
       display: grid;
       grid-template-columns: minmax(0, 1fr) minmax(240px, 500px) auto;
-      gap: 16px;
+      gap: var(--space-4);
       align-items: center;
       min-height: 72px;
-      padding: 14px 24px;
+      padding: 14px var(--space-6);
       border-bottom: 1px solid var(--line);
       background: rgba(13, 17, 25, 0.98);
     }
@@ -208,13 +249,13 @@
     .product-title {
       display: flex;
       align-items: baseline;
-      gap: 12px;
+      gap: var(--space-3);
       min-width: 0;
     }
 
     h1 {
       margin: 0;
-      font-size: 1.36rem;
+      font-size: var(--text-display);
       font-weight: 720;
       letter-spacing: -0.035em;
     }
@@ -226,33 +267,33 @@
 
     .mode-label {
       color: var(--stable);
-      font-size: 0.68rem;
+      font-size: var(--text-label);
       text-transform: uppercase;
     }
 
     .search-box {
       display: flex;
       align-items: center;
-      gap: 10px;
+      gap: var(--space-3);
       min-width: 0;
       height: 38px;
       border: 1px solid var(--line);
-      border-radius: 10px;
+      border-radius: var(--radius-lg);
       background: #0b1018;
       color: var(--text-muted);
-      padding: 0 12px;
-      font-size: 0.82rem;
+      padding: 0 var(--space-3);
+      font-size: var(--text-body);
     }
 
     .search-box span:first-child {
-      font: 780 0.72rem var(--mono);
+      font: 780 var(--text-label) var(--mono);
       color: var(--text-muted);
     }
 
     .authority {
       text-align: right;
       color: var(--text-muted);
-      font-size: 0.72rem;
+      font-size: var(--text-label);
       line-height: 1.35;
     }
 
@@ -273,7 +314,7 @@
     .main-board {
       min-width: 0;
       min-height: 0;
-      padding: 24px;
+      padding: var(--space-6);
       overflow: auto;
     }
 
@@ -312,7 +353,7 @@
     .inspector.open { transform: translateX(0); }
 
     .inspector-header {
-      padding: 22px;
+      padding: var(--space-5);
       border-bottom: 1px solid var(--line);
     }
 
@@ -320,14 +361,14 @@
       display: flex;
       align-items: start;
       justify-content: space-between;
-      gap: 14px;
+      gap: var(--space-4);
     }
 
     .sheet-close {
       width: 34px;
       height: 34px;
       border: 1px solid var(--line);
-      border-radius: 9px;
+      border-radius: var(--radius-lg);
       background: transparent;
       color: var(--text-muted);
       cursor: pointer;
@@ -342,24 +383,24 @@
     }
 
     .inspector-body {
-      padding: 22px;
+      padding: var(--space-5);
       overflow: auto;
     }
 
     .section-head {
       display: grid;
       grid-template-columns: minmax(0, 1fr) auto;
-      gap: 16px;
+      gap: var(--space-4);
       align-items: end;
-      margin-bottom: 18px;
+      margin-bottom: var(--rhythm-cadence-beat);
     }
 
     .eyebrow {
       margin: 0 0 7px;
       color: var(--text-muted);
-      font: 720 0.7rem var(--mono);
+      font: 720 var(--text-label) var(--mono);
       text-transform: uppercase;
-      letter-spacing: 0.09em;
+      letter-spacing: var(--tracking-kicker);
     }
 
     .section-title {
@@ -374,13 +415,13 @@
       margin: 8px 0 0;
       max-width: 760px;
       color: var(--text-muted);
-      font-size: 0.88rem;
+      font-size: var(--text-h2);
       line-height: 1.45;
     }
 
     .filters {
       display: flex;
-      gap: 8px;
+      gap: var(--space-2);
       flex-wrap: wrap;
       justify-content: flex-end;
     }
@@ -388,11 +429,11 @@
     .filter-button {
       height: 32px;
       border: 1px solid var(--line);
-      border-radius: 8px;
+      border-radius: var(--radius-md);
       background: transparent;
       color: var(--text-muted);
-      padding: 0 10px;
-      font-size: 0.76rem;
+      padding: 0 var(--space-3);
+      font-size: var(--text-support);
       cursor: pointer;
     }
 
@@ -408,13 +449,13 @@
     .metrics-row {
       display: grid;
       grid-template-columns: repeat(4, minmax(0, 1fr));
-      gap: 10px;
-      margin-bottom: 18px;
+      gap: var(--space-3);
+      margin-bottom: var(--rhythm-cadence-beat);
     }
 
     .metric {
       min-height: 76px;
-      padding: 14px;
+      padding: var(--space-4);
       border: 1px solid var(--line);
       border-radius: var(--radius-sm);
       background: rgba(20, 26, 37, 0.64);
@@ -429,7 +470,7 @@
 
     .metric-label {
       color: var(--text-muted);
-      font-size: 0.66rem;
+      font-size: var(--text-micro);
       text-transform: uppercase;
     }
 
@@ -443,9 +484,9 @@
     .ledger-toolbar {
       display: grid;
       grid-template-columns: minmax(0, 1fr) auto;
-      gap: 12px;
+      gap: var(--space-3);
       align-items: center;
-      padding: 13px 14px;
+      padding: 13px var(--space-4);
       border-bottom: 1px solid var(--line);
       background: rgba(13, 17, 25, 0.88);
     }
@@ -453,10 +494,10 @@
     .ledger-title {
       display: flex;
       align-items: center;
-      gap: 10px;
+      gap: var(--space-3);
       min-width: 0;
       color: var(--text-soft);
-      font-size: 0.86rem;
+      font-size: var(--text-body);
       font-weight: 680;
     }
 
@@ -496,9 +537,9 @@
       z-index: 2;
       display: flex;
       justify-content: space-between;
-      gap: 10px;
+      gap: var(--space-3);
       align-items: center;
-      padding: 13px 14px;
+      padding: 13px var(--space-4);
       border-bottom: 1px solid var(--line);
       background: #10151f;
     }
@@ -506,16 +547,16 @@
     .lane-name {
       display: flex;
       align-items: center;
-      gap: 8px;
+      gap: var(--space-2);
       min-width: 0;
-      font-size: 0.82rem;
+      font-size: var(--text-body);
       color: var(--text-soft);
       font-weight: 680;
     }
 
     .lane-count {
       color: var(--text-muted);
-      font-size: 0.75rem;
+      font-size: var(--text-label);
     }
 
     .state-dot {
@@ -533,19 +574,19 @@
 
     .slice-list {
       display: grid;
-      gap: 8px;
-      padding: 10px;
+      gap: var(--space-2);
+      padding: var(--space-3);
     }
 
     .slice-card {
       width: 100%;
       display: grid;
-      gap: 10px;
+      gap: var(--space-3);
       text-align: left;
       border: 1px solid var(--line);
       border-radius: var(--radius-sm);
       background: rgba(24, 31, 43, 0.68);
-      padding: 12px;
+      padding: var(--space-3);
       cursor: pointer;
       transition: border-color 140ms ease, background 140ms ease, transform 140ms ease;
     }
@@ -568,16 +609,16 @@
     .slice-meta {
       display: flex;
       justify-content: space-between;
-      gap: 8px;
+      gap: var(--space-2);
       align-items: center;
       color: var(--text-muted);
-      font: 680 0.66rem var(--mono);
+      font: 680 var(--text-micro) var(--mono);
     }
 
     .slice-title {
       margin: 0;
       color: var(--text);
-      font-size: 0.91rem;
+      font-size: var(--text-h2);
       line-height: 1.25;
       letter-spacing: -0.018em;
       font-weight: 700;
@@ -586,14 +627,14 @@
     .slice-copy {
       margin: 0;
       color: var(--text-muted);
-      font-size: 0.76rem;
+      font-size: var(--text-support);
       line-height: 1.36;
     }
 
     .slice-footer {
       display: flex;
       justify-content: space-between;
-      gap: 10px;
+      gap: var(--space-3);
       align-items: center;
       padding-top: 9px;
       border-top: 1px solid var(--line);
@@ -622,34 +663,34 @@
 
     .confidence {
       color: var(--text-muted);
-      font: 680 0.62rem var(--mono);
+      font: 680 var(--text-micro) var(--mono);
       white-space: nowrap;
     }
 
     .event-strip {
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 10px;
-      margin-top: 18px;
+      gap: var(--space-3);
+      margin-top: var(--rhythm-cadence-beat);
     }
 
     .event-card {
       border: 1px solid var(--line);
       border-radius: var(--radius-sm);
       background: rgba(16, 21, 31, 0.72);
-      padding: 13px;
+      padding: var(--space-3);
     }
 
     .event-card p {
       margin: 6px 0 0;
       color: var(--text-muted);
-      font-size: 0.76rem;
+      font-size: var(--text-support);
       line-height: 1.36;
     }
 
     .inspector-title {
       margin: 6px 0 0;
-      font-size: 1.22rem;
+      font-size: var(--text-h1);
       line-height: 1.12;
       letter-spacing: -0.035em;
       font-weight: 720;
@@ -658,12 +699,12 @@
     .inspector-copy {
       margin: 10px 0 0;
       color: var(--text-muted);
-      font-size: 0.82rem;
+      font-size: var(--text-body);
       line-height: 1.45;
     }
 
     .inspector-section {
-      padding: 18px 0;
+      padding: var(--rhythm-cadence-beat) 0;
       border-bottom: 1px solid var(--line);
     }
 
@@ -672,7 +713,7 @@
     .inspector-section h3 {
       margin: 0 0 10px;
       color: var(--text-soft);
-      font-size: 0.78rem;
+      font-size: var(--text-support);
       font-weight: 720;
       text-transform: uppercase;
       letter-spacing: 0.07em;
@@ -680,50 +721,50 @@
 
     .kv {
       display: grid;
-      gap: 9px;
+      gap: var(--space-3);
     }
 
     .kv-row {
       display: grid;
       grid-template-columns: 92px 1fr;
-      gap: 12px;
+      gap: var(--space-3);
       color: var(--text-soft);
-      font-size: 0.8rem;
+      font-size: var(--text-body);
     }
 
     .kv-row span:first-child {
       color: var(--text-muted);
       font-family: var(--mono);
-      font-size: 0.68rem;
+      font-size: var(--text-label);
       text-transform: uppercase;
     }
 
     .trace-list {
       display: grid;
-      gap: 12px;
+      gap: var(--space-3);
     }
 
     .trace-item {
       display: grid;
       grid-template-columns: 42px 1fr;
-      gap: 10px;
+      gap: var(--space-3);
       color: var(--text-muted);
-      font-size: 0.76rem;
+      font-size: var(--text-support);
       line-height: 1.35;
     }
 
     .trace-time {
       color: var(--text-muted);
-      font: 680 0.66rem var(--mono);
+      font: 680 var(--text-micro) var(--mono);
     }
 
     .boundary-note {
       border: 1px solid rgba(132, 185, 154, 0.26);
       border-radius: var(--radius-sm);
       background: rgba(132, 185, 154, 0.045);
-      padding: 12px;
+      padding: var(--space-3);
       color: #bdd7c7;
-      font-size: 0.78rem;
+      font-size: var(--text-support);
       line-height: 1.42;
     }
 
@@ -731,17 +772,17 @@
     .filter-summary {
       display: flex;
       align-items: center;
-      gap: 8px;
+      gap: var(--space-2);
       color: var(--text-muted);
-      font: 680 0.68rem var(--mono);
+      font: 680 var(--text-label) var(--mono);
       white-space: nowrap;
     }
 
     .card-action {
       color: var(--text-soft);
-      font: 720 0.62rem var(--mono);
+      font: 720 var(--text-micro) var(--mono);
       text-transform: uppercase;
-      letter-spacing: 0.07em;
+      letter-spacing: var(--tracking-kicker);
       white-space: nowrap;
     }
 
@@ -753,7 +794,7 @@
 
     .empty-lane {
       display: none;
-      margin: 10px;
+      margin: var(--space-3);
       min-height: 118px;
       place-items: center;
       border: 1px dashed var(--line);
@@ -761,8 +802,8 @@
       background: rgba(174, 185, 207, 0.025);
       color: var(--text-muted);
       text-align: center;
-      padding: 16px;
-      font-size: 0.78rem;
+      padding: var(--space-4);
+      font-size: var(--text-support);
       line-height: 1.42;
     }
 

--- a/examples/visual-operations/prototype/pulso-token-comparison.md
+++ b/examples/visual-operations/prototype/pulso-token-comparison.md
@@ -98,6 +98,18 @@ The next prototype edit can safely:
 4. preserve evidence-state colors and neutral `unavailable`;
 5. avoid importing any package or external build pipeline.
 
+## HTML alias pass applied
+
+The first HTML pass applied this recommendation by adding local aliases inside `mission-control-static.html`:
+
+- Pulso-inspired local type aliases: `--font-pulso-sans`, `--font-pulso-mono`, `--text-*`;
+- Pulso-inspired spacing/rhythm aliases: `--space-*`, `--rhythm-cadence-*`;
+- Pulso-inspired radius aliases: `--radius-md`, `--radius-lg`, `--radius-xl`;
+- Mission Control semantic aliases: `--mc-surface-*`, `--mc-border*`, `--mc-text*`, `--mc-critical`, `--mc-review`, `--mc-stable`, `--mc-evidence`, `--mc-primary`;
+- backward-compatible prototype tokens pointing to those aliases.
+
+This keeps the prototype static and local while making later visual tuning easier.
+
 ## Non-goals
 
 This pass does not:


### PR DESCRIPTION
## What changed
- Added Pulso-inspired local CSS aliases inside `mission-control-static.html`.
- Added Mission Control semantic aliases for surfaces, borders, text, evidence states, and primary accent.
- Kept backward-compatible prototype tokens pointing to the new local aliases.
- Documented the applied alias pass in the Pulso token comparison note.

## Why it changed
- This lets the prototype start speaking a Pulso-like visual vocabulary without importing Pulso or creating a frontend app.
- It makes future visual tuning easier while preserving the accepted Evidence Ledger + Inspector direction.

## How to validate
- Open `examples/visual-operations/prototype/mission-control-static.html` locally.
- Confirm the prototype still behaves as a static read-only surface.
- Confirm filters, nav expand/collapse, and inspector still work.
- `git diff --check`
- `pnpm check:governance`
- `pnpm test`
- `./scripts/check-visual-ops-snapshots.sh`

## Risks, assumptions or follow-ups
- The font aliases reference local/fallback font stacks only; no external font import was added.
- This is still static HTML/CSS/JS with mock data only.
- No Pulso package, Tailwind, build step, backend, runtime, collector, schema, policy engine, or Adaptive Skills integration was added.
- Follow-up: visual review of whether Manrope/IBM Plex Mono are desirable if available locally.
- `plans/` remains untracked and untouched.
