### PR TITLE
feat(visual-ops): implement Evidence Ledger

### DIFF
--- a/apps/mission-control/README.md
+++ b/apps/mission-control/README.md
@@ -5,17 +5,17 @@ projection.
 
 ## Current slice
 
-The implementation intentionally contains only:
+The implementation currently contains:
 
 - the shared full-browser shell;
 - the collapsible navigation rail;
 - the global operational header;
-- Evidence Ledger and Resource Observatory placeholder routes;
+- a functional Evidence Ledger with typed local fixtures, derived filters, Work Slice cards, and an evidence inspector;
+- a Resource Observatory placeholder route;
 - navigation, persistence, focus, and responsive tests.
 
-The accepted static prototypes remain the visual and content reference. Cards,
-inspectors, filters, signals, projection adapters, and live source integration are
-outside this slice.
+The accepted static prototypes remain the visual and content reference. Resource
+signals, projection adapters, and live source integration remain outside this slice.
 
 ## Run locally
 

--- a/apps/mission-control/src/App.test.tsx
+++ b/apps/mission-control/src/App.test.tsx
@@ -17,6 +17,7 @@ describe("Mission Control shared shell", () => {
     expect(screen.getByRole("heading", { name: "AletheIA Mission Control" })).toBeInTheDocument();
     expect(screen.getByText("Work slices by review posture")).toBeInTheDocument();
     expect(screen.getByText("Source records remain authoritative")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("navigates to Resource Observatory without replacing the shell", async () => {

--- a/apps/mission-control/src/features/evidence-ledger/EvidenceInspector.tsx
+++ b/apps/mission-control/src/features/evidence-ledger/EvidenceInspector.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef } from "react";
+import type { EvidenceRecord } from "./evidenceLedgerFixtures";
+
+type EvidenceInspectorProps = {
+  record: EvidenceRecord | null;
+  onClose: () => void;
+};
+
+export function EvidenceInspector({ record, onClose }: EvidenceInspectorProps) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!record) return;
+    closeRef.current?.focus();
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [record, onClose]);
+
+  return (
+    <>
+      <button className={`inspector-backdrop${record ? " open" : ""}`} type="button" aria-label="Close evidence inspector" tabIndex={record ? 0 : -1} onClick={onClose} />
+      <aside className={`inspector${record ? " open" : ""}`} role="dialog" aria-modal="true" aria-labelledby="inspector-title" aria-hidden={!record}>
+        {record ? (
+          <>
+            <header className="inspector-header">
+              <div className="inspector-title-row">
+                <div><p className="inspector-kicker">{record.inspector.kicker}</p><h2 className="inspector-title" id="inspector-title">{record.title}</h2></div>
+                <button ref={closeRef} className="sheet-close" type="button" aria-label="Close evidence inspector" onClick={onClose}>×</button>
+              </div>
+              <p className="inspector-copy">{record.inspector.summary}</p>
+            </header>
+            <div className="inspector-body">
+              <section className="inspector-section is-primary">
+                <h3>Source refs</h3>
+                <div className="source-list">
+                  {record.inspector.sources.map((source) => (
+                    <div className="source-item" key={`${source.name}-${source.type}`}>
+                      <span className="source-main"><span className="source-name">{source.name}</span><span className="source-type">{source.type}</span></span>
+                      <span className={`source-origin ${source.origin}`}>{source.origin}</span>
+                    </div>
+                  ))}
+                </div>
+                <p className="source-ledger-note">References identify where the posture came from; origin labels describe availability, not authority.</p>
+              </section>
+              <section className="inspector-section is-state">
+                <h3>State posture</h3>
+                <div className="state-summary">
+                  <div className="state-cell"><span>Lane</span><strong>{record.inspector.lane}</strong></div>
+                  <div className="state-cell"><span>Status</span><strong>{record.inspector.status}</strong></div>
+                  <div className="state-cell"><span>Confidence</span><strong>{record.inspector.confidence}</strong></div>
+                </div>
+              </section>
+              <section className="inspector-section">
+                <h3>Trace context</h3>
+                <div className="trace-list">
+                  {record.inspector.trace.map((trace) => <div className="trace-item" key={`${trace.time}-${trace.description}`}><span className="trace-time">{trace.time}</span><span>{trace.description}</span></div>)}
+                </div>
+              </section>
+              <section className="inspector-section">
+                <h3>Boundary</h3>
+                <p className="boundary-note">{record.inspector.boundary}</p>
+              </section>
+            </div>
+          </>
+        ) : null}
+      </aside>
+    </>
+  );
+}

--- a/apps/mission-control/src/features/evidence-ledger/EvidenceLedger.test.tsx
+++ b/apps/mission-control/src/features/evidence-ledger/EvidenceLedger.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+import { App } from "../../App";
+
+function renderLedger() {
+  return render(<MemoryRouter initialEntries={["/"]}><App /></MemoryRouter>);
+}
+
+describe("Evidence Ledger", () => {
+  beforeEach(() => window.sessionStorage.clear());
+
+  it("renders seven source-backed fixture cards across derived lanes", () => {
+    renderLedger();
+    expect(screen.getByText("7 visible · All")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Critical risk signal/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Resolve missing telemetry/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Dogfood evidence record/ })).toBeInTheDocument();
+    expect(screen.getByLabelText("Review prompts lane")).toBeInTheDocument();
+    expect(screen.getByLabelText("Closed stable lane")).toBeInTheDocument();
+  });
+
+  it("filters presentation records without mutating lane authority", async () => {
+    const user = userEvent.setup();
+    renderLedger();
+
+    await user.click(screen.getByRole("button", { name: "Needs attention" }));
+    expect(screen.getByText("2 visible · Needs attention")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Critical risk signal/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Policy update impact check/ })).not.toBeInTheDocument();
+    expect(screen.getByText("No closed slices match this filter. Filtering does not reopen or mutate work.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Unavailable" }));
+    expect(screen.getByText("1 visible · Unavailable")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Resolve missing telemetry/ })).toBeInTheDocument();
+  });
+
+  it("opens sourced detail, closes with Escape, and returns focus to its card", async () => {
+    const user = userEvent.setup();
+    renderLedger();
+    const trigger = screen.getByRole("button", { name: /Critical risk signal/ });
+
+    await user.click(trigger);
+    const inspector = screen.getByRole("dialog", { name: "Critical risk signal" });
+    const closeButton = within(inspector).getByRole("button", { name: "Close evidence inspector" });
+    expect(closeButton).toHaveFocus();
+    expect(within(inspector).getByText("SRC-2147")).toBeInTheDocument();
+    expect(within(inspector).getByText(/does not authorize decisions/)).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("keeps unavailable provenance neutral and does not invent estimates", async () => {
+    const user = userEvent.setup();
+    renderLedger();
+    await user.click(screen.getByRole("button", { name: /Resolve missing telemetry/ }));
+    const inspector = screen.getByRole("dialog", { name: "Resolve missing telemetry" });
+
+    expect(within(inspector).getByText("Telemetry unavailable")).toBeInTheDocument();
+    expect(within(inspector).getByText("Unknown")).toBeInTheDocument();
+    expect(within(inspector).getByText("unavailable", { selector: ".source-origin" })).toBeInTheDocument();
+    expect(within(inspector).getByText(/No estimates generated/)).toBeInTheDocument();
+  });
+});

