### PR TITLE
feat(visual-ops): implement Resource Observatory

### DIFF
--- a/apps/mission-control/README.md
+++ b/apps/mission-control/README.md
@@ -11,11 +11,11 @@ The implementation currently contains:
 - the collapsible navigation rail;
 - the global operational header;
 - a functional Evidence Ledger with typed local fixtures, derived filters, Work Slice cards, and an evidence inspector;
-- a Resource Observatory placeholder route;
+- a functional Resource Observatory with nine typed local signal fixtures, three presentation groups, and a provenance inspector;
 - navigation, persistence, focus, and responsive tests.
 
-The accepted static prototypes remain the visual and content reference. Resource
-signals, projection adapters, and live source integration remain outside this slice.
+The accepted static prototypes remain the visual and content reference. Projection
+adapters and live source integration remain outside this slice.
 
 ## Run locally
 

--- a/apps/mission-control/src/features/resource-observatory/ResourceObservatory.test.tsx
+++ b/apps/mission-control/src/features/resource-observatory/ResourceObservatory.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+import { App } from "../../App";
+
+function renderObservatory() {
+  return render(<MemoryRouter initialEntries={["/resource-observatory"]}><App /></MemoryRouter>);
+}
+
+describe("Resource Observatory", () => {
+  beforeEach(() => window.sessionStorage.clear());
+
+  it("renders nine sourced signals in three presentation groups", () => {
+    renderObservatory();
+    expect(screen.getByText("Capacity & spend")).toBeInTheDocument();
+    expect(screen.getByText("Execution efficiency")).toBeInTheDocument();
+    expect(screen.getByText("Quality & orchestration")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /provenance/ })).toHaveLength(9);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("represents unavailable cost telemetry without inventing a value", async () => {
+    const user = userEvent.setup();
+    renderObservatory();
+    await user.click(screen.getByRole("button", { name: "Inspect Token cost provenance" }));
+    const inspector = screen.getByRole("dialog", { name: "Token cost · unavailable" });
+
+    expect(within(inspector).getByText("OBS-COST-∅")).toBeInTheDocument();
+    expect(within(inspector).getByText(/does not invent or estimate/)).toBeInTheDocument();
+    expect(within(inspector).getByText("unavailable", { selector: ".source-origin" })).toBeInTheDocument();
+  });
+
+  it("keeps estimated retry context visibly distinct from reported sources", async () => {
+    const user = userEvent.setup();
+    renderObservatory();
+    await user.click(screen.getByRole("button", { name: "Inspect Retry waste provenance" }));
+    const inspector = screen.getByRole("dialog", { name: "Retry waste · 6.2%" });
+
+    expect(within(inspector).getByText("estimated", { selector: ".source-origin" })).toBeInTheDocument();
+    expect(within(inspector).getByText(/cannot replace a reported source or authorize remediation/)).toBeInTheDocument();
+  });
+
+  it("closes with Escape and returns focus without granting skill authority", async () => {
+    const user = userEvent.setup();
+    renderObservatory();
+    const trigger = screen.getByRole("button", { name: "Inspect Skill usage provenance" });
+    await user.click(trigger);
+    const inspector = screen.getByRole("dialog", { name: "Skill usage · traced" });
+
+    expect(within(inspector).getByText(/not authority over gates, decisions, or lifecycle state/)).toBeInTheDocument();
+    expect(within(inspector).getByRole("button", { name: "Close signal inspector" })).toHaveFocus();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+});

--- a/apps/mission-control/src/features/resource-observatory/ResourceSignalCard.tsx
+++ b/apps/mission-control/src/features/resource-observatory/ResourceSignalCard.tsx
@@ -1,0 +1,24 @@
+import type { ResourceSignal } from "./resourceSignalFixtures";
+
+type ResourceSignalCardProps = {
+  signal: ResourceSignal;
+  selected: boolean;
+  onInspect: (signal: ResourceSignal, trigger: HTMLButtonElement) => void;
+};
+
+export function ResourceSignalCard({ signal, selected, onInspect }: ResourceSignalCardProps) {
+  return (
+    <button
+      className={`signal-card tone-${signal.tone}${selected ? " selected" : ""}`}
+      type="button"
+      aria-label={`Inspect ${signal.label} provenance`}
+      aria-pressed={selected}
+      onClick={(event) => onInspect(signal, event.currentTarget)}
+    >
+      <span className="signal-label">{signal.label}</span>
+      <strong className={`signal-value ${signal.tone}`}>{signal.value}</strong>
+      <span className="signal-note">{signal.note}</span>
+      <span className="signal-source-line"><span className={`source-origin ${signal.origin}`}>{signal.origin}</span><span className="source-ref">{signal.sourceRef}</span></span>
+    </button>
+  );
+}

--- a/apps/mission-control/src/features/resource-observatory/ResourceSignalGroup.tsx
+++ b/apps/mission-control/src/features/resource-observatory/ResourceSignalGroup.tsx
@@ -1,0 +1,19 @@
+import { ResourceSignalCard } from "./ResourceSignalCard";
+import type { ResourceSignal, ResourceSignalGroup as SignalGroup } from "./resourceSignalFixtures";
+
+type ResourceSignalGroupProps = {
+  group: SignalGroup;
+  signals: ResourceSignal[];
+  selectedId: string | null;
+  onInspect: (signal: ResourceSignal, trigger: HTMLButtonElement) => void;
+};
+
+export function ResourceSignalGroup({ group, signals, selectedId, onInspect }: ResourceSignalGroupProps) {
+  const titleId = `signal-group-${group.id}`;
+  return (
+    <section className="signal-group" aria-labelledby={titleId}>
+      <header className="signal-group-header"><h3 id={titleId}>{group.label}</h3><p>{signals.length} sourced signals</p></header>
+      <div className="signal-grid">{signals.map((signal) => <ResourceSignalCard key={signal.id} signal={signal} selected={selectedId === signal.id} onInspect={onInspect} />)}</div>
+    </section>
+  );
+}

--- a/apps/mission-control/src/features/resource-observatory/ResourceSignalInspector.tsx
+++ b/apps/mission-control/src/features/resource-observatory/ResourceSignalInspector.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from "react";
+import type { ResourceSignal } from "./resourceSignalFixtures";
+
+type ResourceSignalInspectorProps = {
+  signal: ResourceSignal | null;
+  onClose: () => void;
+};
+
+export function ResourceSignalInspector({ signal, onClose }: ResourceSignalInspectorProps) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!signal) return;
+    closeRef.current?.focus();
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [signal, onClose]);
+
+  return (
+    <>
+      <button className={`inspector-backdrop${signal ? " open" : ""}`} type="button" aria-label="Close signal inspector" tabIndex={signal ? 0 : -1} onClick={onClose} />
+      <aside className={`inspector signal-inspector${signal ? " open" : ""}`} role="dialog" aria-modal="true" aria-labelledby="signal-inspector-title" aria-hidden={!signal}>
+        {signal ? (
+          <>
+            <header className="inspector-header">
+              <div className="inspector-title-row">
+                <div><p className="inspector-kicker">{signal.kicker}</p><h2 className="inspector-title" id="signal-inspector-title">{signal.label} · {signal.value}</h2></div>
+                <button ref={closeRef} className="sheet-close" type="button" aria-label="Close signal inspector" onClick={onClose}>×</button>
+              </div>
+              <p className="inspector-copy">{signal.note}</p>
+            </header>
+            <div className="inspector-body">
+              <section className="inspector-section">
+                <h3>Source record</h3>
+                <dl className="signal-detail-list">
+                  <div><dt>Reference</dt><dd>{signal.sourceRef}</dd></div>
+                  <div><dt>Origin</dt><dd><span className={`source-origin ${signal.origin}`}>{signal.origin}</span></dd></div>
+                  <div><dt>Availability</dt><dd>{signal.availability}</dd></div>
+                </dl>
+              </section>
+              <section className="inspector-section">
+                <h3>Interpretation</h3>
+                <p className="signal-interpretation">{signal.interpretation}</p>
+              </section>
+              <section className="inspector-section">
+                <h3>Boundary</h3>
+                <p className="boundary-note">The Resource Observatory displays sourced metadata only. Source records remain authoritative; this interface does not collect, calculate, govern, or execute.</p>
+              </section>
+            </div>
+          </>
+        ) : null}
+      </aside>
+    </>
+  );
+}

