### PR TITLE
fix(visual-operations): close inspector on load

### DIFF
--- a/examples/visual-operations/prototype/mission-control-static.html
+++ b/examples/visual-operations/prototype/mission-control-static.html
@@ -1162,7 +1162,7 @@
                 <section class="lane" aria-label="Review lane">
                   <header class="lane-head"><span class="lane-name"><span class="state-dot critical"></span>Review prompts</span><span class="lane-count">2</span></header>
                   <div class="slice-list">
-                    <button class="slice-card selected" type="button" data-detail="human-review" data-status="attention" data-tone="critical">
+                    <button class="slice-card" type="button" data-detail="human-review" data-status="attention" data-tone="critical">
                       <span class="slice-meta"><span>WS-2026-0616-001</span><span class="chip critical">Human review</span></span>
                       <strong class="slice-title">Critical risk signal</strong>
                       <span class="slice-copy">Threshold breach detected. Human confirmation is required before trusting closure.</span>
@@ -1243,8 +1243,8 @@
             </section>
           </section>
 
-          <div class="inspector-backdrop open" id="inspector-backdrop"></div>
-          <aside class="inspector open" aria-label="Evidence inspector" id="evidence-inspector" aria-hidden="false">
+          <div class="inspector-backdrop" id="inspector-backdrop"></div>
+          <aside class="inspector" aria-label="Evidence inspector" id="evidence-inspector" aria-hidden="true">
             <header class="inspector-header">
               <div class="inspector-title-row">
                 <div>

--- a/tests/visual-operations/test-static-prototype-state.test.ts
+++ b/tests/visual-operations/test-static-prototype-state.test.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const prototypePath = path.resolve(
+  process.cwd(),
+  "examples/visual-operations/prototype/mission-control-static.html",
+);
+
+describe("Mission Control static prototype initial state", () => {
+  it("opens with the evidence inspector closed", () => {
+    const html = fs.readFileSync(prototypePath, "utf8");
+
+    expect(html).toContain('class="inspector-backdrop" id="inspector-backdrop"');
+    expect(html).toContain(
+      'class="inspector" aria-label="Evidence inspector" id="evidence-inspector" aria-hidden="true"',
+    );
+    expect(html).not.toContain('class="inspector-backdrop open"');
+    expect(html).not.toContain('class="inspector open"');
+    expect(html).not.toContain('class="slice-card selected"');
+  });
+});


### PR DESCRIPTION
## What changed
- removes the initial open state from the Home evidence inspector and backdrop
- removes the initial selected state from the first Work Slice card
- adds a regression test for the static prototype initial state

## Why
The Home always loaded with the side sheet open, obscuring the clean workspace and making inspection appear mandatory rather than contextual.

## How to validate
- open `examples/visual-operations/prototype/mission-control-static.html`
- confirm the Home loads with no side sheet or backdrop
- select a Work Slice and confirm the side sheet still opens
- run `pnpm vitest run tests/visual-operations/test-static-prototype-state.test.ts`
- run `pnpm check:governance`
- run `pnpm test`
- run `./scripts/check-visual-ops-snapshots.sh`

## Risks and follow-ups
- rendered Browser automation could not navigate to the local `file://` artifact; source-state regression coverage was added instead
- no data, runtime, backend, schema, or dependency changes
- `plans/` remains untouched and untracked