### PR TITLE
feat(visual-ops): adapt projected records for Mission Control

### DIFF
--- a/apps/mission-control/README.md
+++ b/apps/mission-control/README.md
@@ -10,12 +10,14 @@ The implementation currently contains:
 - the shared full-browser shell;
 - the collapsible navigation rail;
 - the global operational header;
-- a functional Evidence Ledger with typed local fixtures, derived filters, Work Slice cards, and an evidence inspector;
+- a functional Evidence Ledger with derived filters, Work Slice cards, and an evidence inspector;
+- a narrow read-only adapter that renders the versioned PR #201 and PR #207 projector snapshots beside typed synthetic records;
 - a functional Resource Observatory with nine typed local signal fixtures, three presentation groups, and a provenance inspector;
 - navigation, persistence, focus, and responsive tests.
 
-The accepted static prototypes remain the visual and content reference. Projection
-adapters and live source integration remain outside this slice.
+The accepted static prototypes remain the visual and content reference. The first
+projection-adapter checkpoint is implemented; live source integration remains
+outside this slice.
 
 ## Run locally
 
@@ -38,7 +40,7 @@ pnpm build:mission-control
 ## Boundary
 
 - read-only presentation state only;
-- static fixture copy only;
+- versioned projection snapshots and explicit synthetic fixtures only;
 - no write API, persistence, collection, backend, runtime, or event bus;
 - no new schema, lifecycle, policy, gate, or decision authority;
 - no Adaptive Skills integration;

--- a/apps/mission-control/src/adapters/README.md
+++ b/apps/mission-control/src/adapters/README.md
@@ -1,0 +1,16 @@
+# Mission Control projection adapters
+
+Adapters translate existing, read-only Visual Operations outputs into UI input.
+They are formatting boundaries, not data sources or domain authorities.
+
+The current checkpoint:
+
+- accepts `GitHubPullRequestProjection` records already produced by the existing
+  projector;
+- rejects any projection whose mode is not `read_only`;
+- preserves historical closure when a later alert creates review follow-up;
+- exposes absent references as `unavailable` rather than inventing provenance;
+- maps the versioned PR #201 and PR #207 snapshots into Evidence Ledger records.
+
+It does not fetch, collect, mutate, persist, authorize, or recalculate source state.
+Additional projector types and live delivery are separate future slices.

