### PR TITLE
fix(visual-operations): restore inspector focus

### DIFF
--- a/examples/visual-operations/prototype/mission-control-static.html
+++ b/examples/visual-operations/prototype/mission-control-static.html
@@ -1509,6 +1509,7 @@
     const inspector = document.getElementById('evidence-inspector');
     const inspectorBackdrop = document.getElementById('inspector-backdrop');
     const sheetClose = document.getElementById('sheet-close');
+    let inspectorTrigger = null;
 
     const filterSummary = document.getElementById('filter-summary');
 
@@ -1524,19 +1525,24 @@
       boundary: document.getElementById('inspector-boundary')
     };
 
-    function openInspector() {
+    function openInspector(trigger) {
+      inspectorTrigger = trigger;
       inspector.classList.add('open');
       inspectorBackdrop.classList.add('open');
       inspector.setAttribute('aria-hidden', 'false');
+      requestAnimationFrame(() => sheetClose.focus());
     }
 
     function closeInspector() {
+      const wasOpen = inspector.classList.contains('open');
       inspector.classList.remove('open');
       inspectorBackdrop.classList.remove('open');
       inspector.setAttribute('aria-hidden', 'true');
+      if (wasOpen && inspectorTrigger?.isConnected) inspectorTrigger.focus();
+      inspectorTrigger = null;
     }
 
-    function renderInspector(key) {
+    function renderInspector(key, trigger) {
       const data = details[key] || details['human-review'];
       fields.kicker.textContent = data.kicker;
       fields.title.textContent = data.title;
@@ -1550,7 +1556,7 @@
       }).join('');
       fields.trace.innerHTML = data.trace.map(([time, copy]) => `<div class="trace-item"><span class="trace-time">${time}</span><span>${copy}</span></div>`).join('');
       fields.boundary.textContent = data.boundary;
-      openInspector();
+      openInspector(trigger);
     }
 
     function setNavigationExpanded(expanded) {
@@ -1584,7 +1590,7 @@
       card.addEventListener('click', () => {
         document.querySelectorAll('.slice-card').forEach(item => item.classList.remove('selected'));
         card.classList.add('selected');
-        renderInspector(card.dataset.detail);
+        renderInspector(card.dataset.detail, card);
       });
     });
 

--- a/examples/visual-operations/prototype/resource-observatory-static.html
+++ b/examples/visual-operations/prototype/resource-observatory-static.html
@@ -805,6 +805,7 @@
     const signalInspector = document.getElementById('signal-inspector');
     const inspectorBackdrop = document.getElementById('inspector-backdrop');
     const inspectorClose = document.getElementById('inspector-close');
+    let inspectorTrigger = null;
     const signalDetails = {
       'context-tokens': { kicker: 'Reported signal', title: 'Context tokens · 128k', summary: 'Reported from a synthetic APOB event sample.', source: 'OBS-CTX-01', origin: 'reported', availability: 'available', interpretation: 'Context volume is visible for review. No target, threshold, or decision is inferred from this value.' },
       'token-cost': { kicker: 'Unavailable signal', title: 'Token cost · unavailable', summary: 'No durable cost export exists for this docs-only slice.', source: 'OBS-COST-∅', origin: 'unavailable', availability: 'unavailable', interpretation: 'Absence of cost telemetry is represented neutrally. The interface does not invent or estimate a replacement value.' },
@@ -839,14 +840,18 @@
     });
 
     function closeSignalInspector() {
+      const wasOpen = signalInspector.classList.contains('open');
       signalInspector.classList.remove('open');
       inspectorBackdrop.classList.remove('open');
       signalInspector.setAttribute('aria-hidden', 'true');
+      if (wasOpen && inspectorTrigger?.isConnected) inspectorTrigger.focus();
+      inspectorTrigger = null;
     }
 
-    function openSignalInspector(key) {
+    function openSignalInspector(key, trigger) {
       const detail = signalDetails[key];
       if (!detail) return;
+      inspectorTrigger = trigger;
       document.querySelectorAll('.signal-card').forEach(card => card.classList.toggle('selected', card.dataset.signal === key));
       document.getElementById('inspector-kicker').textContent = detail.kicker;
       document.getElementById('inspector-title').textContent = detail.title;
@@ -858,14 +863,15 @@
       signalInspector.classList.add('open');
       inspectorBackdrop.classList.add('open');
       signalInspector.setAttribute('aria-hidden', 'false');
+      requestAnimationFrame(() => inspectorClose.focus());
     }
 
     document.querySelectorAll('.signal-card').forEach(card => {
-      card.addEventListener('click', () => openSignalInspector(card.dataset.signal));
+      card.addEventListener('click', () => openSignalInspector(card.dataset.signal, card));
       card.addEventListener('keydown', event => {
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault();
-          openSignalInspector(card.dataset.signal);
+          openSignalInspector(card.dataset.signal, card);
         }
       });
     });

--- a/tests/visual-operations/test-static-prototype-state.test.ts
+++ b/tests/visual-operations/test-static-prototype-state.test.ts
@@ -55,4 +55,19 @@ describe("Mission Control static prototype initial state", () => {
       }
     }
   });
+
+  it("moves focus into each inspector and restores it to its trigger", () => {
+    const home = fs.readFileSync(prototypePath, "utf8");
+    const observatory = fs.readFileSync(observatoryPath, "utf8");
+
+    expect(home).toContain("requestAnimationFrame(() => sheetClose.focus())");
+    expect(home).toContain("renderInspector(card.dataset.detail, card)");
+    expect(observatory).toContain("requestAnimationFrame(() => inspectorClose.focus())");
+    expect(observatory).toContain("openSignalInspector(card.dataset.signal, card)");
+
+    for (const html of [home, observatory]) {
+      expect(html).toContain("if (wasOpen && inspectorTrigger?.isConnected) inspectorTrigger.focus()");
+      expect(html).toContain("inspectorTrigger = null");
+    }
+  });
 });


### PR DESCRIPTION
## What changed
- moves keyboard focus to the close control when either static inspector opens
- remembers the initiating Work Slice or signal card
- restores focus to that trigger when closing by button, backdrop, or Escape
- adds regression coverage for both inspector flows

## Why
The side sheets changed visual state without managing keyboard focus, making the interaction harder to follow and leaving users without a predictable return point.

## How to validate
- focus a Work Slice or Resource Observatory signal
- activate it and confirm focus moves to the inspector close button
- close by button, backdrop, and Escape; confirm focus returns to the initiating card
- run `pnpm vitest run tests/visual-operations/test-static-prototype-state.test.ts`
- run `pnpm check:governance`
- run `pnpm test`
- run `./scripts/check-visual-ops-snapshots.sh`

## Risks and follow-ups
- no focus trap was introduced; this slice only establishes entry and return focus
- Browser automation cannot navigate to these local `file://` artifacts under current policy, so interaction source regression coverage and manual opening were used
- no runtime, backend, data, schema, or dependency changes
- `plans/` remains untouched and untracked