### PR TITLE
fix(visual-operations): preserve navigation state

### DIFF
--- a/examples/visual-operations/prototype/mission-control-static.html
+++ b/examples/visual-operations/prototype/mission-control-static.html
@@ -1376,6 +1376,7 @@
 
     const shell = document.getElementById('mission-shell');
     const navToggle = document.getElementById('nav-toggle');
+    const navStorageKey = 'aletheia-mission-control-nav-expanded';
     const inspector = document.getElementById('evidence-inspector');
     const inspectorBackdrop = document.getElementById('inspector-backdrop');
     const sheetClose = document.getElementById('sheet-close');
@@ -1423,10 +1424,22 @@
       openInspector();
     }
 
-    navToggle.addEventListener('click', () => {
-      const expanded = shell.classList.toggle('nav-expanded');
+    function setNavigationExpanded(expanded) {
+      shell.classList.toggle('nav-expanded', expanded);
       navToggle.setAttribute('aria-expanded', String(expanded));
       navToggle.querySelector('.nav-toggle-label').textContent = expanded ? 'Collapse menu' : 'Expand menu';
+    }
+
+    try {
+      setNavigationExpanded(sessionStorage.getItem(navStorageKey) === 'true');
+    } catch {
+      setNavigationExpanded(false);
+    }
+
+    navToggle.addEventListener('click', () => {
+      const expanded = !shell.classList.contains('nav-expanded');
+      setNavigationExpanded(expanded);
+      try { sessionStorage.setItem(navStorageKey, String(expanded)); } catch { /* Static preview may deny storage. */ }
     });
 
     sheetClose.addEventListener('click', closeInspector);

--- a/examples/visual-operations/prototype/resource-observatory-static.html
+++ b/examples/visual-operations/prototype/resource-observatory-static.html
@@ -519,11 +519,24 @@
   <script>
     const shell = document.getElementById('mission-shell');
     const navToggle = document.getElementById('nav-toggle');
+    const navStorageKey = 'aletheia-mission-control-nav-expanded';
 
-    navToggle.addEventListener('click', () => {
-      const expanded = shell.classList.toggle('nav-expanded');
+    function setNavigationExpanded(expanded) {
+      shell.classList.toggle('nav-expanded', expanded);
       navToggle.setAttribute('aria-expanded', String(expanded));
       navToggle.querySelector('.nav-toggle-label').textContent = expanded ? 'Collapse menu' : 'Expand menu';
+    }
+
+    try {
+      setNavigationExpanded(sessionStorage.getItem(navStorageKey) === 'true');
+    } catch {
+      setNavigationExpanded(false);
+    }
+
+    navToggle.addEventListener('click', () => {
+      const expanded = !shell.classList.contains('nav-expanded');
+      setNavigationExpanded(expanded);
+      try { sessionStorage.setItem(navStorageKey, String(expanded)); } catch { /* Static preview may deny storage. */ }
     });
   </script>
 </body>


### PR DESCRIPTION
## What changed
- preserves the expanded or collapsed navigation state between the Evidence Ledger and Resource Observatory static pages
- centralizes each page's rail state update through the same small helper
- falls back safely to the collapsed state when browser storage is unavailable

## Why
Both prototype views now share the same application shell, so navigation should not visibly reset when moving between them.

## How to validate
- expand the menu in `mission-control-static.html`
- navigate to Resource Observatory and confirm the menu remains expanded
- collapse it, return to Evidence Ledger, and confirm it remains collapsed
- run `pnpm check:governance`
- run `pnpm test`
- run `./scripts/check-visual-ops-snapshots.sh`
- run `git diff --check`

## Risks and follow-ups
- stores only a transient visual preference in `sessionStorage`
- no project, evidence, telemetry, or user data is stored
- static prototype only; no backend, runtime, dependency, or schema changes
- `plans/` remains untouched and untracked