--- a/apps/mission-control/src/adapters/githubPullRequestProjectionAdapter.test.ts
+++ b/apps/mission-control/src/adapters/githubPullRequestProjectionAdapter.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import pr207ProjectionJson from "../../../../examples/visual-operations/github-pr-207-dogfood-output.json";
+import type { GitHubPullRequestProjection } from "../../../../engine/visual-operations-projector";
+import { adaptGitHubPullRequestProjection } from "./githubPullRequestProjectionAdapter";
+
+const pr207Projection = pr207ProjectionJson as GitHubPullRequestProjection;
+
+function projectionWith(
+  state: Partial<GitHubPullRequestProjection["work_slice_visual_state"]>,
+): GitHubPullRequestProjection {
+  return {
+    ...pr207Projection,
+    work_slice_visual_state: {
+      ...pr207Projection.work_slice_visual_state,
+      ...state,
+    },
+  };
+}
+
+describe("GitHub pull request projection adapter", () => {
+  it("maps a versioned closed projection without losing its sources or trace", () => {
+    const record = adaptGitHubPullRequestProjection(pr207Projection);
+
+    expect(record).toMatchObject({
+      id: "github-pr-207",
+      laneId: "closed",
+      filterStatus: "stable",
+      label: "Closed",
+      title: "docs(visual-ops): map human review sources",
+      sourceRefs: ["PR #207", "CI 81688153415"],
+      inspector: {
+        confidence: "High",
+        status: "Closed · sufficient evidence",
+      },
+    });
+    expect(record.inspector.sources.some((source) => source.name.endsWith("/pull/207"))).toBe(true);
+    expect(record.inspector.trace).toHaveLength(3);
+    expect(record.inspector.trace.at(-1)?.description).toContain("merged");
+  });
+
+  it("keeps historical closure while exposing unresolved alerts as follow-up", () => {
+    const record = adaptGitHubPullRequestProjection(projectionWith({
+      alerts: [{
+        alert_id: "alert-post-close",
+        type: "post_close_review",
+        severity: "warning",
+        summary: "A later source requires review.",
+        suggested_review: "Inspect the later source.",
+        source_refs: ["https://github.com/nevitonsantana/AletheIA/pull/207"],
+        resolved_at: null,
+        resolution_ref: null,
+      }],
+    }));
+
+    expect(record).toMatchObject({ laneId: "closed", filterStatus: "attention", label: "Follow-up" });
+    expect(record.cardSummary).toBe("A later source requires review.");
+  });
+
+  it("routes pending human review to review prompts", () => {
+    const record = adaptGitHubPullRequestProjection(projectionWith({
+      presentation_lane: "validation",
+      human_review: {
+        required: true,
+        status: "pending",
+        reviewer_role: "repository_reviewer",
+        open_question: "Can closure be trusted?",
+        source_refs: ["https://github.com/nevitonsantana/AletheIA/pull/207"],
+      },
+    }));
+
+    expect(record).toMatchObject({ laneId: "review", filterStatus: "attention", label: "Human review" });
+  });
+
+  it("shows missing source data as unavailable instead of inventing provenance", () => {
+    const projection = projectionWith({
+      presentation_lane: "intake",
+      lane_confidence: "unknown",
+      evidence_status: "unknown",
+      evidence: [],
+      source_refs: [],
+    });
+    projection.projection = { ...projection.projection, source_refs: [] };
+
+    const record = adaptGitHubPullRequestProjection(projection);
+
+    expect(record).toMatchObject({
+      laneId: "reconcile",
+      filterStatus: "unavailable",
+      sourceRefs: ["unavailable"],
+      inspector: { confidence: "Unknown" },
+    });
+    expect(record.inspector.sources).toEqual([{
+      name: "Source reference unavailable",
+      type: "Projection source",
+      origin: "unavailable",
+    }]);
+  });
+
+  it("rejects projections that are not read-only", () => {
+    const projection = {
+      ...pr207Projection,
+      projection: { ...pr207Projection.projection, mode: "write" },
+    } as unknown as GitHubPullRequestProjection;
+
+    expect(() => adaptGitHubPullRequestProjection(projection)).toThrow("read-only projections only");
+  });
+});

