### PR TITLE
docs(visual-ops): split resource observatory page

### DIFF
--- a/examples/visual-operations/prototype/README.md
+++ b/examples/visual-operations/prototype/README.md
@@ -15,6 +15,12 @@ Open:
 examples/visual-operations/prototype/mission-control-static.html
 ```
 
+Resource Observatory preview:
+
+```text
+examples/visual-operations/prototype/resource-observatory-static.html
+```
+
 No build step, server, backend, runtime, collector, schema, or package dependency is required.
 
 ## Prototype boundaries
@@ -58,6 +64,7 @@ Design intent:
 - [Prototype visual QA pass](visual-qa-pass.md)
 - [Pulso Design System bridge](pulso-design-system-bridge.md)
 - [Pulso token comparison pass](pulso-token-comparison.md)
+- [Resource Observatory static prototype](resource-observatory-static.html)
 - [Refined visual mock](../cockpit-refined-visual-mock.md)
 - [Light wireframe spec](../cockpit-light-wireframe-spec.md)
 - [Static board composition](../cockpit-static-board-composition.md)

--- a/examples/visual-operations/prototype/iteration-plan.md
+++ b/examples/visual-operations/prototype/iteration-plan.md
@@ -51,7 +51,7 @@ Future Resource Observatory views may monitor:
 
 A signal can appear visually only when it has a source reference and provenance. If no durable source exists, the visual state must be `unknown` or `unavailable`.
 
-The first static preview is included in the prototype as a compact Resource Observatory panel. It uses mock data only and treats APOB as an input/source layer, not as a governance authority.
+The first static preview now lives in a dedicated Resource Observatory page at [resource-observatory-static.html](resource-observatory-static.html). It uses mock data only and treats APOB as an input/source layer, not as a governance authority.
 
 ## Acceptance criteria for future slices
 

--- a/examples/visual-operations/prototype/mission-control-static.html
+++ b/examples/visual-operations/prototype/mission-control-static.html
@@ -203,6 +203,7 @@
 
     .rail-button {
       width: 100%;
+      text-decoration: none;
       height: 38px;
       display: flex;
       align-items: center;
@@ -741,93 +742,42 @@
       white-space: nowrap;
     }
 
-    .observatory-panel {
-      display: grid;
-      gap: var(--space-3);
-      margin-top: var(--space-4);
-      padding: var(--space-4);
-      border: 1px solid color-mix(in oklab, var(--mc-evidence) 18%, var(--mc-border));
-      border-radius: var(--radius);
-      background: linear-gradient(180deg, color-mix(in oklab, var(--mc-evidence) 4%, var(--mc-surface-panel) 56%), color-mix(in oklab, var(--mc-surface-page) 88%, transparent));
-    }
-
-    .observatory-head {
+    .context-link {
       display: grid;
       grid-template-columns: minmax(0, 1fr) auto;
       gap: var(--space-3);
-      align-items: end;
-    }
-
-    .observatory-title {
-      margin: 0;
-      color: var(--text-soft);
-      font-size: var(--text-h2);
-      font-weight: 760;
-      letter-spacing: -0.01em;
-    }
-
-    .observatory-copy {
-      margin: 4px 0 0;
-      color: var(--text-muted);
-      font-size: var(--text-support);
-      line-height: 1.4;
-    }
-
-    .observatory-grid {
-      display: grid;
-      grid-template-columns: repeat(4, minmax(0, 1fr));
-      gap: var(--space-2);
-    }
-
-    .signal-card {
-      display: grid;
-      gap: var(--space-2);
-      min-width: 0;
-      padding: 12px;
-      border: 1px solid color-mix(in oklab, var(--mc-border) 82%, transparent);
-      border-radius: var(--radius-ledger);
-      background: color-mix(in oklab, var(--mc-surface-panel-raised) 42%, transparent);
-    }
-
-    .signal-label {
-      color: var(--text-muted);
-      font: 760 var(--text-micro) var(--mono);
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-    }
-
-    .signal-value {
-      color: var(--text);
-      font-size: 1.12rem;
-      font-weight: 760;
-      letter-spacing: -0.035em;
-    }
-
-    .signal-value.is-neutral { color: var(--text-muted); }
-    .signal-value.is-review { color: var(--review); }
-    .signal-value.is-evidence { color: var(--info); }
-    .signal-value.is-stable { color: var(--stable); }
-
-    .signal-meta {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 5px;
       align-items: center;
+      margin-top: var(--space-4);
+      padding: 12px var(--space-4);
+      border: 1px solid color-mix(in oklab, var(--mc-evidence) 18%, var(--mc-border));
+      border-radius: var(--radius-ledger);
+      background: color-mix(in oklab, var(--mc-surface-panel) 34%, transparent);
+      color: inherit;
+      text-decoration: none;
     }
 
-    .signal-origin {
-      border: 1px solid color-mix(in oklab, var(--mc-border-strong) 42%, transparent);
-      border-radius: var(--radius-md);
-      padding: 3px 6px;
+    .context-link:hover,
+    .context-link:focus-visible {
+      border-color: color-mix(in oklab, var(--mc-evidence) 36%, var(--mc-border-strong));
+      background: color-mix(in oklab, var(--mc-surface-panel-raised) 40%, transparent);
+      outline: none;
+    }
+
+    .context-link strong {
+      display: block;
+      color: var(--text-soft);
+      font-size: var(--text-support);
+    }
+
+    .context-link span {
+      display: block;
+      margin-top: 3px;
       color: var(--text-muted);
-      font: 760 var(--text-micro) var(--mono);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
+      font-size: var(--text-micro);
+      line-height: 1.35;
     }
 
-    .signal-origin.reported { color: var(--stable); border-color: color-mix(in oklab, var(--stable) 36%, transparent); }
-    .signal-origin.estimated { color: var(--review); border-color: color-mix(in oklab, var(--review) 36%, transparent); }
-    .signal-origin.unavailable { color: var(--text-muted); border-color: color-mix(in oklab, var(--mc-border-strong) 46%, transparent); }
+    .context-link .utility { margin: 0; }
 
     .event-strip {
       display: grid;
@@ -1115,7 +1065,7 @@
     @media (max-width: 1180px) {
       .mission-shell.nav-expanded { --rail-width: 220px; }
       .metrics-row, .event-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-      .observatory-grid, .review-flow { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .review-flow { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       .topbar { grid-template-columns: 1fr; align-items: start; }
       .authority { text-align: left; }
     }
@@ -1128,7 +1078,7 @@
       .section-head { grid-template-columns: 1fr; }
       .filters { justify-content: flex-start; }
       .filter-summary { width: 100%; }
-      .metrics-row, .event-strip, .observatory-grid, .review-flow { grid-template-columns: 1fr; }
+      .metrics-row, .event-strip, .review-flow { grid-template-columns: 1fr; }
       .main-board { padding: 16px; }
       .board-grid { min-width: 760px; }
       .inspector { width: min(390px, 100vw); }
@@ -1153,6 +1103,7 @@
           <button class="rail-button active" type="button"><span>EV</span><span class="rail-button-label">Evidence ledger</span></button>
           <button class="rail-button" type="button"><span>TR</span><span class="rail-button-label">Trace context</span></button>
           <button class="rail-button" type="button"><span>SRC</span><span class="rail-button-label">Source records</span></button>
+          <a class="rail-button" href="resource-observatory-static.html"><span>RO</span><span class="rail-button-label">Resource observatory</span></a>
         </nav>
         <nav class="rail-stack" aria-label="Utility views">
           <button class="rail-button" type="button"><span>CFG</span><span class="rail-button-label">Configuration</span></button>
@@ -1280,38 +1231,10 @@
               </div>
             </section>
 
-            <section class="observatory-panel" aria-label="Resource Observatory preview">
-              <div class="observatory-head">
-                <div>
-                  <p class="eyebrow">Resource observatory</p>
-                  <h3 class="observatory-title">Secondary operational signals</h3>
-                  <p class="observatory-copy">Static context only. Signals show source availability and provenance without collecting telemetry or creating authority.</p>
-                </div>
-                <span class="utility">APOB input layer · mock data</span>
-              </div>
-              <div class="observatory-grid">
-                <article class="signal-card">
-                  <span class="signal-label">Context tokens</span>
-                  <strong class="signal-value is-evidence">128k</strong>
-                  <span class="signal-meta"><span class="signal-origin reported">reported</span><span class="source-ref">OBS-CTX-01</span></span>
-                </article>
-                <article class="signal-card">
-                  <span class="signal-label">Token cost</span>
-                  <strong class="signal-value is-neutral">unavailable</strong>
-                  <span class="signal-meta"><span class="signal-origin unavailable">unavailable</span><span class="source-ref">OBS-COST-∅</span></span>
-                </article>
-                <article class="signal-card">
-                  <span class="signal-label">Retry waste</span>
-                  <strong class="signal-value is-review">6.2%</strong>
-                  <span class="signal-meta"><span class="signal-origin estimated">estimated</span><span class="source-ref">OBS-RTY-02</span></span>
-                </article>
-                <article class="signal-card">
-                  <span class="signal-label">Review effort</span>
-                  <strong class="signal-value is-stable">3.1h</strong>
-                  <span class="signal-meta"><span class="signal-origin reported">reported</span><span class="source-ref">OBS-HR-04</span></span>
-                </article>
-              </div>
-            </section>
+            <a class="context-link" href="resource-observatory-static.html" aria-label="Open Resource Observatory static prototype page">
+              <span><strong>Resource Observatory moved to a dedicated view</strong><span>Operational signals remain sourced secondary context, separate from the evidence ledger workspace.</span></span>
+              <span class="utility">Open RO</span>
+            </a>
 
             <section class="event-strip" aria-label="Recent trace events">
               <article class="event-card"><span class="kicker">10:18 · Review</span><p>Critical risk signal moved into review prompt from existing risk source.</p></article>

--- a/examples/visual-operations/prototype/pulso-token-comparison.md
+++ b/examples/visual-operations/prototype/pulso-token-comparison.md
@@ -161,17 +161,18 @@ The inspector source section was then expanded from simple chips into source-led
 
 This prepares the prototype for future source-detail exploration without introducing schemas or collectors.
 
-## Resource Observatory preview applied
+## Resource Observatory dedicated page applied
 
-The prototype now includes a compact Resource Observatory preview:
+The Resource Observatory preview now lives on a dedicated static page:
 
-- shows context tokens, token cost, retry waste, and review effort as static operational signals;
+- keeps operational signals separate from the primary Evidence Ledger workspace;
+- shows context tokens, token cost, retry waste, review effort, quality signals, and skill usage as static operational signals;
 - every signal has a source ref and an origin label;
 - `unavailable` remains neutral for missing cost data;
 - `estimated` is visibly distinct from `reported`;
 - APOB is presented as an input/source layer only, not a governance authority.
 
-This is a visual preview only. It does not collect telemetry, calculate cost, or create a runtime observability layer.
+The main ledger now links to this page as secondary context instead of rendering the full observability panel inline. The Resource Observatory page keeps the same base Mission Control shell and navigation pattern so it feels like a sibling view, not a separate artifact. This is a visual preview only. It does not collect telemetry, calculate cost, or create a runtime observability layer.
 
 ## Review workflow readability applied
 

--- a/examples/visual-operations/prototype/resource-observatory-static.html
+++ b/examples/visual-operations/prototype/resource-observatory-static.html
@@ -1,0 +1,438 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>AletheIA Mission Control — Resource Observatory Static Prototype</title>
+  <style>
+    :root {
+      --font-pulso-sans: Manrope, Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --font-pulso-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      --text-display: 1.36rem;
+      --text-h1: 1.22rem;
+      --text-h2: 0.91rem;
+      --text-body: 0.82rem;
+      --text-support: 0.76rem;
+      --text-micro: 0.62rem;
+      --tracking-kicker: 0.12em;
+      --space-2: 8px;
+      --space-3: 12px;
+      --space-4: 16px;
+      --space-5: 20px;
+      --space-6: 24px;
+      --radius-md: 8px;
+      --radius-lg: 10px;
+      --radius-xl: 14px;
+      --radius-ledger: 7px;
+      --mc-surface-page: #0f0c1a;
+      --mc-surface-shell: #151126;
+      --mc-surface-panel: #1b1630;
+      --mc-surface-panel-raised: #221b3d;
+      --mc-surface-panel-strong: #2a2250;
+      --mc-border: #302a50;
+      --mc-border-strong: color-mix(in oklab, #302a50 62%, #ffffff 38%);
+      --mc-text: #f6f3ff;
+      --mc-text-support: #c5c2d2;
+      --mc-text-muted: #8f89a8;
+      --mc-critical: #da6a88;
+      --mc-review: #e0a144;
+      --mc-stable: #7ddba9;
+      --mc-evidence: #5dcab8;
+      --mc-primary: #8a63ff;
+      color-scheme: dark;
+    }
+
+    * { box-sizing: border-box; }
+    html { background: var(--mc-surface-page); }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--mc-surface-page);
+      color: var(--mc-text);
+      font-family: var(--font-pulso-sans);
+      letter-spacing: -0.01em;
+    }
+
+    .stage { min-height: 100vh; }
+
+    .mission-shell {
+      width: 100vw;
+      height: 100vh;
+      display: grid;
+      grid-template-columns: 238px minmax(0, 1fr);
+      background: var(--mc-surface-shell);
+      overflow: hidden;
+    }
+
+    .side-rail {
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      gap: var(--space-5);
+      padding: var(--space-4) var(--space-3);
+      border-right: 1px solid var(--mc-border);
+      background: #0f0c1a;
+      min-width: 0;
+    }
+
+    .rail-top, .rail-stack { display: grid; gap: var(--space-2); align-content: start; }
+
+    .mark-row {
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+      min-width: 0;
+    }
+
+    .mark {
+      width: 38px;
+      height: 38px;
+      display: grid;
+      place-items: center;
+      border: 1px solid color-mix(in oklab, var(--mc-primary) 48%, transparent);
+      border-radius: var(--radius-lg);
+      color: #d8ceff;
+      font: 800 var(--text-support) var(--font-pulso-mono);
+      background: color-mix(in oklab, var(--mc-primary) 12%, transparent);
+      flex: 0 0 auto;
+    }
+
+    .rail-brand strong {
+      display: block;
+      color: var(--mc-text);
+      font-size: var(--text-body);
+      line-height: 1.1;
+    }
+
+    .rail-brand span {
+      display: block;
+      margin-top: 2px;
+      color: var(--mc-text-muted);
+      font: 720 var(--text-micro) var(--font-pulso-mono);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .rail-button {
+      width: 100%;
+      min-height: 38px;
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+      border: 1px solid transparent;
+      border-radius: var(--radius-lg);
+      background: transparent;
+      color: var(--mc-text-muted);
+      padding: 0 var(--space-3);
+      font: 760 var(--text-support) var(--font-pulso-sans);
+      text-align: left;
+      text-decoration: none;
+    }
+
+    .rail-button span:first-child {
+      width: 24px;
+      color: inherit;
+      font: 760 var(--text-micro) var(--font-pulso-mono);
+      letter-spacing: 0.04em;
+    }
+
+    .rail-button.active,
+    .rail-button:hover,
+    .rail-button:focus-visible {
+      border-color: var(--mc-border-strong);
+      background: var(--mc-surface-panel-raised);
+      color: var(--mc-text);
+      outline: none;
+    }
+
+    .app {
+      display: grid;
+      grid-template-rows: auto 1fr;
+      min-width: 0;
+      min-height: 0;
+    }
+
+    .topbar {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: var(--space-4);
+      align-items: center;
+      min-height: 72px;
+      padding: 14px var(--space-6);
+      border-bottom: 1px solid var(--mc-border);
+      background: color-mix(in oklab, var(--mc-surface-shell) 94%, #090712 6%);
+    }
+
+    .workspace {
+      min-width: 0;
+      min-height: 0;
+      overflow: auto;
+      background: radial-gradient(circle at top right, color-mix(in oklab, var(--mc-primary) 14%, transparent), transparent 34rem), var(--mc-surface-page);
+    }
+
+    .kicker, .utility, .source-ref, .origin {
+      font-family: var(--font-pulso-mono);
+      letter-spacing: 0.04em;
+    }
+
+    .kicker {
+      margin: 0 0 7px;
+      color: var(--mc-text-muted);
+      font-size: var(--text-micro);
+      font-weight: 760;
+      text-transform: uppercase;
+      letter-spacing: var(--tracking-kicker);
+    }
+
+    h1, h2, h3, p { margin-top: 0; }
+
+    h1 {
+      margin-bottom: 6px;
+      font-size: var(--text-display);
+      line-height: 1.08;
+      letter-spacing: -0.04em;
+    }
+
+    .lead {
+      max-width: 760px;
+      margin-bottom: 0;
+      color: var(--mc-text-muted);
+      font-size: var(--text-body);
+      line-height: 1.45;
+    }
+
+    .content {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 340px;
+      gap: var(--space-5);
+      padding: var(--space-6);
+      min-height: 0;
+    }
+
+    .signal-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: var(--space-3);
+      align-content: start;
+    }
+
+    .signal-card, .side-panel {
+      border: 1px solid color-mix(in oklab, var(--mc-border) 84%, transparent);
+      border-radius: var(--radius-lg);
+      background: color-mix(in oklab, var(--mc-surface-panel) 62%, transparent);
+    }
+
+    .signal-card {
+      display: grid;
+      gap: var(--space-3);
+      min-height: 148px;
+      padding: var(--space-4);
+    }
+
+    .signal-card::before {
+      content: "";
+      width: 34px;
+      height: 2px;
+      border-radius: 999px;
+      background: var(--mc-evidence);
+    }
+
+    .signal-card.is-review::before { background: var(--mc-review); }
+    .signal-card.is-stable::before { background: var(--mc-stable); }
+    .signal-card.is-neutral::before { background: var(--mc-text-muted); }
+
+    .signal-label {
+      color: var(--mc-text-muted);
+      font: 760 var(--text-micro) var(--font-pulso-mono);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .signal-value {
+      color: var(--mc-text);
+      font-size: 1.9rem;
+      font-weight: 760;
+      letter-spacing: -0.05em;
+    }
+
+    .signal-value.review { color: var(--mc-review); }
+    .signal-value.stable { color: var(--mc-stable); }
+    .signal-value.neutral { color: var(--mc-text-muted); font-size: 1.35rem; }
+
+    .signal-note {
+      margin: 0;
+      color: var(--mc-text-muted);
+      font-size: var(--text-support);
+      line-height: 1.38;
+    }
+
+    .source-line {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      align-items: center;
+      margin-top: auto;
+    }
+
+    .source-ref, .origin {
+      border: 1px solid color-mix(in oklab, var(--mc-border-strong) 44%, transparent);
+      border-radius: var(--radius-md);
+      padding: 3px 7px;
+      color: var(--mc-text-support);
+      font-size: var(--text-micro);
+      white-space: nowrap;
+    }
+
+    .origin { text-transform: uppercase; }
+    .origin.reported { color: var(--mc-stable); border-color: color-mix(in oklab, var(--mc-stable) 36%, transparent); }
+    .origin.estimated { color: var(--mc-review); border-color: color-mix(in oklab, var(--mc-review) 36%, transparent); }
+    .origin.unavailable { color: var(--mc-text-muted); }
+
+    .side-panel {
+      display: grid;
+      gap: var(--space-4);
+      align-content: start;
+      padding: var(--space-4);
+    }
+
+    .side-panel h2 {
+      margin-bottom: 6px;
+      color: var(--mc-text-support);
+      font-size: var(--text-h2);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .rule-list {
+      display: grid;
+      gap: var(--space-3);
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .rule-list li {
+      padding: var(--space-3);
+      border: 1px solid color-mix(in oklab, var(--mc-border) 74%, transparent);
+      border-radius: var(--radius-ledger);
+      color: var(--mc-text-muted);
+      font-size: var(--text-support);
+      line-height: 1.38;
+      background: color-mix(in oklab, var(--mc-surface-page) 34%, transparent);
+    }
+
+    @media (max-width: 1100px) {
+      .content { grid-template-columns: 1fr; }
+      .signal-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+
+    @media (max-width: 720px) {
+      .mission-shell { grid-template-columns: 58px minmax(0, 1fr); }
+      .side-rail { padding: 12px 8px; }
+      .rail-brand, .rail-button-label { display: none; }
+      .rail-button { justify-content: center; padding: 0; }
+      .topbar, .content { padding: var(--space-4); }
+      .topbar { grid-template-columns: 1fr; }
+      .signal-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <div class="stage">
+    <main class="mission-shell" aria-label="AletheIA Mission Control Resource Observatory static prototype">
+      <aside class="side-rail" aria-label="Mission Control navigation">
+        <div class="rail-top">
+          <div class="mark-row">
+            <div class="mark">AI</div>
+            <div class="rail-brand"><strong>AletheIA</strong><span>Mission Control</span></div>
+          </div>
+        </div>
+        <nav class="rail-stack" aria-label="Workspace views">
+          <a class="rail-button" href="mission-control-static.html"><span>EV</span><span class="rail-button-label">Evidence ledger</span></a>
+          <a class="rail-button active" href="resource-observatory-static.html" aria-current="page"><span>RO</span><span class="rail-button-label">Resource observatory</span></a>
+          <a class="rail-button" href="mission-control-static.html"><span>TR</span><span class="rail-button-label">Trace context</span></a>
+          <a class="rail-button" href="mission-control-static.html"><span>SRC</span><span class="rail-button-label">Source records</span></a>
+        </nav>
+        <nav class="rail-stack" aria-label="Utility views">
+          <a class="rail-button" href="mission-control-static.html"><span>CFG</span><span class="rail-button-label">Configuration</span></a>
+          <a class="rail-button" href="mission-control-static.html"><span>AUD</span><span class="rail-button-label">Audit view</span></a>
+        </nav>
+      </aside>
+
+      <section class="app">
+        <header class="topbar">
+          <div>
+            <p class="kicker">Resource Observatory · static preview</p>
+            <h1>Operational signals as sourced context</h1>
+            <p class="lead">This view separates operational intelligence from the Evidence Ledger. Signals are metadata-first, sourced, and read-only; they do not collect telemetry or authorize decisions.</p>
+          </div>
+          <span class="utility">APOB input layer · mock data only</span>
+        </header>
+
+        <div class="workspace">
+          <div class="content">
+        <section class="signal-grid" aria-label="Operational signal cards">
+          <article class="signal-card">
+            <span class="signal-label">Context tokens</span>
+            <strong class="signal-value">128k</strong>
+            <p class="signal-note">Reported from a synthetic APOB event sample.</p>
+            <span class="source-line"><span class="origin reported">reported</span><span class="source-ref">OBS-CTX-01</span></span>
+          </article>
+          <article class="signal-card is-neutral">
+            <span class="signal-label">Token cost</span>
+            <strong class="signal-value neutral">unavailable</strong>
+            <p class="signal-note">No durable cost export exists for this docs-only slice.</p>
+            <span class="source-line"><span class="origin unavailable">unavailable</span><span class="source-ref">OBS-COST-∅</span></span>
+          </article>
+          <article class="signal-card is-review">
+            <span class="signal-label">Retry waste</span>
+            <strong class="signal-value review">6.2%</strong>
+            <p class="signal-note">Estimated from synthetic retry records; not a billing source.</p>
+            <span class="source-line"><span class="origin estimated">estimated</span><span class="source-ref">OBS-RTY-02</span></span>
+          </article>
+          <article class="signal-card is-stable">
+            <span class="signal-label">Review effort</span>
+            <strong class="signal-value stable">3.1h</strong>
+            <p class="signal-note">Reported from review metadata in the synthetic example.</p>
+            <span class="source-line"><span class="origin reported">reported</span><span class="source-ref">OBS-HR-04</span></span>
+          </article>
+          <article class="signal-card">
+            <span class="signal-label">Quality signals</span>
+            <strong class="signal-value">94</strong>
+            <p class="signal-note">Reported quality score from mocked evaluation summary.</p>
+            <span class="source-line"><span class="origin reported">reported</span><span class="source-ref">OBS-QA-07</span></span>
+          </article>
+          <article class="signal-card is-stable">
+            <span class="signal-label">Skill usage</span>
+            <strong class="signal-value stable">traced</strong>
+            <p class="signal-note">Skill activation appears as trace context only.</p>
+            <span class="source-line"><span class="origin reported">reported</span><span class="source-ref">ACT-552</span></span>
+          </article>
+        </section>
+
+        <aside class="side-panel" aria-label="Resource Observatory boundaries">
+          <section>
+            <h2>Boundary</h2>
+            <ul class="rule-list">
+              <li>APOB is represented as an input/source layer only.</li>
+              <li>Signals show availability and provenance; they do not create governance authority.</li>
+              <li>`unavailable` is neutral and must not be colored as failure.</li>
+              <li>Estimated values must stay labeled and cannot replace reported source records.</li>
+            </ul>
+          </section>
+          <section>
+            <h2>Not included</h2>
+            <ul class="rule-list">
+              <li>No telemetry collection.</li>
+              <li>No cost calculation.</li>
+              <li>No backend, runtime, collector, schema, or policy engine.</li>
+              <li>No Adaptive Skills integration.</li>
+            </ul>
+          </section>
+        </aside>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## What changed
- Moved Resource Observatory out of the main Mission Control ledger canvas into a dedicated static page.
- Added `examples/visual-operations/prototype/resource-observatory-static.html`.
- Replaced the inline Resource Observatory panel on the main prototype with a compact link to the dedicated view.
- Added a sidebar RO link from the main static prototype.
- Updated prototype README, iteration plan, and Pulso token comparison notes.

## Why it changed
- The observability preview was useful but competed with the Evidence Ledger.
- A dedicated page keeps the ledger focused while preserving Resource Observatory as secondary operational context.

## How to validate
- Open `examples/visual-operations/prototype/mission-control-static.html` locally.
- Confirm Resource Observatory appears as a compact link, not a full inline panel.
- Open `examples/visual-operations/prototype/resource-observatory-static.html` locally.
- Confirm signals remain sourced, metadata-first, and read-only.
- `git diff --check`
- `pnpm check:governance`
- `pnpm test`
- `./scripts/check-visual-ops-snapshots.sh`

## Risks, assumptions or follow-ups
- Static prototype only; mock data only.
- No telemetry collection, cost calculation, backend, runtime, schema, collector, policy engine, or Adaptive Skills integration was added.
- Follow-up: decide whether future navigation should become a real static prototype shell or remain simple linked HTML files.
- `plans/` remains untracked and untouched.
