### PR TITLE
docs(visual-ops): clarify prototype review workflow

### DIFF
--- a/examples/visual-operations/prototype/iteration-plan.md
+++ b/examples/visual-operations/prototype/iteration-plan.md
@@ -33,6 +33,8 @@ Pulso Design System may be used as a design acceleration reference for future pr
 | 4. Source detail depth | Improve inspector treatment for source refs, trace, confidence, and boundary copy. | Metadata-first privacy and source authority. | Prompt bodies, secrets, restricted content. |
 | 5. Review workflow readability | Clarify how human review, conflicts, and unavailable telemetry are scanned. | Alerts as review prompts, not decisions. | Approve/reject commands or lifecycle mutation. |
 
+The first review workflow readability pass is represented in the prototype as a compact review-flow rail. It explains review prompt, conflict, source gap, and stable derived postures without adding commands or lifecycle mutation.
+
 ## Operational intelligence candidates
 
 Future Resource Observatory views may monitor:

--- a/examples/visual-operations/prototype/mission-control-static.html
+++ b/examples/visual-operations/prototype/mission-control-static.html
@@ -478,6 +478,61 @@
       text-transform: uppercase;
     }
 
+    .review-flow {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: var(--space-2);
+      margin-bottom: var(--rhythm-cadence-beat);
+      padding: var(--space-3);
+      border: 1px solid color-mix(in oklab, var(--mc-border) 88%, transparent);
+      border-radius: var(--radius);
+      background: color-mix(in oklab, var(--mc-surface-panel) 46%, transparent);
+    }
+
+    .review-step {
+      position: relative;
+      display: grid;
+      gap: 6px;
+      min-width: 0;
+      padding: 12px;
+      border: 1px solid color-mix(in oklab, var(--mc-border) 72%, transparent);
+      border-radius: var(--radius-ledger);
+      background: color-mix(in oklab, var(--mc-surface-page) 42%, transparent);
+    }
+
+    .review-step::before {
+      content: "";
+      width: 26px;
+      height: 2px;
+      border-radius: 999px;
+      background: var(--text-muted);
+    }
+
+    .review-step.is-review::before { background: var(--review); }
+    .review-step.is-conflict::before { background: var(--critical); }
+    .review-step.is-gap::before { background: var(--info); }
+    .review-step.is-stable::before { background: var(--stable); }
+
+    .review-step span {
+      color: var(--text-muted);
+      font: 760 var(--text-micro) var(--mono);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .review-step strong {
+      color: var(--text-soft);
+      font-size: var(--text-support);
+      line-height: 1.25;
+    }
+
+    .review-step p {
+      margin: 0;
+      color: var(--text-muted);
+      font-size: var(--text-support);
+      line-height: 1.35;
+    }
+
     .ledger-shell {
       border: 1px solid var(--line);
       border-radius: var(--radius);
@@ -1060,7 +1115,7 @@
     @media (max-width: 1180px) {
       .mission-shell.nav-expanded { --rail-width: 220px; }
       .metrics-row, .event-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-      .observatory-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .observatory-grid, .review-flow { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       .topbar { grid-template-columns: 1fr; align-items: start; }
       .authority { text-align: left; }
     }
@@ -1073,7 +1128,7 @@
       .section-head { grid-template-columns: 1fr; }
       .filters { justify-content: flex-start; }
       .filter-summary { width: 100%; }
-      .metrics-row, .event-strip, .observatory-grid { grid-template-columns: 1fr; }
+      .metrics-row, .event-strip, .observatory-grid, .review-flow { grid-template-columns: 1fr; }
       .main-board { padding: 16px; }
       .board-grid { min-width: 760px; }
       .inspector { width: min(390px, 100vw); }
@@ -1137,6 +1192,13 @@
               <div class="metric"><div class="metric-label">Critical prompt</div><div class="metric-value" style="color: var(--critical)">1</div></div>
               <div class="metric"><div class="metric-label">Source gaps</div><div class="metric-value" style="color: var(--info)">3</div></div>
               <div class="metric"><div class="metric-label">Closed stable</div><div class="metric-value" style="color: var(--stable)">2</div></div>
+            </section>
+
+            <section class="review-flow" aria-label="Review workflow readability preview">
+              <article class="review-step is-review"><span>Review prompt</span><strong>Requires human confirmation</strong><p>Prompt for review; not an automated decision.</p></article>
+              <article class="review-step is-conflict"><span>Conflict</span><strong>Evidence disagrees</strong><p>Reconcile sources before trusting posture.</p></article>
+              <article class="review-step is-gap"><span>Source gap</span><strong>Use unavailable</strong><p>Missing telemetry stays neutral until sourced.</p></article>
+              <article class="review-step is-stable"><span>Stable derived</span><strong>Still traceable</strong><p>Stable posture remains linked to source refs.</p></article>
             </section>
 
             <section class="ledger-shell" aria-label="Work Slice evidence board">

--- a/examples/visual-operations/prototype/pulso-token-comparison.md
+++ b/examples/visual-operations/prototype/pulso-token-comparison.md
@@ -173,6 +173,17 @@ The prototype now includes a compact Resource Observatory preview:
 
 This is a visual preview only. It does not collect telemetry, calculate cost, or create a runtime observability layer.
 
+## Review workflow readability applied
+
+The prototype now includes a compact review-flow rail above the ledger:
+
+- review prompts are described as requiring human confirmation, not automated decisions;
+- conflicts are framed as evidence disagreement to reconcile;
+- source gaps instruct the viewer to keep `unavailable` neutral until sourced;
+- stable postures remain derived and traceable.
+
+This improves scanning of review states without adding approve/reject commands or lifecycle mutation.
+
 ## Non-goals
 
 This pass does not:


### PR DESCRIPTION
## What changed
- Added a compact review-flow rail above the evidence ledger.
- Clarified four scan states: review prompt, conflict, source gap, and stable derived posture.
- Reinforced that review prompts are not automated decisions.
- Documented the review workflow readability pass in the prototype iteration plan and Pulso token comparison note.

## Why it changed
- The prototype needed clearer scanning for human review, conflicts, unavailable telemetry, and stable derived states.
- This improves operational readability without adding workflow commands or lifecycle mutation.

## How to validate
- Open `examples/visual-operations/prototype/mission-control-static.html` locally.
- Confirm the review-flow rail appears above the ledger.
- Confirm it reads as explanatory posture, not an action workflow.
- `git diff --check`
- `pnpm check:governance`
- `pnpm test`
- `./scripts/check-visual-ops-snapshots.sh`

## Risks, assumptions or follow-ups
- Static prototype only; mock data only.
- No approve/reject commands, backend, runtime, schema, collector, policy engine, or Adaptive Skills integration was added.
- Follow-up: decide whether this rail should remain persistent or become a contextual guide in a later real UI.
- `plans/` remains untracked and untouched.