--- a/apps/mission-control/src/features/resource-observatory/resourceSignalFixtures.ts
+++ b/apps/mission-control/src/features/resource-observatory/resourceSignalFixtures.ts
@@ -1,0 +1,149 @@
+export type SignalOrigin = "reported" | "estimated" | "unavailable";
+export type SignalAvailability = "available" | "unavailable";
+export type SignalTone = "evidence" | "review" | "stable" | "neutral";
+export type SignalGroupId = "capacity" | "efficiency" | "quality";
+
+export type ResourceSignal = {
+  id: string;
+  groupId: SignalGroupId;
+  label: string;
+  value: string;
+  note: string;
+  sourceRef: string;
+  origin: SignalOrigin;
+  availability: SignalAvailability;
+  tone: SignalTone;
+  kicker: string;
+  interpretation: string;
+};
+
+export type ResourceSignalGroup = {
+  id: SignalGroupId;
+  label: string;
+};
+
+export const resourceSignalGroups: ResourceSignalGroup[] = [
+  { id: "capacity", label: "Capacity & spend" },
+  { id: "efficiency", label: "Execution efficiency" },
+  { id: "quality", label: "Quality & orchestration" },
+];
+
+export const resourceSignals: ResourceSignal[] = [
+  {
+    id: "context-tokens",
+    groupId: "capacity",
+    label: "Context tokens",
+    value: "128k",
+    note: "Reported from a synthetic APOB event sample.",
+    sourceRef: "OBS-CTX-01",
+    origin: "reported",
+    availability: "available",
+    tone: "evidence",
+    kicker: "Reported signal",
+    interpretation: "Context volume is visible for review. No target, threshold, or decision is inferred from this value.",
+  },
+  {
+    id: "token-cost",
+    groupId: "capacity",
+    label: "Token cost",
+    value: "unavailable",
+    note: "No durable cost export exists for this docs-only slice.",
+    sourceRef: "OBS-COST-∅",
+    origin: "unavailable",
+    availability: "unavailable",
+    tone: "neutral",
+    kicker: "Unavailable signal",
+    interpretation: "Absence of cost telemetry is represented neutrally. The interface does not invent or estimate a replacement value.",
+  },
+  {
+    id: "runtime-fit",
+    groupId: "capacity",
+    label: "Runtime fit",
+    value: "unavailable",
+    note: "No durable runtime profile exists for this docs-only slice.",
+    sourceRef: "OBS-RUN-∅",
+    origin: "unavailable",
+    availability: "unavailable",
+    tone: "neutral",
+    kicker: "Unavailable signal",
+    interpretation: "Without an authoritative runtime profile, the interface presents no fit score, target, or inferred recommendation.",
+  },
+  {
+    id: "retry-waste",
+    groupId: "efficiency",
+    label: "Retry waste",
+    value: "6.2%",
+    note: "Estimated from synthetic retry records; not a billing source.",
+    sourceRef: "OBS-RTY-02",
+    origin: "estimated",
+    availability: "available",
+    tone: "review",
+    kicker: "Estimated signal",
+    interpretation: "This estimate can prompt inspection, but it cannot replace a reported source or authorize remediation.",
+  },
+  {
+    id: "active-threads",
+    groupId: "efficiency",
+    label: "Active threads",
+    value: "37",
+    note: "Reported from a synthetic thread inventory snapshot.",
+    sourceRef: "OBS-THR-08",
+    origin: "reported",
+    availability: "available",
+    tone: "evidence",
+    kicker: "Reported signal",
+    interpretation: "Thread count describes observed concurrency only. It does not indicate health, priority, or required intervention.",
+  },
+  {
+    id: "review-effort",
+    groupId: "efficiency",
+    label: "Review effort",
+    value: "3.1h",
+    note: "Reported from review metadata in the synthetic example.",
+    sourceRef: "OBS-HR-04",
+    origin: "reported",
+    availability: "available",
+    tone: "stable",
+    kicker: "Reported signal",
+    interpretation: "Review effort describes recorded human activity; it is not a productivity score or approval signal.",
+  },
+  {
+    id: "quality-signals",
+    groupId: "quality",
+    label: "Quality signals",
+    value: "94",
+    note: "Reported quality score from a mocked evaluation summary.",
+    sourceRef: "OBS-QA-07",
+    origin: "reported",
+    availability: "available",
+    tone: "evidence",
+    kicker: "Reported signal",
+    interpretation: "Quality remains tied to its evaluation source and cannot independently close a readiness gate.",
+  },
+  {
+    id: "skill-usage",
+    groupId: "quality",
+    label: "Skill usage",
+    value: "traced",
+    note: "Skill activation appears as trace context only.",
+    sourceRef: "ACT-552",
+    origin: "reported",
+    availability: "available",
+    tone: "stable",
+    kicker: "Traced activation",
+    interpretation: "A skill activation is observable evidence, not authority over gates, decisions, or lifecycle state.",
+  },
+  {
+    id: "agent-usage",
+    groupId: "quality",
+    label: "Agent usage",
+    value: "traced",
+    note: "Agent participation is represented as sourced trace context.",
+    sourceRef: "AGT-204",
+    origin: "reported",
+    availability: "available",
+    tone: "stable",
+    kicker: "Traced participation",
+    interpretation: "Agent participation is visible for audit. It does not confer authority or imply that an output was accepted.",
+  },
+];