--- a/apps/mission-control/src/adapters/githubPullRequestProjectionAdapter.ts
+++ b/apps/mission-control/src/adapters/githubPullRequestProjectionAdapter.ts
@@ -1,0 +1,117 @@
+import type { GitHubPullRequestProjection } from "../../../../engine/visual-operations-projector";
+import type { EvidenceLaneId, EvidenceRecord, EvidenceTone } from "../features/evidence-ledger/evidenceLedgerTypes";
+
+type VisualState = GitHubPullRequestProjection["work_slice_visual_state"];
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim()))];
+}
+
+function sourceType(sourceRef: string): string {
+  if (/\/pull\/\d+/.test(sourceRef)) return "Pull request";
+  if (/\/actions\/runs\//.test(sourceRef)) return "Check run";
+  if (/github\.com\/[^/]+\/[^/]+\/?$/.test(sourceRef)) return "Repository";
+  return "Projection source";
+}
+
+function compactSourceRef(sourceRef: string): string {
+  const pullRequest = sourceRef.match(/\/pull\/(\d+)/);
+  if (pullRequest) return `PR #${pullRequest[1]}`;
+  const job = sourceRef.match(/\/job\/(\d+)/);
+  if (job) return `CI ${job[1]}`;
+  const run = sourceRef.match(/\/runs\/(\d+)/);
+  if (run) return `CI ${run[1]}`;
+  try {
+    return new URL(sourceRef).hostname;
+  } catch {
+    return sourceRef;
+  }
+}
+
+function hasActiveReviewPrompt(state: VisualState): boolean {
+  return state.human_review.status === "pending" || state.evidence_status === "failed" || state.alerts.some(
+    (alert) => !alert.resolved_at && (alert.severity === "critical" || alert.severity === "warning"),
+  );
+}
+
+function presentation(state: VisualState): {
+  laneId: EvidenceLaneId;
+  tone: EvidenceTone;
+  filterStatus: EvidenceRecord["filterStatus"];
+  label: string;
+} {
+  if (state.presentation_lane === "closed") {
+    const needsAttention = hasActiveReviewPrompt(state);
+    return { laneId: "closed", tone: needsAttention ? "review" : "stable", filterStatus: needsAttention ? "attention" : "stable", label: needsAttention ? "Follow-up" : "Closed" };
+  }
+  if (hasActiveReviewPrompt(state)) {
+    return { laneId: "review", tone: state.evidence_status === "failed" ? "critical" : "review", filterStatus: "attention", label: state.evidence_status === "failed" ? "Failed" : "Human review" };
+  }
+  if (state.presentation_lane === "validation" || state.evidence_status === "partial" || state.evidence_status === "sufficient") {
+    return { laneId: "validation", tone: "stable", filterStatus: "stable", label: "Validation" };
+  }
+  return { laneId: "reconcile", tone: "info", filterStatus: "unavailable", label: "Source gap" };
+}
+
+function confidence(state: VisualState): EvidenceRecord["inspector"]["confidence"] {
+  if (state.lane_confidence === "confirmed") return "High";
+  if (state.lane_confidence === "inferred") return "Medium";
+  return "Unknown";
+}
+
+function cardSummary(state: VisualState): string {
+  const activeAlert = state.alerts.find((alert) => !alert.resolved_at);
+  if (activeAlert) return activeAlert.summary;
+  const failedEvidence = state.evidence.find((item) => item.status === "failed");
+  if (failedEvidence) return failedEvidence.summary;
+  const latestEvidence = state.evidence.at(-1);
+  if (latestEvidence) return latestEvidence.summary;
+  return "No evidence summary is available in the projection.";
+}
+
+function statusLabel(state: VisualState): string {
+  if (state.presentation_lane === "closed") return `Closed · ${state.evidence_status} evidence`;
+  if (state.human_review.status === "pending") return "Pending human review";
+  if (state.evidence_status === "failed") return "Validation failed";
+  return `${state.presentation_lane} · ${state.evidence_status} evidence`;
+}
+
+export function adaptGitHubPullRequestProjection(projection: GitHubPullRequestProjection): EvidenceRecord {
+  if (projection.projection.mode !== "read_only") {
+    throw new Error("Mission Control accepts read-only projections only");
+  }
+
+  const state = projection.work_slice_visual_state;
+  const display = presentation(state);
+  const sourceRefs = unique([...projection.projection.source_refs, ...state.source_refs]);
+  const prioritizedRefs = [...sourceRefs].sort((left, right) => {
+    const rank = (value: string) => (/\/pull\/\d+/.test(value) ? 0 : /\/actions\/runs\//.test(value) ? 1 : 2);
+    return rank(left) - rank(right);
+  });
+  const visibleRefs = prioritizedRefs.length > 0 ? prioritizedRefs.slice(0, 2).map(compactSourceRef) : ["unavailable"];
+  const inspectorSources = prioritizedRefs.length > 0
+    ? prioritizedRefs.slice(0, 6).map((sourceRef) => ({ name: sourceRef, type: sourceType(sourceRef), origin: "reported" as const }))
+    : [{ name: "Source reference unavailable", type: "Projection source", origin: "unavailable" as const }];
+  const latestEvents = projection.normalized_events.slice(-3);
+
+  return {
+    id: state.work_slice_id,
+    reference: state.work_slice_id,
+    ...display,
+    title: state.title,
+    cardSummary: cardSummary(state),
+    sourceRefs: visibleRefs,
+    inspector: {
+      kicker: `${display.label} · ${state.lane_confidence}`,
+      summary: `Read-only ${projection.projection.projector} projection generated at ${state.projected_at}.`,
+      lane: display.laneId === "closed" ? "Closed stable" : display.laneId === "review" ? "Review prompts" : display.laneId === "validation" ? "Validation" : "Reconcile",
+      status: statusLabel(state),
+      confidence: confidence(state),
+      sources: inspectorSources,
+      trace: latestEvents.map((item) => ({ time: item.timestamp, description: item.summary })),
+      boundary: state.presentation_lane === "closed"
+        ? "Closed is a historical presentation posture derived from authoritative records. Alerts create follow-up context; they do not rewrite closure."
+        : "This adapter formats existing projection data for review. It does not authorize, mutate, collect, or persist source state.",
+    },
+  };
+}

--- a/apps/mission-control/src/adapters/projectionEvidenceRecords.ts
+++ b/apps/mission-control/src/adapters/projectionEvidenceRecords.ts
@@ -1,0 +1,11 @@
+import pr201ProjectionJson from "../../../../examples/visual-operations/github-pr-201-dogfood-output.json";
+import pr207ProjectionJson from "../../../../examples/visual-operations/github-pr-207-dogfood-output.json";
+import type { GitHubPullRequestProjection } from "../../../../engine/visual-operations-projector";
+import { adaptGitHubPullRequestProjection } from "./githubPullRequestProjectionAdapter";
+
+const sourceProjections = [
+  pr207ProjectionJson as GitHubPullRequestProjection,
+  pr201ProjectionJson as GitHubPullRequestProjection,
+];
+
+export const projectionEvidenceRecords = sourceProjections.map(adaptGitHubPullRequestProjection);

--- a/apps/mission-control/src/features/evidence-ledger/EvidenceLedger.test.tsx
+++ b/apps/mission-control/src/features/evidence-ledger/EvidenceLedger.test.tsx
@@ -11,14 +11,26 @@ function renderLedger() {
 describe("Evidence Ledger", () => {
   beforeEach(() => window.sessionStorage.clear());
 
-  it("renders seven source-backed fixture cards across derived lanes", () => {
+  it("renders seven source-backed records across derived lanes", () => {
     renderLedger();
     expect(screen.getByText("7 visible · All")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Critical risk signal/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Resolve missing telemetry/ })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Dogfood evidence record/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /record PR 200 dogfood evidence/ })).toBeInTheDocument();
     expect(screen.getByLabelText("Review prompts lane")).toBeInTheDocument();
     expect(screen.getByLabelText("Closed stable lane")).toBeInTheDocument();
+  });
+
+  it("opens projected PR detail with reported source references", async () => {
+    const user = userEvent.setup();
+    renderLedger();
+
+    await user.click(screen.getByRole("button", { name: /map human review sources/ }));
+    const inspector = screen.getByRole("dialog", { name: "docs(visual-ops): map human review sources" });
+
+    expect(within(inspector).getByText("High")).toBeInTheDocument();
+    expect(within(inspector).getByText("https://github.com/nevitonsantana/AletheIA/pull/207")).toBeInTheDocument();
+    expect(within(inspector).getAllByText("reported").length).toBeGreaterThan(0);
   });
 
   it("filters presentation records without mutating lane authority", async () => {

--- a/apps/mission-control/src/features/evidence-ledger/evidenceLedgerFixtures.ts
+++ b/apps/mission-control/src/features/evidence-ledger/evidenceLedgerFixtures.ts
@@ -1,47 +1,6 @@
-export type EvidenceFilter = "all" | "attention" | "stable" | "unavailable";
-export type EvidenceTone = "critical" | "review" | "stable" | "info";
-export type EvidenceOrigin = "reported" | "estimated" | "unavailable";
-export type EvidenceLaneId = "review" | "validation" | "reconcile" | "closed";
-
-export type EvidenceSource = {
-  name: string;
-  type: string;
-  origin: EvidenceOrigin;
-};
-
-export type EvidenceTrace = {
-  time: string;
-  description: string;
-};
-
-export type EvidenceRecord = {
-  id: string;
-  reference: string;
-  laneId: EvidenceLaneId;
-  filterStatus: Exclude<EvidenceFilter, "all">;
-  tone: EvidenceTone;
-  label: string;
-  title: string;
-  cardSummary: string;
-  sourceRefs: string[];
-  inspector: {
-    kicker: string;
-    summary: string;
-    lane: string;
-    status: string;
-    confidence: "Low" | "Medium" | "High" | "Unknown";
-    sources: EvidenceSource[];
-    trace: EvidenceTrace[];
-    boundary: string;
-  };
-};
-
-export type EvidenceLane = {
-  id: EvidenceLaneId;
-  label: string;
-  tone: EvidenceTone;
-  emptyMessage: string;
-};
+import { projectionEvidenceRecords } from "../../adapters/projectionEvidenceRecords";
+import type { EvidenceLane, EvidenceRecord } from "./evidenceLedgerTypes";
+export type { EvidenceFilter, EvidenceLaneId, EvidenceOrigin, EvidenceRecord, EvidenceSource, EvidenceTone, EvidenceTrace } from "./evidenceLedgerTypes";
 
 export const evidenceLanes: EvidenceLane[] = [
   { id: "review", label: "Review prompts", tone: "critical", emptyMessage: "No review prompts match this filter. Absence is a filtered view, not source truth." },
@@ -189,60 +148,5 @@ export const evidenceRecords: EvidenceRecord[] = [
       boundary: "Do not invent estimates just to complete the card. Use unavailable until a durable source exists.",
     },
   },
-  {
-    id: "closed-207",
-    reference: "PR #207",
-    laneId: "closed",
-    filterStatus: "stable",
-    tone: "stable",
-    label: "Closed",
-    title: "Human-review source mapping",
-    cardSummary: "Source supports closure; review source remains represented as unavailable.",
-    sourceRefs: ["PR #207", "39f76cf"],
-    inspector: {
-      kicker: "Closed · confirmed",
-      summary: "Source records support closure while human_review remains unavailable because no durable review source was supplied.",
-      lane: "Closed stable",
-      status: "Closed derived posture",
-      confidence: "High",
-      sources: [
-        { name: "PR #207", type: "Pull request", origin: "reported" },
-        { name: "CI 27626141953", type: "Check run", origin: "reported" },
-        { name: "Merge 39f76cf", type: "Merge ref", origin: "reported" },
-      ],
-      trace: [
-        { time: "2026-06-16", description: "PR merged after governance and test checks." },
-        { time: "2026-06-16", description: "Review source absence preserved as unavailable metadata." },
-      ],
-      boundary: "Closed is a presentation posture derived from sources, not a new authority.",
-    },
-  },
-  {
-    id: "closed-201",
-    reference: "PR #201",
-    laneId: "closed",
-    filterStatus: "stable",
-    tone: "stable",
-    label: "Closed",
-    title: "Dogfood evidence record",
-    cardSummary: "Snapshot evidence supports closeout; human review absence remains visible.",
-    sourceRefs: ["Dogfood", "Snapshot"],
-    inspector: {
-      kicker: "Closed · confirmed",
-      summary: "Snapshot evidence supports closeout. Human review unavailable remains visible as honest absence of source authority.",
-      lane: "Closed stable",
-      status: "Closed derived posture",
-      confidence: "High",
-      sources: [
-        { name: "PR #201", type: "Pull request", origin: "reported" },
-        { name: "Dogfood snapshot", type: "Snapshot", origin: "reported" },
-        { name: "Human review", type: "Review source", origin: "unavailable" },
-      ],
-      trace: [
-        { time: "2026-06-15", description: "Dogfood snapshot recorded." },
-        { time: "2026-06-15", description: "Closeout posture reconstructed from source refs." },
-      ],
-      boundary: "Unavailable is not failure; it is absence of authoritative source.",
-    },
-  },
+  ...projectionEvidenceRecords,
 ];

--- a/apps/mission-control/src/features/evidence-ledger/evidenceLedgerTypes.ts
+++ b/apps/mission-control/src/features/evidence-ledger/evidenceLedgerTypes.ts
@@ -1,0 +1,44 @@
+export type EvidenceFilter = "all" | "attention" | "stable" | "unavailable";
+export type EvidenceTone = "critical" | "review" | "stable" | "info";
+export type EvidenceOrigin = "reported" | "estimated" | "unavailable";
+export type EvidenceLaneId = "review" | "validation" | "reconcile" | "closed";
+
+export type EvidenceSource = {
+  name: string;
+  type: string;
+  origin: EvidenceOrigin;
+};
+
+export type EvidenceTrace = {
+  time: string;
+  description: string;
+};
+
+export type EvidenceRecord = {
+  id: string;
+  reference: string;
+  laneId: EvidenceLaneId;
+  filterStatus: Exclude<EvidenceFilter, "all">;
+  tone: EvidenceTone;
+  label: string;
+  title: string;
+  cardSummary: string;
+  sourceRefs: string[];
+  inspector: {
+    kicker: string;
+    summary: string;
+    lane: string;
+    status: string;
+    confidence: "Low" | "Medium" | "High" | "Unknown";
+    sources: EvidenceSource[];
+    trace: EvidenceTrace[];
+    boundary: string;
+  };
+};
+
+export type EvidenceLane = {
+  id: EvidenceLaneId;
+  label: string;
+  tone: EvidenceTone;
+  emptyMessage: string;
+};

--- a/examples/visual-operations/prototype/component-implementation-handoff.md
+++ b/examples/visual-operations/prototype/component-implementation-handoff.md
@@ -3,9 +3,10 @@
 ## Status
 
 The static prototype has moved from visual exploration into implementation. The
-shared shell and typed-fixture Evidence Ledger now live in `apps/mission-control/`;
-the typed-fixture Resource Observatory is also implemented, while projection adapters
-remain intentionally deferred.
+shared shell and Evidence Ledger now live in `apps/mission-control/`; the typed-fixture
+Resource Observatory is also implemented. A first narrow projection adapter now maps
+two versioned GitHub pull-request snapshots into the Evidence Ledger without adding
+live integration.
 
 This document freezes the accepted interaction model without choosing a frontend framework, creating an application, or changing Visual Operations contracts.
 
@@ -106,7 +107,7 @@ Evidence Ledger cards, Resource Observatory signals and source-record adapters s
 |---|---|---|
 | 2. Evidence Ledger — implemented | Read-only lanes, cards, filters and inspector using typed mock input. | Derived states and source refs match the accepted prototype; focus returns to the initiating card. |
 | 3. Resource Observatory — implemented | Grouped signals and signal inspector using typed mock input. | Nine candidates preserve availability, provenance, and no-authority semantics. |
-| 4. Projection adapter | One narrow adapter from existing Visual Operations outputs. | Dashboard reconstructs from source-backed records without creating new truth. |
+| 4. Projection adapter — first checkpoint implemented | A pure adapter maps the versioned PR #201 and PR #207 Visual Operations outputs into Evidence Ledger records. Live delivery and additional projector types remain deferred. | Source refs, evidence posture, confidence and trace remain attributable; non-read-only input is rejected. |
 | 5. Product QA | Responsive, keyboard, contrast and visual-regression pass. | Critical interaction paths and boundary states are covered. |
 
 ## Decisions required before slice 1


### PR DESCRIPTION
## What changed
- added a pure adapter from the existing GitHub pull-request projector contract to Evidence Ledger records
- replaced two manual closed cards with versioned PR #201 and PR #207 projection snapshots
- added boundary tests for read-only input, closure follow-up, pending review, unavailable sources, and source/trace preservation
- documented the first projection-adapter checkpoint

## Why
This is the smallest source-backed integration slice for Mission Control. It proves that the accepted UI can render existing Visual Operations outputs without creating new truth or introducing live infrastructure.

## How to validate
- `pnpm typecheck`
- `pnpm check:governance`
- `pnpm test`
- `pnpm build:mission-control`
- `./scripts/check-visual-ops-snapshots.sh`
- `git diff --check`
- local visual capture at 1600x1000

## Risks, assumptions, follow-ups
- only the versioned PR #201 and PR #207 snapshots are adapted; remaining records are explicit synthetic fixtures
- live delivery, additional projector types, and Resource Observatory adapters remain deferred
- the adapter formats and groups read-only state; it does not fetch, mutate, persist, authorize, or recalculate source records
- `plans/` remains untouched and untracked