--- a/apps/mission-control/src/features/evidence-ledger/EvidenceLedger.tsx
+++ b/apps/mission-control/src/features/evidence-ledger/EvidenceLedger.tsx
@@ -1,0 +1,35 @@
+import type { EvidenceFilter, EvidenceRecord } from "./evidenceLedgerFixtures";
+import { evidenceLanes, evidenceRecords } from "./evidenceLedgerFixtures";
+import { WorkSliceCard } from "./WorkSliceCard";
+
+type EvidenceLedgerProps = {
+  filter: EvidenceFilter;
+  selectedId: string | null;
+  onInspect: (record: EvidenceRecord, trigger: HTMLButtonElement) => void;
+};
+
+export function EvidenceLedger({ filter, selectedId, onInspect }: EvidenceLedgerProps) {
+  const visibleRecords = filter === "all" ? evidenceRecords : evidenceRecords.filter((record) => record.filterStatus === filter);
+
+  return (
+    <section className="ledger-shell" aria-label="Work Slice evidence board">
+      <div className="ledger-toolbar">
+        <div className="ledger-title"><span>Ledger confidence</span><span className="progress-track" aria-hidden="true"><span /></span><span className="utility">42%</span></div>
+        <span className="utility">Derived review posture · source records authoritative</span>
+      </div>
+      <div className="board-scroll">
+        <div className="board-grid">
+          {evidenceLanes.map((lane) => {
+            const records = visibleRecords.filter((record) => record.laneId === lane.id);
+            return (
+              <section className={`lane${records.length === 0 ? " is-empty" : ""}`} aria-label={`${lane.label} lane`} key={lane.id}>
+                <header className="lane-head"><span className="lane-name"><span className={`state-dot ${lane.tone}`} />{lane.label}</span><span className="lane-count">{records.length}</span></header>
+                {records.length > 0 ? <div className="slice-list">{records.map((record) => <WorkSliceCard key={record.id} record={record} selected={selectedId === record.id} onInspect={onInspect} />)}</div> : <p className="empty-lane">{lane.emptyMessage}</p>}
+              </section>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/mission-control/src/features/evidence-ledger/WorkSliceCard.tsx
+++ b/apps/mission-control/src/features/evidence-ledger/WorkSliceCard.tsx
@@ -1,0 +1,27 @@
+import type { EvidenceRecord } from "./evidenceLedgerFixtures";
+
+type WorkSliceCardProps = {
+  record: EvidenceRecord;
+  selected: boolean;
+  onInspect: (record: EvidenceRecord, trigger: HTMLButtonElement) => void;
+};
+
+export function WorkSliceCard({ record, selected, onInspect }: WorkSliceCardProps) {
+  return (
+      <button
+        className={`slice-card${selected ? " selected" : ""}`}
+        type="button"
+        data-tone={record.tone}
+        aria-pressed={selected}
+        onClick={(event) => onInspect(record, event.currentTarget)}
+      >
+        <span className="slice-meta"><span>{record.reference}</span><span className={`chip ${record.tone}`}>{record.label}</span></span>
+        <strong className="slice-title">{record.title}</strong>
+        <span className="slice-copy">{record.cardSummary}</span>
+        <span className="slice-footer">
+          <span className="source-stack">{record.sourceRefs.map((source) => <span className="source-ref" key={source}>{source}</span>)}</span>
+          <span className="card-action">Inspect</span>
+        </span>
+      </button>
+  );
+}

--- a/apps/mission-control/src/features/evidence-ledger/evidenceLedgerFixtures.ts
+++ b/apps/mission-control/src/features/evidence-ledger/evidenceLedgerFixtures.ts
@@ -1,0 +1,248 @@
+export type EvidenceFilter = "all" | "attention" | "stable" | "unavailable";
+export type EvidenceTone = "critical" | "review" | "stable" | "info";
+export type EvidenceOrigin = "reported" | "estimated" | "unavailable";
+export type EvidenceLaneId = "review" | "validation" | "reconcile" | "closed";
+
+export type EvidenceSource = {
+  name: string;
+  type: string;
+  origin: EvidenceOrigin;
+};
+
+export type EvidenceTrace = {
+  time: string;
+  description: string;
+};
+
+export type EvidenceRecord = {
+  id: string;
+  reference: string;
+  laneId: EvidenceLaneId;
+  filterStatus: Exclude<EvidenceFilter, "all">;
+  tone: EvidenceTone;
+  label: string;
+  title: string;
+  cardSummary: string;
+  sourceRefs: string[];
+  inspector: {
+    kicker: string;
+    summary: string;
+    lane: string;
+    status: string;
+    confidence: "Low" | "Medium" | "High" | "Unknown";
+    sources: EvidenceSource[];
+    trace: EvidenceTrace[];
+    boundary: string;
+  };
+};
+
+export type EvidenceLane = {
+  id: EvidenceLaneId;
+  label: string;
+  tone: EvidenceTone;
+  emptyMessage: string;
+};
+
+export const evidenceLanes: EvidenceLane[] = [
+  { id: "review", label: "Review prompts", tone: "critical", emptyMessage: "No review prompts match this filter. Absence is a filtered view, not source truth." },
+  { id: "validation", label: "Validation", tone: "review", emptyMessage: "No validation slices match this filter. Source records remain unchanged." },
+  { id: "reconcile", label: "Reconcile", tone: "info", emptyMessage: "No reconcile slices match this filter. Unknown and unavailable states stay neutral." },
+  { id: "closed", label: "Closed stable", tone: "stable", emptyMessage: "No closed slices match this filter. Filtering does not reopen or mutate work." },
+];
+
+export const evidenceRecords: EvidenceRecord[] = [
+  {
+    id: "human-review",
+    reference: "WS-2026-0616-001",
+    laneId: "review",
+    filterStatus: "attention",
+    tone: "critical",
+    label: "Human review",
+    title: "Critical risk signal",
+    cardSummary: "Threshold breach detected. Human confirmation is required before trusting closure.",
+    sourceRefs: ["SRC-2147", "PR-2.1"],
+    inspector: {
+      kicker: "Human review · confirmed",
+      summary: "A source says human review is required before trusting closure. This is a review prompt, not an automated decision.",
+      lane: "Review prompts",
+      status: "Pending human review",
+      confidence: "Low",
+      sources: [
+        { name: "SRC-2147", type: "Risk source", origin: "reported" },
+        { name: "Risk Policy PR-2.1", type: "Policy reference", origin: "reported" },
+        { name: "Rule R-7", type: "Rule reference", origin: "reported" },
+      ],
+      trace: [
+        { time: "10:18", description: "Risk threshold breach normalized into visual event." },
+        { time: "10:22", description: "Human review source required before closure posture can be trusted." },
+      ],
+      boundary: "Do not move this slice to closed without a resolving review source. The cockpit explains evidence; it does not authorize decisions.",
+    },
+  },
+  {
+    id: "conflict",
+    reference: "WS-2026-0616-002",
+    laneId: "review",
+    filterStatus: "attention",
+    tone: "review",
+    label: "Conflict",
+    title: "Model output mismatch",
+    cardSummary: "Validation sources disagree with the policy baseline and risk thresholds.",
+    sourceRefs: ["SRC-2149", "Eval 3.2"],
+    inspector: {
+      kicker: "Validation · conflicted",
+      summary: "Validation sources disagree. The ledger preserves both source refs instead of choosing the convenient truth.",
+      lane: "Review prompts",
+      status: "Conflicted validation",
+      confidence: "Medium",
+      sources: [
+        { name: "SRC-2149", type: "Validation source", origin: "reported" },
+        { name: "Eval Report v3.2", type: "Evaluation output", origin: "reported" },
+        { name: "Policy M-1.4", type: "Policy baseline", origin: "reported" },
+      ],
+      trace: [
+        { time: "10:05", description: "Evaluation output diverged from policy baseline." },
+        { time: "10:11", description: "Conflict surfaced as review posture, not an automated decision." },
+      ],
+      boundary: "Conflicted confidence is stronger than the lane label itself. Reconcile before treating this as stable.",
+    },
+  },
+  {
+    id: "validated",
+    reference: "WS-2026-0615-006",
+    laneId: "validation",
+    filterStatus: "stable",
+    tone: "stable",
+    label: "Validated",
+    title: "Policy update impact check",
+    cardSummary: "Evidence supports the validation posture for this static example.",
+    sourceRefs: ["SRC-2120", "Eval 3.1"],
+    inspector: {
+      kicker: "Validation · stable",
+      summary: "Evidence supports the validation posture for this static example.",
+      lane: "Validation",
+      status: "Validated",
+      confidence: "High",
+      sources: [
+        { name: "SRC-2120", type: "Evidence source", origin: "reported" },
+        { name: "Eval v3.1", type: "Evaluation output", origin: "reported" },
+      ],
+      trace: [
+        { time: "08:52", description: "Evaluation source attached." },
+        { time: "08:58", description: "Policy impact check remained inside expected bounds." },
+      ],
+      boundary: "Stable still links to source refs for verification. Stability is derived, not authoritative.",
+    },
+  },
+  {
+    id: "skill",
+    reference: "WS-2026-0615-004",
+    laneId: "validation",
+    filterStatus: "stable",
+    tone: "stable",
+    label: "Skill traced",
+    title: "Adaptive skill activation",
+    cardSummary: "Skill activation is visible as trace context, without gate or decision authority.",
+    sourceRefs: ["ACT-552", "Trace"],
+    inspector: {
+      kicker: "Skill activation · traced",
+      summary: "Skill activation is visible as trace context, without gate or decision authority.",
+      lane: "Validation",
+      status: "Activation tracked",
+      confidence: "High",
+      sources: [
+        { name: "ACT-552", type: "Activation record", origin: "reported" },
+        { name: "Trace Event", type: "Trace normalization", origin: "reported" },
+        { name: "Skill Registry", type: "Registry reference", origin: "reported" },
+      ],
+      trace: [
+        { time: "08:31", description: "Skill activation normalized into trace context." },
+        { time: "08:35", description: "No readiness gate was changed by the activation." },
+      ],
+      boundary: "Skills appear as activations. They do not approve gates, close slices, or override source records.",
+    },
+  },
+  {
+    id: "telemetry",
+    reference: "WS-2026-0616-003",
+    laneId: "reconcile",
+    filterStatus: "unavailable",
+    tone: "info",
+    label: "Unavailable",
+    title: "Resolve missing telemetry",
+    cardSummary: "Runtime, token, and cost records were not exported for this docs-only slice.",
+    sourceRefs: ["Telemetry", "R-556"],
+    inspector: {
+      kicker: "Reconcile · unavailable",
+      summary: "Optional runtime, token, or cost telemetry was not exported. This is a neutral source gap, not a failed slice.",
+      lane: "Reconcile",
+      status: "Telemetry unavailable",
+      confidence: "Unknown",
+      sources: [
+        { name: "Telemetry Spec", type: "Expected source", origin: "unavailable" },
+        { name: "Closeout R-556", type: "Reconcile rule", origin: "reported" },
+      ],
+      trace: [
+        { time: "09:42", description: "Token and cost fields marked unavailable." },
+        { time: "09:44", description: "No estimates generated because source origin is missing." },
+      ],
+      boundary: "Do not invent estimates just to complete the card. Use unavailable until a durable source exists.",
+    },
+  },
+  {
+    id: "closed-207",
+    reference: "PR #207",
+    laneId: "closed",
+    filterStatus: "stable",
+    tone: "stable",
+    label: "Closed",
+    title: "Human-review source mapping",
+    cardSummary: "Source supports closure; review source remains represented as unavailable.",
+    sourceRefs: ["PR #207", "39f76cf"],
+    inspector: {
+      kicker: "Closed · confirmed",
+      summary: "Source records support closure while human_review remains unavailable because no durable review source was supplied.",
+      lane: "Closed stable",
+      status: "Closed derived posture",
+      confidence: "High",
+      sources: [
+        { name: "PR #207", type: "Pull request", origin: "reported" },
+        { name: "CI 27626141953", type: "Check run", origin: "reported" },
+        { name: "Merge 39f76cf", type: "Merge ref", origin: "reported" },
+      ],
+      trace: [
+        { time: "2026-06-16", description: "PR merged after governance and test checks." },
+        { time: "2026-06-16", description: "Review source absence preserved as unavailable metadata." },
+      ],
+      boundary: "Closed is a presentation posture derived from sources, not a new authority.",
+    },
+  },
+  {
+    id: "closed-201",
+    reference: "PR #201",
+    laneId: "closed",
+    filterStatus: "stable",
+    tone: "stable",
+    label: "Closed",
+    title: "Dogfood evidence record",
+    cardSummary: "Snapshot evidence supports closeout; human review absence remains visible.",
+    sourceRefs: ["Dogfood", "Snapshot"],
+    inspector: {
+      kicker: "Closed · confirmed",
+      summary: "Snapshot evidence supports closeout. Human review unavailable remains visible as honest absence of source authority.",
+      lane: "Closed stable",
+      status: "Closed derived posture",
+      confidence: "High",
+      sources: [
+        { name: "PR #201", type: "Pull request", origin: "reported" },
+        { name: "Dogfood snapshot", type: "Snapshot", origin: "reported" },
+        { name: "Human review", type: "Review source", origin: "unavailable" },
+      ],
+      trace: [
+        { time: "2026-06-15", description: "Dogfood snapshot recorded." },
+        { time: "2026-06-15", description: "Closeout posture reconstructed from source refs." },
+      ],
+      boundary: "Unavailable is not failure; it is absence of authoritative source.",
+    },
+  },
+];

--- a/apps/mission-control/src/styles.css
+++ b/apps/mission-control/src/styles.css
@@ -13,7 +13,10 @@
   --mc-text: #f6f3ff;
   --mc-text-support: #c5c2d2;
   --mc-text-muted: #8f89a8;
+  --mc-critical: #da6a88;
+  --mc-review: #e0a144;
   --mc-stable: #7ddba9;
+  --mc-info: #79b9d8;
   --rail-width: 72px;
   --mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
@@ -67,6 +70,97 @@ button, a { font: inherit; }
 .route-placeholder strong { min-width: 0; max-width: 620px; overflow-wrap: anywhere; font-size: 1.1rem; }
 .route-placeholder span { min-width: 0; max-width: 620px; overflow-wrap: anywhere; color: var(--mc-text-muted); font-size: 0.82rem; line-height: 1.5; }
 
+.evidence-workspace > * { max-width: none; }
+.evidence-workspace > .workspace-header { max-width: 980px; }
+.ledger-controls { margin-top: 24px; display: flex; align-items: center; justify-content: flex-end; gap: 12px; }
+.filters { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; }
+.filter-button { height: 32px; padding: 0 12px; border: 1px solid var(--mc-border); border-radius: 8px; color: var(--mc-text-muted); background: transparent; font-size: 0.76rem; cursor: pointer; }
+.filter-button[aria-pressed="true"], .filter-button:hover, .filter-button:focus-visible { border-color: var(--mc-border-strong); outline: none; color: var(--mc-text); background: var(--mc-surface-raised); }
+.filter-summary, .utility { color: var(--mc-text-muted); font: 720 0.62rem var(--mono); white-space: nowrap; }
+.metrics-row { margin: 12px 0 16px; display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 8px; }
+.metric { min-height: 72px; padding: 12px 14px; display: grid; align-content: space-between; border: 1px solid var(--mc-border); border-radius: 8px; background: color-mix(in oklab, var(--mc-surface-raised) 46%, transparent); }
+.metric span { color: var(--mc-text-muted); font: 720 0.62rem var(--mono); text-transform: uppercase; }
+.metric strong { font-size: 1.34rem; line-height: 1; }
+.metric-review { color: var(--mc-review); }
+.metric-critical { color: var(--mc-critical); }
+.metric-info { color: var(--mc-info); }
+.metric-stable { color: var(--mc-stable); }
+.ledger-shell { border: 1px solid var(--mc-border); border-radius: 14px; overflow: hidden; background: var(--mc-surface-page); }
+.ledger-toolbar { padding: 13px 16px; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; border-bottom: 1px solid var(--mc-border); background: #100d1c; }
+.ledger-title { min-width: 0; display: flex; align-items: center; gap: 12px; color: var(--mc-text-support); font-size: 0.82rem; font-weight: 680; }
+.progress-track { width: 112px; height: 4px; overflow: hidden; border-radius: 999px; background: rgb(174 185 207 / 14%); }
+.progress-track span { display: block; width: 42%; height: 100%; background: var(--mc-review); }
+.board-scroll { overflow-x: auto; }
+.board-grid { min-width: 960px; display: grid; grid-template-columns: repeat(4, minmax(220px, 1fr)); }
+.lane { min-height: 420px; border-right: 1px solid var(--mc-border); background: #100d1c; }
+.lane:last-child { border-right: 0; }
+.lane-head { position: sticky; top: 0; z-index: 2; padding: 11px 16px; display: flex; align-items: center; justify-content: space-between; gap: 12px; border-bottom: 1px solid var(--mc-border); background: #151126; }
+.lane-name { min-width: 0; display: flex; align-items: center; gap: 8px; color: var(--mc-text-support); font-size: 0.76rem; font-weight: 720; text-transform: uppercase; letter-spacing: 0.035em; }
+.lane-count { color: var(--mc-text-muted); font-size: 0.68rem; }
+.state-dot { width: 6px; height: 6px; flex: 0 0 6px; border-radius: 999px; background: var(--mc-text-muted); }
+.state-dot.critical { background: var(--mc-critical); }
+.state-dot.review { background: var(--mc-review); }
+.state-dot.stable { background: var(--mc-stable); }
+.state-dot.info { background: var(--mc-info); }
+.slice-list { padding: 10px 12px 14px; display: grid; gap: 10px; }
+.slice-card { position: relative; width: 100%; padding: 13px 14px; display: grid; gap: 10px; border: 1px solid var(--mc-border); border-radius: 8px; color: inherit; background: #1b1630; text-align: left; cursor: pointer; transition: border-color 140ms ease, background 140ms ease, transform 140ms ease; }
+.slice-card::before { content: ""; width: 100%; height: 2px; border-radius: 999px; background: var(--mc-border-strong); }
+.slice-card[data-tone="critical"]::before { background: var(--mc-critical); }
+.slice-card[data-tone="review"]::before { background: var(--mc-review); }
+.slice-card[data-tone="stable"]::before { background: var(--mc-stable); }
+.slice-card[data-tone="info"]::before { background: var(--mc-info); }
+.slice-card:hover, .slice-card:focus-visible, .slice-card.selected { border-color: var(--mc-border-strong); outline: none; background: var(--mc-surface-raised); }
+.slice-card:hover { transform: translateY(-1px); }
+.slice-card.selected { box-shadow: 0 0 0 1px color-mix(in oklab, var(--mc-review) 52%, transparent); }
+.slice-meta { display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--mc-text-muted); font: 720 0.62rem var(--mono); }
+.slice-title { color: var(--mc-text); font-size: 0.91rem; line-height: 1.25; letter-spacing: -0.018em; }
+.slice-copy { color: var(--mc-text-muted); font-size: 0.76rem; line-height: 1.36; }
+.slice-footer { padding-top: 9px; display: flex; align-items: center; justify-content: space-between; gap: 12px; border-top: 1px solid var(--mc-border); }
+.source-stack { display: flex; flex-wrap: wrap; gap: 5px; }
+.source-ref, .chip { padding: 3px 7px; border: 1px solid var(--mc-border-strong); border-radius: 8px; color: var(--mc-text-support); background: #292143; font: 720 0.58rem var(--mono); white-space: nowrap; }
+.chip.critical { color: #f09cad; border-color: #784058; }
+.chip.review { color: #e5bd77; border-color: #705429; }
+.chip.stable { color: #a6dfbd; border-color: #355f4b; }
+.chip.info { color: #afd6e8; border-color: #365c70; }
+.card-action { color: var(--mc-text-muted); font: 760 0.58rem var(--mono); text-transform: uppercase; letter-spacing: 0.08em; }
+.slice-card:hover .card-action, .slice-card:focus-visible .card-action, .slice-card.selected .card-action { color: var(--mc-review); }
+.empty-lane { margin: 14px; padding: 20px 14px; border: 1px dashed var(--mc-border); border-radius: 8px; color: var(--mc-text-muted); font-size: 0.72rem; line-height: 1.45; text-align: center; }
+.inspector-backdrop { position: fixed; inset: 0; z-index: 19; border: 0; background: rgb(0 0 0 / 28%); opacity: 0; pointer-events: none; transition: opacity 160ms ease; }
+.inspector-backdrop.open { opacity: 1; pointer-events: auto; cursor: default; }
+.inspector { position: fixed; top: 0; right: 0; bottom: 0; z-index: 20; width: min(430px, 100vw); min-height: 0; display: grid; grid-template-rows: auto 1fr; border-left: 1px solid var(--mc-border-strong); color: var(--mc-text); background: #0d0a16; box-shadow: -24px 0 70px rgb(0 0 0 / 46%); transform: translateX(100%); transition: transform 210ms cubic-bezier(.2,.8,.2,1); }
+.inspector.open { transform: translateX(0); }
+.inspector-header { padding: 20px; border-bottom: 1px solid var(--mc-border); background: linear-gradient(180deg, #181329, #0d0a16); }
+.inspector-title-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
+.inspector-kicker { margin: 0; color: var(--mc-text-muted); font: 720 0.68rem var(--mono); text-transform: uppercase; letter-spacing: 0.12em; }
+.inspector-title { margin: 6px 0 0; font-size: 1.22rem; line-height: 1.12; letter-spacing: -0.035em; }
+.inspector-copy { margin: 10px 0 0; color: var(--mc-text-muted); font-size: 0.82rem; line-height: 1.45; }
+.sheet-close { width: 34px; height: 34px; flex: 0 0 34px; border: 1px solid var(--mc-border); border-radius: 10px; color: var(--mc-text-muted); background: transparent; cursor: pointer; }
+.sheet-close:hover, .sheet-close:focus-visible { border-color: var(--mc-border-strong); outline: none; color: var(--mc-text); background: var(--mc-surface-raised); }
+.inspector-body { min-height: 0; padding: 20px; display: grid; align-content: start; gap: 16px; overflow: auto; }
+.inspector-section { padding: 16px; border: 1px solid var(--mc-border); border-radius: 10px; background: #151126; }
+.inspector-section.is-primary { border-color: #365c70; background: #111725; }
+.inspector-section h3 { margin: 0 0 12px; color: var(--mc-text-support); font-size: 0.76rem; text-transform: uppercase; letter-spacing: 0.12em; }
+.source-list { display: grid; gap: 8px; }
+.source-item { padding: 9px 10px; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; border: 1px solid var(--mc-border); border-radius: 8px; background: #0f0c1a; }
+.source-main { min-width: 0; display: grid; gap: 4px; }
+.source-name { overflow: hidden; color: var(--mc-text-support); font: 760 0.76rem var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.source-type { color: var(--mc-text-muted); font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; }
+.source-origin { padding: 3px 7px; border: 1px solid var(--mc-border-strong); border-radius: 8px; color: var(--mc-text-muted); font: 760 0.62rem var(--mono); text-transform: uppercase; }
+.source-origin.reported { color: var(--mc-stable); border-color: #355f4b; }
+.source-origin.estimated { color: var(--mc-review); border-color: #705429; }
+.source-origin.unavailable { color: var(--mc-text-muted); border-color: var(--mc-border-strong); }
+.source-ledger-note { margin: 12px 0 0; color: var(--mc-text-muted); font-size: 0.72rem; line-height: 1.4; }
+.state-summary { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
+.state-cell { min-width: 0; padding: 10px; border: 1px solid var(--mc-border); border-radius: 8px; background: #0f0c1a; }
+.state-cell span { display: block; margin-bottom: 5px; color: var(--mc-text-muted); font: 760 0.62rem var(--mono); text-transform: uppercase; }
+.state-cell strong { display: block; overflow-wrap: anywhere; color: var(--mc-text-support); font-size: 0.72rem; }
+.trace-list { margin-left: 4px; display: grid; border-left: 1px solid #365c70; }
+.trace-item { position: relative; padding: 0 0 12px 16px; display: grid; grid-template-columns: 58px 1fr; gap: 12px; color: var(--mc-text-muted); font-size: 0.76rem; line-height: 1.35; }
+.trace-item:last-child { padding-bottom: 0; }
+.trace-item::before { content: ""; position: absolute; left: -4px; top: 0.38em; width: 7px; height: 7px; border-radius: 999px; background: var(--mc-info); box-shadow: 0 0 0 3px #151126; }
+.trace-time { color: var(--mc-text-muted); font: 720 0.62rem var(--mono); }
+.boundary-note { margin: 0; padding: 12px; border: 1px solid #355f4b; border-radius: 10px; color: #bdd7c7; background: #102019; font-size: 0.76rem; line-height: 1.42; }
+
 @media (max-width: 1080px) { .topbar { grid-template-columns: 1fr auto; } .search-box { display: none; } }
 @media (max-width: 760px) {
   .mission-shell, .mission-shell.nav-expanded { --rail-width: 58px; }
@@ -81,5 +175,12 @@ button, a { font: inherit; }
   .workspace-boundary { width: 100%; align-items: flex-start; flex-direction: column; gap: 4px; }
   .route-placeholder { min-height: 220px; margin-top: 26px; padding: 22px; }
   .route-placeholder strong, .route-placeholder span { word-break: break-word; }
+  .ledger-controls { align-items: flex-start; flex-direction: column; }
+  .filters { justify-content: flex-start; }
+  .metrics-row { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .ledger-toolbar { grid-template-columns: 1fr; }
+  .ledger-toolbar > .utility { display: none; }
+  .inspector { width: 100vw; }
+  .state-summary { grid-template-columns: 1fr; }
 }
 @media (prefers-reduced-motion: reduce) { *, *::before, *::after { scroll-behavior: auto !important; transition-duration: 0.01ms !important; } }

--- a/apps/mission-control/src/views/EvidenceLedgerView.tsx
+++ b/apps/mission-control/src/views/EvidenceLedgerView.tsx
@@ -1,14 +1,58 @@
+import { useCallback, useRef, useState } from "react";
 import { WorkspaceHeader } from "../components/WorkspaceHeader";
+import { EvidenceInspector } from "../features/evidence-ledger/EvidenceInspector";
+import { EvidenceLedger } from "../features/evidence-ledger/EvidenceLedger";
+import { evidenceRecords, type EvidenceFilter, type EvidenceRecord } from "../features/evidence-ledger/evidenceLedgerFixtures";
+
+const filters: Array<{ value: EvidenceFilter; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "attention", label: "Needs attention" },
+  { value: "stable", label: "Stable" },
+  { value: "unavailable", label: "Unavailable" },
+];
 
 export function EvidenceLedgerView() {
+  const [filter, setFilter] = useState<EvidenceFilter>("all");
+  const [selectedRecord, setSelectedRecord] = useState<EvidenceRecord | null>(null);
+  const inspectorTrigger = useRef<HTMLButtonElement | null>(null);
+
+  const closeInspector = useCallback(() => {
+    setSelectedRecord(null);
+    const trigger = inspectorTrigger.current;
+    inspectorTrigger.current = null;
+    if (trigger?.isConnected) trigger.focus();
+  }, []);
+
+  const inspectRecord = useCallback((record: EvidenceRecord, trigger: HTMLButtonElement) => {
+    inspectorTrigger.current = trigger;
+    setSelectedRecord(record);
+  }, []);
+
+  const changeFilter = (nextFilter: EvidenceFilter) => {
+    if (selectedRecord) closeInspector();
+    setFilter(nextFilter);
+  };
+
+  const visibleCount = filter === "all" ? evidenceRecords.length : evidenceRecords.filter((record) => record.filterStatus === filter).length;
+  const activeFilterLabel = filters.find((item) => item.value === filter)?.label ?? "All";
+
   return (
-    <section className="workspace" aria-labelledby="evidence-title">
+    <section className="workspace evidence-workspace" aria-label="Evidence Ledger workspace">
       <WorkspaceHeader label="Evidence ledger" title="Work slices by review posture" description="A compact operational surface for derived state, supporting sources, and explicit evidence gaps." boundary="Presentation state only · no lifecycle mutation" />
-      <section className="route-placeholder" aria-label="Evidence Ledger implementation status">
-        <p>Shared shell checkpoint</p>
-        <strong id="evidence-title">Evidence records remain in the accepted static reference.</strong>
-        <span>Cards, filters, and the evidence inspector enter in the next bounded slice.</span>
+      <section className="ledger-controls" aria-label="Evidence Ledger filters">
+        <div className="filters">
+          {filters.map((item) => <button className="filter-button" type="button" aria-pressed={filter === item.value} onClick={() => changeFilter(item.value)} key={item.value}>{item.label}</button>)}
+        </div>
+        <span className="filter-summary" aria-live="polite">{visibleCount} visible · {activeFilterLabel}</span>
       </section>
+      <section className="metrics-row" aria-label="Derived posture summary">
+        <div className="metric"><span>Needs review</span><strong className="metric-review">2</strong></div>
+        <div className="metric"><span>Critical prompt</span><strong className="metric-critical">1</strong></div>
+        <div className="metric"><span>Source gaps</span><strong className="metric-info">3</strong></div>
+        <div className="metric"><span>Closed stable</span><strong className="metric-stable">2</strong></div>
+      </section>
+      <EvidenceLedger filter={filter} selectedId={selectedRecord?.id ?? null} onInspect={inspectRecord} />
+      <EvidenceInspector record={selectedRecord} onClose={closeInspector} />
     </section>
   );
 }

--- a/examples/visual-operations/prototype/component-implementation-handoff.md
+++ b/examples/visual-operations/prototype/component-implementation-handoff.md
@@ -3,8 +3,8 @@
 ## Status
 
 The static prototype has moved from visual exploration into implementation. The
-shared shell slice now lives in `apps/mission-control/`; cards, signals, inspectors,
-and projection adapters remain intentionally deferred.
+shared shell and typed-fixture Evidence Ledger now live in `apps/mission-control/`;
+Resource Observatory signals and projection adapters remain intentionally deferred.
 
 This document freezes the accepted interaction model without choosing a frontend framework, creating an application, or changing Visual Operations contracts.
 
@@ -103,7 +103,7 @@ Evidence Ledger cards, Resource Observatory signals and source-record adapters s
 
 | Slice | Deliverable | Proof |
 |---|---|---|
-| 2. Evidence Ledger | Read-only lanes, cards, filters and inspector using typed mock input. | Derived states and source refs match the accepted prototype. |
+| 2. Evidence Ledger — implemented | Read-only lanes, cards, filters and inspector using typed mock input. | Derived states and source refs match the accepted prototype; focus returns to the initiating card. |
 | 3. Resource Observatory | Grouped signals and signal inspector using typed mock input. | Nine candidates preserve availability and provenance semantics. |
 | 4. Projection adapter | One narrow adapter from existing Visual Operations outputs. | Dashboard reconstructs from source-backed records without creating new truth. |
 | 5. Product QA | Responsive, keyboard, contrast and visual-regression pass. | Critical interaction paths and boundary states are covered. |


### PR DESCRIPTION
## What changed
- replaced the Evidence Ledger placeholder with seven typed local fixture records
- added four derived presentation lanes, source-backed Work Slice cards, and filter-specific empty states
- added working All, Needs attention, Stable, and Unavailable filters with visible counts
- added a right-side evidence inspector for source refs, provenance, posture, trace, confidence, and boundary context
- added Escape/backdrop close, initial-closed behavior, and focus return to the initiating card
- added four Evidence Ledger interaction and semantic tests

## Why
The shared shell is established. This bounded slice migrates the primary Evidence Ledger experience without introducing projection adapters, live sources, writes, collection, or new domain authority.

## How to validate
- `pnpm typecheck`
- `pnpm check:governance`
- `pnpm test` (196 framework tests + 8 app tests)
- `pnpm build:mission-control`
- `./scripts/check-visual-ops-snapshots.sh`
- `git diff --check`
- run `pnpm dev:mission-control` and inspect `/`

## Visual QA
- compared the 1600×1000 closed and inspector-open renders with the accepted prototype
- checked the 500×844 reliable narrow breakpoint
- inspected hierarchy, lane density, card anatomy, source rails, inspector evidence order, typography, and palette
- confirmed the initial-open capture state was temporary and reverted before validation
- no material visual mismatch remains for this bounded slice

## Risks, assumptions, and follow-ups
- fixture types are component input contracts, not new schemas or source records
- lane placement and counts are presentation-only and cannot mutate lifecycle state
- `unavailable` remains neutral and no estimate is invented
- Resource Observatory remains a placeholder
- projection adapters and live data remain deferred
- untracked `plans/` remains untouched