--- a/apps/mission-control/src/styles.css
+++ b/apps/mission-control/src/styles.css
@@ -160,8 +160,37 @@ button, a { font: inherit; }
 .trace-item::before { content: ""; position: absolute; left: -4px; top: 0.38em; width: 7px; height: 7px; border-radius: 999px; background: var(--mc-info); box-shadow: 0 0 0 3px #151126; }
 .trace-time { color: var(--mc-text-muted); font: 720 0.62rem var(--mono); }
 .boundary-note { margin: 0; padding: 12px; border: 1px solid #355f4b; border-radius: 10px; color: #bdd7c7; background: #102019; font-size: 0.76rem; line-height: 1.42; }
+.resource-workspace > * { max-width: none; }
+.resource-workspace > .workspace-header { max-width: 980px; }
+.signal-groups { margin-top: 30px; display: grid; gap: 24px; align-content: start; }
+.signal-group { display: grid; gap: 12px; }
+.signal-group-header { padding-bottom: 8px; display: flex; align-items: baseline; justify-content: space-between; gap: 16px; border-bottom: 1px solid var(--mc-border); }
+.signal-group-header h3 { margin: 0; color: var(--mc-text-support); font-size: 0.91rem; letter-spacing: -0.01em; }
+.signal-group-header p { margin: 0; color: var(--mc-text-muted); font: 680 0.62rem var(--mono); }
+.signal-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
+.signal-card { min-height: 148px; padding: 16px; display: grid; gap: 12px; border: 1px solid var(--mc-border); border-radius: 10px; color: inherit; background: #1b1630; text-align: left; cursor: pointer; transition: border-color 140ms ease, background 140ms ease, transform 140ms ease; }
+.signal-card::before { content: ""; width: 34px; height: 2px; border-radius: 999px; background: var(--mc-info); }
+.signal-card.tone-review::before { background: var(--mc-review); }
+.signal-card.tone-stable::before { background: var(--mc-stable); }
+.signal-card.tone-neutral::before { background: var(--mc-text-muted); }
+.signal-card:hover, .signal-card:focus-visible, .signal-card.selected { border-color: var(--mc-border-strong); outline: none; background: var(--mc-surface-raised); }
+.signal-card:hover { transform: translateY(-1px); }
+.signal-label { color: var(--mc-text-muted); font: 760 0.62rem var(--mono); text-transform: uppercase; letter-spacing: 0.06em; }
+.signal-value { color: var(--mc-text); font-size: 1.9rem; line-height: 1; letter-spacing: -0.05em; }
+.signal-value.review { color: var(--mc-review); }
+.signal-value.stable { color: var(--mc-stable); }
+.signal-value.neutral { color: var(--mc-text-muted); font-size: 1.35rem; }
+.signal-note { margin: 0; color: var(--mc-text-muted); font-size: 0.76rem; line-height: 1.38; }
+.signal-source-line { margin-top: auto; display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
+.signal-inspector .inspector-section { background: transparent; }
+.signal-detail-list { margin: 0; display: grid; gap: 12px; }
+.signal-detail-list > div { display: grid; grid-template-columns: 90px minmax(0, 1fr); align-items: center; gap: 12px; }
+.signal-detail-list dt { color: var(--mc-text-muted); font: 720 0.62rem var(--mono); text-transform: uppercase; }
+.signal-detail-list dd { margin: 0; color: var(--mc-text-support); font-size: 0.76rem; font-weight: 620; }
+.signal-interpretation { margin: 0; padding: 14px; border: 1px solid var(--mc-border); border-radius: 10px; color: var(--mc-text-support); background: #0f0c1a; font-size: 0.76rem; line-height: 1.45; }
 
 @media (max-width: 1080px) { .topbar { grid-template-columns: 1fr auto; } .search-box { display: none; } }
+@media (max-width: 1100px) { .signal-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 @media (max-width: 760px) {
   .mission-shell, .mission-shell.nav-expanded { --rail-width: 58px; }
   .side-rail { padding: 12px 8px; }
@@ -182,5 +211,6 @@ button, a { font: inherit; }
   .ledger-toolbar > .utility { display: none; }
   .inspector { width: 100vw; }
   .state-summary { grid-template-columns: 1fr; }
+  .signal-grid { grid-template-columns: 1fr; }
 }
 @media (prefers-reduced-motion: reduce) { *, *::before, *::after { scroll-behavior: auto !important; transition-duration: 0.01ms !important; } }

--- a/apps/mission-control/src/views/ResourceObservatoryView.tsx
+++ b/apps/mission-control/src/views/ResourceObservatoryView.tsx
@@ -1,14 +1,32 @@
+import { useCallback, useRef, useState } from "react";
 import { WorkspaceHeader } from "../components/WorkspaceHeader";
+import { ResourceSignalGroup } from "../features/resource-observatory/ResourceSignalGroup";
+import { ResourceSignalInspector } from "../features/resource-observatory/ResourceSignalInspector";
+import { resourceSignalGroups, resourceSignals, type ResourceSignal } from "../features/resource-observatory/resourceSignalFixtures";
 
 export function ResourceObservatoryView() {
+  const [selectedSignal, setSelectedSignal] = useState<ResourceSignal | null>(null);
+  const inspectorTrigger = useRef<HTMLButtonElement | null>(null);
+
+  const closeInspector = useCallback(() => {
+    setSelectedSignal(null);
+    const trigger = inspectorTrigger.current;
+    inspectorTrigger.current = null;
+    if (trigger?.isConnected) trigger.focus();
+  }, []);
+
+  const inspectSignal = useCallback((signal: ResourceSignal, trigger: HTMLButtonElement) => {
+    inspectorTrigger.current = trigger;
+    setSelectedSignal(signal);
+  }, []);
+
   return (
-    <section className="workspace" aria-labelledby="resource-title">
+    <section className="workspace resource-workspace" aria-label="Resource Observatory workspace">
       <WorkspaceHeader label="Resource observatory" title="Operational signals as sourced context" description="Signals remain metadata-first, sourced, and read-only; they do not collect telemetry or authorize decisions." boundary="APOB input only · no collection · no decision authority" />
-      <section className="route-placeholder" aria-label="Resource Observatory implementation status">
-        <p>Shared shell checkpoint</p>
-        <strong id="resource-title">Operational signals remain in the accepted static reference.</strong>
-        <span>Signal groups, provenance, and the inspector enter in a later bounded slice.</span>
-      </section>
+      <div className="signal-groups" aria-label="Operational signal groups">
+        {resourceSignalGroups.map((group) => <ResourceSignalGroup key={group.id} group={group} signals={resourceSignals.filter((signal) => signal.groupId === group.id)} selectedId={selectedSignal?.id ?? null} onInspect={inspectSignal} />)}
+      </div>
+      <ResourceSignalInspector signal={selectedSignal} onClose={closeInspector} />
     </section>
   );
 }

--- a/examples/visual-operations/prototype/component-implementation-handoff.md
+++ b/examples/visual-operations/prototype/component-implementation-handoff.md
@@ -4,7 +4,8 @@
 
 The static prototype has moved from visual exploration into implementation. The
 shared shell and typed-fixture Evidence Ledger now live in `apps/mission-control/`;
-Resource Observatory signals and projection adapters remain intentionally deferred.
+the typed-fixture Resource Observatory is also implemented, while projection adapters
+remain intentionally deferred.
 
 This document freezes the accepted interaction model without choosing a frontend framework, creating an application, or changing Visual Operations contracts.
 
@@ -104,7 +105,7 @@ Evidence Ledger cards, Resource Observatory signals and source-record adapters s
 | Slice | Deliverable | Proof |
 |---|---|---|
 | 2. Evidence Ledger — implemented | Read-only lanes, cards, filters and inspector using typed mock input. | Derived states and source refs match the accepted prototype; focus returns to the initiating card. |
-| 3. Resource Observatory | Grouped signals and signal inspector using typed mock input. | Nine candidates preserve availability and provenance semantics. |
+| 3. Resource Observatory — implemented | Grouped signals and signal inspector using typed mock input. | Nine candidates preserve availability, provenance, and no-authority semantics. |
 | 4. Projection adapter | One narrow adapter from existing Visual Operations outputs. | Dashboard reconstructs from source-backed records without creating new truth. |
 | 5. Product QA | Responsive, keyboard, contrast and visual-regression pass. | Critical interaction paths and boundary states are covered. |
 


### PR DESCRIPTION
## What changed
- replaced the Resource Observatory placeholder with nine typed local signal fixtures
- grouped signals into Capacity & spend, Execution efficiency, and Quality & orchestration
- preserved reported, estimated, and unavailable provenance on every signal card
- added a contextual signal inspector with source reference, origin, availability, interpretation, and boundary
- added Escape/backdrop close, initial-closed behavior, and focus return
- added four Resource Observatory semantic and interaction tests

## Why
The Evidence Ledger is implemented. This bounded slice completes the second primary Mission Control view without introducing collectors, live telemetry, projection adapters, or decision authority.

## How to validate
- `pnpm typecheck`
- `pnpm check:governance`
- `pnpm test` (196 framework tests + 12 app tests)
- `pnpm build:mission-control`
- `./scripts/check-visual-ops-snapshots.sh`
- `git diff --check`
- run `pnpm dev:mission-control` and inspect `/resource-observatory`

## Visual QA
- compared the implementation with the accepted static Resource Observatory at 1600×1000
- checked the reliable 500×844 narrow breakpoint
- inspected group hierarchy, card density, typography, palette, provenance labels, unavailable treatment, and inspector composition
- confirmed the initial-open inspector capture state was temporary and reverted
- no material visual mismatch remains for this bounded slice

## Risks, assumptions, and follow-ups
- fixture types are UI input contracts, not schemas or source records
- values are synthetic and do not establish targets or recommendations
- unavailable token cost and runtime fit remain neutral
- retry waste remains explicitly estimated
- skill and agent usage remain trace context without governance authority
- projection adapters and live data remain deferred
- untracked `plans/` remains untouched
