### PR TITLE
fix(visual-operations): unify icon navigation rail

### DIFF
--- a/examples/visual-operations/prototype/mission-control-static.html
+++ b/examples/visual-operations/prototype/mission-control-static.html
@@ -230,6 +230,125 @@
       outline: 1px solid var(--line-strong);
     }
 
+
+    /* Canonical Mission Control rail geometry shared by both static pages. */
+    .side-rail {
+      position: relative;
+      z-index: 10;
+      gap: var(--space-5);
+      overflow: visible;
+    }
+
+    .mark {
+      width: 40px;
+      height: 40px;
+    }
+
+    .nav-toggle,
+    .rail-button {
+      position: relative;
+      width: 100%;
+      height: 40px;
+      min-height: 40px;
+      padding: 0 10px;
+      border: 1px solid transparent;
+      border-radius: var(--radius-lg);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: var(--space-3);
+      color: var(--mc-text-muted);
+      background: transparent;
+      box-sizing: border-box;
+      text-decoration: none;
+      cursor: pointer;
+    }
+
+    .nav-toggle { border-color: var(--mc-border); }
+
+    .nav-icon {
+      width: 18px;
+      height: 18px;
+      flex: 0 0 18px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 1.75;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .rail-button-label,
+    .nav-toggle-label {
+      display: none;
+      width: auto;
+      min-width: 0;
+    }
+
+    .nav-expanded .rail-button,
+    .nav-expanded .nav-toggle {
+      justify-content: flex-start;
+      padding: 0 var(--space-3);
+    }
+
+    .nav-expanded .rail-button-label,
+    .nav-expanded .nav-toggle-label {
+      display: inline;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-family: var(--font-pulso-sans);
+      font-size: var(--text-body);
+      font-weight: 640;
+      letter-spacing: -0.01em;
+    }
+
+    .rail-button.active,
+    .rail-button:hover,
+    .rail-button:focus-visible,
+    .nav-toggle:hover,
+    .nav-toggle:focus-visible {
+      border-color: var(--mc-border-strong);
+      background: var(--mc-surface-panel-raised);
+      color: var(--mc-text);
+      outline: none;
+    }
+
+    .mission-shell:not(.nav-expanded) [data-tooltip]::after {
+      content: attr(data-tooltip);
+      position: absolute;
+      left: calc(100% + 10px);
+      top: 50%;
+      z-index: 30;
+      padding: 6px 8px;
+      border: 1px solid var(--mc-border-strong);
+      border-radius: var(--radius-md);
+      background: var(--mc-surface-panel-strong);
+      color: var(--mc-text-support);
+      box-shadow: 0 8px 24px rgb(0 0 0 / 0.24);
+      font: 650 var(--text-support) var(--font-pulso-sans);
+      letter-spacing: 0;
+      line-height: 1;
+      white-space: nowrap;
+      opacity: 0;
+      pointer-events: none;
+      transform: translate(4px, -50%);
+      transition: opacity 120ms ease, transform 120ms ease;
+    }
+
+    .mission-shell:not(.nav-expanded) [data-tooltip]:hover::after,
+    .mission-shell:not(.nav-expanded) [data-tooltip]:focus-visible::after {
+      opacity: 1;
+      transform: translate(0, -50%);
+    }
+
+    .icon-sprite {
+      position: absolute;
+      width: 0;
+      height: 0;
+      overflow: hidden;
+    }
+
+
     .app {
       display: grid;
       grid-template-rows: auto 1fr;
@@ -1088,6 +1207,16 @@
   </style>
 </head>
 <body>
++  <svg class="icon-sprite" aria-hidden="true">
+    <symbol id="nav-overview" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"></rect><rect x="14" y="3" width="7" height="7" rx="1"></rect><rect x="3" y="14" width="7" height="7" rx="1"></rect><rect x="14" y="14" width="7" height="7" rx="1"></rect></symbol>
+    <symbol id="nav-evidence" viewBox="0 0 24 24"><path d="M6 3h9l3 3v15H6z"></path><path d="M15 3v4h4M9 11h6M9 15h6"></path></symbol>
+    <symbol id="nav-trace" viewBox="0 0 24 24"><path d="M3 12h4l2-5 4 10 2-5h6"></path></symbol>
+    <symbol id="nav-source" viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="7" ry="3"></ellipse><path d="M5 5v6c0 1.7 3.1 3 7 3s7-1.3 7-3V5M5 11v6c0 1.7 3.1 3 7 3s7-1.3 7-3v-6"></path></symbol>
+    <symbol id="nav-resource" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"></circle><path d="M7.5 15a5 5 0 0 1 9-4M12 12l3-3"></path></symbol>
+    <symbol id="nav-config" viewBox="0 0 24 24"><path d="M4 7h10M18 7h2M4 17h2M10 17h10"></path><circle cx="16" cy="7" r="2"></circle><circle cx="8" cy="17" r="2"></circle></symbol>
+    <symbol id="nav-audit" viewBox="0 0 24 24"><path d="M12 3l7 3v5c0 4.6-2.8 8-7 10-4.2-2-7-5.4-7-10V6z"></path><path d="M9 12l2 2 4-4"></path></symbol>
+    <symbol id="nav-toggle-icon" viewBox="0 0 24 24"><path d="M9 6l-4 6 4 6M15 5h5v14h-5"></path></symbol>
+  </svg>
   <div class="stage">
     <main class="mission-shell" id="mission-shell" aria-label="AletheIA Mission Control static prototype">
       <aside class="side-rail" aria-label="Mission Control navigation">
@@ -1096,18 +1225,18 @@
             <div class="mark">AI</div>
             <div class="rail-brand"><strong>AletheIA</strong><span>Mission Control</span></div>
           </div>
-          <button class="nav-toggle" type="button" id="nav-toggle" aria-expanded="false" aria-controls="mission-shell"><span>⇄</span><span class="nav-toggle-label">Collapse menu</span></button>
+          <button class="nav-toggle" type="button" id="nav-toggle" aria-label="Expand menu" aria-expanded="false" aria-controls="mission-shell" data-tooltip="Expand menu"><svg class="nav-icon" aria-hidden="true"><use href="#nav-toggle-icon"></use></svg><span class="nav-toggle-label">Expand menu</span></button>
         </div>
         <nav class="rail-stack" aria-label="Workspace views">
-          <button class="rail-button" type="button"><span>OV</span><span class="rail-button-label">Overview</span></button>
-          <button class="rail-button active" type="button"><span>EV</span><span class="rail-button-label">Evidence ledger</span></button>
-          <button class="rail-button" type="button"><span>TR</span><span class="rail-button-label">Trace context</span></button>
-          <button class="rail-button" type="button"><span>SRC</span><span class="rail-button-label">Source records</span></button>
-          <a class="rail-button" href="resource-observatory-static.html"><span>RO</span><span class="rail-button-label">Resource observatory</span></a>
+          <button class="rail-button" type="button" aria-label="Overview" data-tooltip="Overview"><svg class="nav-icon" aria-hidden="true"><use href="#nav-overview"></use></svg><span class="rail-button-label">Overview</span></button>
+          <button class="rail-button active" type="button" aria-label="Evidence ledger" aria-current="page" data-tooltip="Evidence ledger"><svg class="nav-icon" aria-hidden="true"><use href="#nav-evidence"></use></svg><span class="rail-button-label">Evidence ledger</span></button>
+          <button class="rail-button" type="button" aria-label="Trace context" data-tooltip="Trace context"><svg class="nav-icon" aria-hidden="true"><use href="#nav-trace"></use></svg><span class="rail-button-label">Trace context</span></button>
+          <button class="rail-button" type="button" aria-label="Source records" data-tooltip="Source records"><svg class="nav-icon" aria-hidden="true"><use href="#nav-source"></use></svg><span class="rail-button-label">Source records</span></button>
+          <a class="rail-button" href="resource-observatory-static.html" aria-label="Resource observatory" data-tooltip="Resource observatory"><svg class="nav-icon" aria-hidden="true"><use href="#nav-resource"></use></svg><span class="rail-button-label">Resource observatory</span></a>
         </nav>
         <nav class="rail-stack" aria-label="Utility views">
-          <button class="rail-button" type="button"><span>CFG</span><span class="rail-button-label">Configuration</span></button>
-          <button class="rail-button" type="button"><span>AUD</span><span class="rail-button-label">Audit view</span></button>
+          <button class="rail-button" type="button" aria-label="Configuration" data-tooltip="Configuration"><svg class="nav-icon" aria-hidden="true"><use href="#nav-config"></use></svg><span class="rail-button-label">Configuration</span></button>
+          <button class="rail-button" type="button" aria-label="Audit view" data-tooltip="Audit view"><svg class="nav-icon" aria-hidden="true"><use href="#nav-audit"></use></svg><span class="rail-button-label">Audit view</span></button>
         </nav>
       </aside>
 
@@ -1427,7 +1556,10 @@
     function setNavigationExpanded(expanded) {
       shell.classList.toggle('nav-expanded', expanded);
       navToggle.setAttribute('aria-expanded', String(expanded));
-      navToggle.querySelector('.nav-toggle-label').textContent = expanded ? 'Collapse menu' : 'Expand menu';
+      const toggleLabel = expanded ? 'Collapse menu' : 'Expand menu';
+      navToggle.setAttribute('aria-label', toggleLabel);
+      navToggle.dataset.tooltip = toggleLabel;
+      navToggle.querySelector('.nav-toggle-label').textContent = toggleLabel;
     }
 
     try {

--- a/examples/visual-operations/prototype/resource-observatory-static.html
+++ b/examples/visual-operations/prototype/resource-observatory-static.html
@@ -165,13 +165,6 @@
     .rail-button-label { display: none; }
     .nav-expanded .rail-button-label { display: inline; }
 
-    .rail-button span:first-child {
-      width: 24px;
-      color: inherit;
-      font: 760 var(--text-micro) var(--font-pulso-mono);
-      letter-spacing: 0.04em;
-    }
-
     .rail-button.active,
     .rail-button:hover,
     .rail-button:focus-visible {
@@ -179,6 +172,125 @@
       color: var(--mc-text);
       outline: 1px solid var(--mc-border-strong);
     }
+
+
+    /* Canonical Mission Control rail geometry shared by both static pages. */
+    .side-rail {
+      position: relative;
+      z-index: 10;
+      gap: var(--space-5);
+      overflow: visible;
+    }
+
+    .mark {
+      width: 40px;
+      height: 40px;
+    }
+
+    .nav-toggle,
+    .rail-button {
+      position: relative;
+      width: 100%;
+      height: 40px;
+      min-height: 40px;
+      padding: 0 10px;
+      border: 1px solid transparent;
+      border-radius: var(--radius-lg);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: var(--space-3);
+      color: var(--mc-text-muted);
+      background: transparent;
+      box-sizing: border-box;
+      text-decoration: none;
+      cursor: pointer;
+    }
+
+    .nav-toggle { border-color: var(--mc-border); }
+
+    .nav-icon {
+      width: 18px;
+      height: 18px;
+      flex: 0 0 18px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 1.75;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .rail-button-label,
+    .nav-toggle-label {
+      display: none;
+      width: auto;
+      min-width: 0;
+    }
+
+    .nav-expanded .rail-button,
+    .nav-expanded .nav-toggle {
+      justify-content: flex-start;
+      padding: 0 var(--space-3);
+    }
+
+    .nav-expanded .rail-button-label,
+    .nav-expanded .nav-toggle-label {
+      display: inline;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-family: var(--font-pulso-sans);
+      font-size: var(--text-body);
+      font-weight: 640;
+      letter-spacing: -0.01em;
+    }
+
+    .rail-button.active,
+    .rail-button:hover,
+    .rail-button:focus-visible,
+    .nav-toggle:hover,
+    .nav-toggle:focus-visible {
+      border-color: var(--mc-border-strong);
+      background: var(--mc-surface-panel-raised);
+      color: var(--mc-text);
+      outline: none;
+    }
+
+    .mission-shell:not(.nav-expanded) [data-tooltip]::after {
+      content: attr(data-tooltip);
+      position: absolute;
+      left: calc(100% + 10px);
+      top: 50%;
+      z-index: 30;
+      padding: 6px 8px;
+      border: 1px solid var(--mc-border-strong);
+      border-radius: var(--radius-md);
+      background: var(--mc-surface-panel-strong);
+      color: var(--mc-text-support);
+      box-shadow: 0 8px 24px rgb(0 0 0 / 0.24);
+      font: 650 var(--text-support) var(--font-pulso-sans);
+      letter-spacing: 0;
+      line-height: 1;
+      white-space: nowrap;
+      opacity: 0;
+      pointer-events: none;
+      transform: translate(4px, -50%);
+      transition: opacity 120ms ease, transform 120ms ease;
+    }
+
+    .mission-shell:not(.nav-expanded) [data-tooltip]:hover::after,
+    .mission-shell:not(.nav-expanded) [data-tooltip]:focus-visible::after {
+      opacity: 1;
+      transform: translate(0, -50%);
+    }
+
+    .icon-sprite {
+      position: absolute;
+      width: 0;
+      height: 0;
+      overflow: hidden;
+    }
+
 
     .app {
       display: grid;
@@ -513,6 +625,16 @@
   </style>
 </head>
 <body>
++  <svg class="icon-sprite" aria-hidden="true">
+    <symbol id="nav-overview" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"></rect><rect x="14" y="3" width="7" height="7" rx="1"></rect><rect x="3" y="14" width="7" height="7" rx="1"></rect><rect x="14" y="14" width="7" height="7" rx="1"></rect></symbol>
+    <symbol id="nav-evidence" viewBox="0 0 24 24"><path d="M6 3h9l3 3v15H6z"></path><path d="M15 3v4h4M9 11h6M9 15h6"></path></symbol>
+    <symbol id="nav-trace" viewBox="0 0 24 24"><path d="M3 12h4l2-5 4 10 2-5h6"></path></symbol>
+    <symbol id="nav-source" viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="7" ry="3"></ellipse><path d="M5 5v6c0 1.7 3.1 3 7 3s7-1.3 7-3V5M5 11v6c0 1.7 3.1 3 7 3s7-1.3 7-3v-6"></path></symbol>
+    <symbol id="nav-resource" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"></circle><path d="M7.5 15a5 5 0 0 1 9-4M12 12l3-3"></path></symbol>
+    <symbol id="nav-config" viewBox="0 0 24 24"><path d="M4 7h10M18 7h2M4 17h2M10 17h10"></path><circle cx="16" cy="7" r="2"></circle><circle cx="8" cy="17" r="2"></circle></symbol>
+    <symbol id="nav-audit" viewBox="0 0 24 24"><path d="M12 3l7 3v5c0 4.6-2.8 8-7 10-4.2-2-7-5.4-7-10V6z"></path><path d="M9 12l2 2 4-4"></path></symbol>
+    <symbol id="nav-toggle-icon" viewBox="0 0 24 24"><path d="M9 6l-4 6 4 6M15 5h5v14h-5"></path></symbol>
+  </svg>
   <div class="stage">
     <main class="mission-shell" id="mission-shell" aria-label="AletheIA Mission Control Resource Observatory static prototype">
       <aside class="side-rail" aria-label="Mission Control navigation">
@@ -521,18 +643,18 @@
             <div class="mark">AI</div>
             <div class="rail-brand"><strong>AletheIA</strong><span>Mission Control</span></div>
           </div>
-          <button class="nav-toggle" type="button" id="nav-toggle" aria-expanded="false" aria-controls="mission-shell"><span>⇄</span><span class="nav-toggle-label">Collapse menu</span></button>
+          <button class="nav-toggle" type="button" id="nav-toggle" aria-label="Expand menu" aria-expanded="false" aria-controls="mission-shell" data-tooltip="Expand menu"><svg class="nav-icon" aria-hidden="true"><use href="#nav-toggle-icon"></use></svg><span class="nav-toggle-label">Expand menu</span></button>
         </div>
         <nav class="rail-stack" aria-label="Workspace views">
-          <a class="rail-button" href="mission-control-static.html"><span>OV</span><span class="rail-button-label">Overview</span></a>
-          <a class="rail-button" href="mission-control-static.html"><span>EV</span><span class="rail-button-label">Evidence ledger</span></a>
-          <a class="rail-button" href="mission-control-static.html"><span>TR</span><span class="rail-button-label">Trace context</span></a>
-          <a class="rail-button" href="mission-control-static.html"><span>SRC</span><span class="rail-button-label">Source records</span></a>
-          <a class="rail-button active" href="resource-observatory-static.html" aria-current="page"><span>RO</span><span class="rail-button-label">Resource observatory</span></a>
+          <a class="rail-button" href="mission-control-static.html" aria-label="Overview" data-tooltip="Overview"><svg class="nav-icon" aria-hidden="true"><use href="#nav-overview"></use></svg><span class="rail-button-label">Overview</span></a>
+          <a class="rail-button" href="mission-control-static.html" aria-label="Evidence ledger" data-tooltip="Evidence ledger"><svg class="nav-icon" aria-hidden="true"><use href="#nav-evidence"></use></svg><span class="rail-button-label">Evidence ledger</span></a>
+          <a class="rail-button" href="mission-control-static.html" aria-label="Trace context" data-tooltip="Trace context"><svg class="nav-icon" aria-hidden="true"><use href="#nav-trace"></use></svg><span class="rail-button-label">Trace context</span></a>
+          <a class="rail-button" href="mission-control-static.html" aria-label="Source records" data-tooltip="Source records"><svg class="nav-icon" aria-hidden="true"><use href="#nav-source"></use></svg><span class="rail-button-label">Source records</span></a>
+          <a class="rail-button active" href="resource-observatory-static.html" aria-label="Resource observatory" aria-current="page" data-tooltip="Resource observatory"><svg class="nav-icon" aria-hidden="true"><use href="#nav-resource"></use></svg><span class="rail-button-label">Resource observatory</span></a>
         </nav>
         <nav class="rail-stack" aria-label="Utility views">
-          <a class="rail-button" href="mission-control-static.html"><span>CFG</span><span class="rail-button-label">Configuration</span></a>
-          <a class="rail-button" href="mission-control-static.html"><span>AUD</span><span class="rail-button-label">Audit view</span></a>
+          <a class="rail-button" href="mission-control-static.html" aria-label="Configuration" data-tooltip="Configuration"><svg class="nav-icon" aria-hidden="true"><use href="#nav-config"></use></svg><span class="rail-button-label">Configuration</span></a>
+          <a class="rail-button" href="mission-control-static.html" aria-label="Audit view" data-tooltip="Audit view"><svg class="nav-icon" aria-hidden="true"><use href="#nav-audit"></use></svg><span class="rail-button-label">Audit view</span></a>
         </nav>
       </aside>
 
@@ -698,7 +820,10 @@
     function setNavigationExpanded(expanded) {
       shell.classList.toggle('nav-expanded', expanded);
       navToggle.setAttribute('aria-expanded', String(expanded));
-      navToggle.querySelector('.nav-toggle-label').textContent = expanded ? 'Collapse menu' : 'Expand menu';
+      const toggleLabel = expanded ? 'Collapse menu' : 'Expand menu';
+      navToggle.setAttribute('aria-label', toggleLabel);
+      navToggle.dataset.tooltip = toggleLabel;
+      navToggle.querySelector('.nav-toggle-label').textContent = toggleLabel;
     }
 
     try {

--- a/tests/visual-operations/test-static-prototype-state.test.ts
+++ b/tests/visual-operations/test-static-prototype-state.test.ts
@@ -6,6 +6,16 @@ const prototypePath = path.resolve(
   process.cwd(),
   "examples/visual-operations/prototype/mission-control-static.html",
 );
+const observatoryPath = path.resolve(
+  process.cwd(),
+  "examples/visual-operations/prototype/resource-observatory-static.html",
+);
+
+function navigationLabels(html: string): string[] {
+  return [...html.matchAll(/class="rail-button[^"]*"[^>]*aria-label="([^"]+)"/g)].map(
+    (match) => match[1],
+  );
+}
 
 describe("Mission Control static prototype initial state", () => {
   it("opens with the evidence inspector closed", () => {
@@ -18,5 +28,31 @@ describe("Mission Control static prototype initial state", () => {
     expect(html).not.toContain('class="inspector-backdrop open"');
     expect(html).not.toContain('class="inspector open"');
     expect(html).not.toContain('class="slice-card selected"');
+  });
+
+  it("keeps the same icon rail and tooltips across static pages", () => {
+    const home = fs.readFileSync(prototypePath, "utf8");
+    const observatory = fs.readFileSync(observatoryPath, "utf8");
+    const expectedLabels = [
+      "Overview",
+      "Evidence ledger",
+      "Trace context",
+      "Source records",
+      "Resource observatory",
+      "Configuration",
+      "Audit view",
+    ];
+
+    expect(navigationLabels(home)).toEqual(expectedLabels);
+    expect(navigationLabels(observatory)).toEqual(expectedLabels);
+
+    for (const html of [home, observatory]) {
+      expect(html).toContain("Canonical Mission Control rail geometry shared by both static pages.");
+      expect(html).toContain("height: 40px;");
+      expect(html.match(/class="nav-icon"/g)).toHaveLength(8);
+      for (const label of expectedLabels) {
+        expect(html).toContain(`data-tooltip="${label}"`);
+      }
+    }
   });
 });


### PR DESCRIPTION
## What changed
- replaces closed-menu abbreviations with the same local SVG icon set on both static pages
- standardizes rail controls to a 40px geometry with identical spacing, borders, typography, and alignment
- adds hover and keyboard-focus tooltips while the rail is collapsed
- keeps accessible labels and synchronizes the expand/collapse label
- extends regression coverage to compare navigation order, icons, tooltips, and geometry across both pages

## Why
The two pages still rendered different lateral menus, with misaligned controls and inconsistent sizes. Text abbreviations also made the collapsed navigation harder to scan.

## How to validate
- open both static prototype pages side by side
- compare button alignment in collapsed and expanded states
- hover or focus each collapsed icon and confirm its tooltip
- navigate between pages and confirm the rail state remains consistent
- run `pnpm vitest run tests/visual-operations/test-static-prototype-state.test.ts`
- run `pnpm check:governance`
- run `pnpm test`
- run `./scripts/check-visual-ops-snapshots.sh`

## Risks and follow-ups
- icons are inline local SVG symbols; no dependency or network asset was introduced
- rendered Browser automation cannot navigate to local `file://` artifacts in this environment, so both files were opened for manual review and static parity tests were added
- `plans/` remains untouched and untracked