### PR TITLE
docs(visual-ops): improve prototype cohesion

### DIFF
--- a/examples/visual-operations/prototype/mission-control-static.html
+++ b/examples/visual-operations/prototype/mission-control-static.html
@@ -453,21 +453,21 @@
     .metrics-row {
       display: grid;
       grid-template-columns: repeat(4, minmax(0, 1fr));
-      gap: var(--space-3);
-      margin-bottom: var(--rhythm-cadence-beat);
+      gap: var(--space-2);
+      margin-bottom: var(--space-3);
     }
 
     .metric {
-      min-height: 76px;
-      padding: var(--space-4);
-      border: 1px solid var(--line);
-      border-radius: var(--radius-sm);
-      background: color-mix(in oklab, var(--mc-surface-panel-raised) 66%, transparent);
+      min-height: 58px;
+      padding: 11px 12px;
+      border: 1px solid color-mix(in oklab, var(--mc-border) 78%, transparent);
+      border-radius: var(--radius-ledger);
+      background: color-mix(in oklab, var(--mc-surface-panel-raised) 46%, transparent);
     }
 
     .metric-value {
-      margin-top: 8px;
-      font-size: 1.6rem;
+      margin-top: 4px;
+      font-size: 1.34rem;
       font-weight: 720;
       letter-spacing: -0.045em;
     }
@@ -482,22 +482,22 @@
       display: grid;
       grid-template-columns: repeat(4, minmax(0, 1fr));
       gap: var(--space-2);
-      margin-bottom: var(--rhythm-cadence-beat);
-      padding: var(--space-3);
-      border: 1px solid color-mix(in oklab, var(--mc-border) 88%, transparent);
+      margin-bottom: var(--space-4);
+      padding: 0;
+      border: 0;
       border-radius: var(--radius);
-      background: color-mix(in oklab, var(--mc-surface-panel) 46%, transparent);
+      background: transparent;
     }
 
     .review-step {
       position: relative;
       display: grid;
-      gap: 6px;
+      gap: 5px;
       min-width: 0;
-      padding: 12px;
-      border: 1px solid color-mix(in oklab, var(--mc-border) 72%, transparent);
+      padding: 9px 10px;
+      border: 1px solid color-mix(in oklab, var(--mc-border) 68%, transparent);
       border-radius: var(--radius-ledger);
-      background: color-mix(in oklab, var(--mc-surface-page) 42%, transparent);
+      background: color-mix(in oklab, var(--mc-surface-page) 36%, transparent);
     }
 
     .review-step::before {
@@ -523,14 +523,14 @@
     .review-step strong {
       color: var(--text-soft);
       font-size: var(--text-support);
-      line-height: 1.25;
+      line-height: 1.22;
     }
 
     .review-step p {
       margin: 0;
       color: var(--text-muted);
-      font-size: var(--text-support);
-      line-height: 1.35;
+      font-size: var(--text-micro);
+      line-height: 1.3;
     }
 
     .ledger-shell {
@@ -744,11 +744,11 @@
     .observatory-panel {
       display: grid;
       gap: var(--space-3);
-      margin-top: var(--rhythm-cadence-beat);
+      margin-top: var(--space-4);
       padding: var(--space-4);
-      border: 1px solid color-mix(in oklab, var(--mc-evidence) 24%, var(--mc-border));
+      border: 1px solid color-mix(in oklab, var(--mc-evidence) 18%, var(--mc-border));
       border-radius: var(--radius);
-      background: linear-gradient(180deg, color-mix(in oklab, var(--mc-evidence) 6%, var(--mc-surface-panel) 68%), color-mix(in oklab, var(--mc-surface-page) 82%, transparent));
+      background: linear-gradient(180deg, color-mix(in oklab, var(--mc-evidence) 4%, var(--mc-surface-panel) 56%), color-mix(in oklab, var(--mc-surface-page) 88%, transparent));
     }
 
     .observatory-head {
@@ -798,9 +798,9 @@
 
     .signal-value {
       color: var(--text);
-      font-size: 1.28rem;
+      font-size: 1.12rem;
       font-weight: 760;
-      letter-spacing: -0.04em;
+      letter-spacing: -0.035em;
     }
 
     .signal-value.is-neutral { color: var(--text-muted); }
@@ -832,22 +832,22 @@
     .event-strip {
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: var(--space-3);
-      margin-top: var(--rhythm-cadence-beat);
+      gap: var(--space-2);
+      margin-top: var(--space-3);
     }
 
     .event-card {
-      border: 1px solid var(--line);
-      border-radius: var(--radius-sm);
-      background: color-mix(in oklab, var(--mc-surface-panel) 78%, transparent);
-      padding: var(--space-3);
+      border: 1px solid color-mix(in oklab, var(--mc-border) 72%, transparent);
+      border-radius: var(--radius-ledger);
+      background: color-mix(in oklab, var(--mc-surface-panel) 48%, transparent);
+      padding: 10px 12px;
     }
 
     .event-card p {
-      margin: 6px 0 0;
+      margin: 5px 0 0;
       color: var(--text-muted);
-      font-size: var(--text-support);
-      line-height: 1.36;
+      font-size: var(--text-micro);
+      line-height: 1.34;
     }
 
     .inspector-title {
@@ -1284,8 +1284,8 @@
               <div class="observatory-head">
                 <div>
                   <p class="eyebrow">Resource observatory</p>
-                  <h3 class="observatory-title">Operational signals with source posture</h3>
-                  <p class="observatory-copy">Static preview only. Signals show source availability and provenance; they do not collect telemetry or create authority.</p>
+                  <h3 class="observatory-title">Secondary operational signals</h3>
+                  <p class="observatory-copy">Static context only. Signals show source availability and provenance without collecting telemetry or creating authority.</p>
                 </div>
                 <span class="utility">APOB input layer · mock data</span>
               </div>

--- a/examples/visual-operations/prototype/pulso-token-comparison.md
+++ b/examples/visual-operations/prototype/pulso-token-comparison.md
@@ -184,6 +184,18 @@ The prototype now includes a compact review-flow rail above the ledger:
 
 This improves scanning of review states without adding approve/reject commands or lifecycle mutation.
 
+## Prototype cohesion pass applied
+
+A later cohesion pass reduced visual competition around the main ledger:
+
+- posture metrics were compacted;
+- review-flow cards were reduced into a lighter explanatory rail;
+- Resource Observatory was labeled as secondary operational context;
+- trace event cards were visually de-emphasized;
+- the evidence ledger remains the primary workspace.
+
+This keeps the screen from becoming a generic dashboard while preserving all existing static context.
+
 ## Non-goals
 
 This pass does not:


### PR DESCRIPTION
## What changed
- Applied a prototype cohesion pass to reduce visual competition around the main evidence ledger.
- Compactly restyled posture metrics and review-flow guidance.
- Labeled the Resource Observatory as secondary operational context.
- De-emphasized trace event cards so the ledger remains the primary workspace.
- Documented the cohesion pass in the Pulso token comparison note.

## Why it changed
- The prototype accumulated useful context blocks, but risked feeling too dashboard-like and dense.
- This pass keeps the Evidence Ledger as the main working surface while preserving supporting context.

## How to validate
- Open `examples/visual-operations/prototype/mission-control-static.html` locally.
- Confirm the ledger remains visually primary.
- Confirm metrics, review-flow, observatory, and trace events still read as supporting context.
- `git diff --check`
- `pnpm check:governance`
- `pnpm test`
- `./scripts/check-visual-ops-snapshots.sh`

## Risks, assumptions or follow-ups
- Static prototype only; mock data only.
- No backend, runtime, schema, collector, policy engine, or Adaptive Skills integration was added.
- Follow-up: visual review in browser to decide whether Resource Observatory should stay on the main canvas or move to a secondary view.
- `plans/` remains untracked and untouched.
