### PR TITLE
fix(visual-ops): align Mission Control authority copy

### DIFF
--- a/apps/mission-control/src/App.test.tsx
+++ b/apps/mission-control/src/App.test.tsx
@@ -17,6 +17,8 @@ describe("Mission Control shared shell", () => {
     expect(screen.getByRole("heading", { name: "AletheIA Mission Control" })).toBeInTheDocument();
     expect(screen.getByText("Work slices by review posture")).toBeInTheDocument();
     expect(screen.getByText("Source records remain authoritative")).toBeInTheDocument();
+    expect(screen.getByText("Versioned snapshots · synthetic fixtures")).toBeInTheDocument();
+    expect(screen.queryByText(/static fixtures only/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 

--- a/apps/mission-control/src/components/MissionControlShell.tsx
+++ b/apps/mission-control/src/components/MissionControlShell.tsx
@@ -17,7 +17,7 @@ export function MissionControlShell() {
         <header className="topbar">
           <div className="product-title"><h1>AletheIA Mission Control</h1><span className="mode-label">Read-only projection</span></div>
           <div className="search-box" aria-label="Search unavailable in shell implementation"><span aria-hidden="true">⌕</span><span>{searchLabel}</span></div>
-          <div className="authority"><strong>Source records remain authoritative</strong>Shell implementation · static fixtures only</div>
+          <div className="authority"><strong>Source records remain authoritative</strong>Versioned snapshots · synthetic fixtures</div>
         </header>
         <Outlet />
       </section>

--- a/examples/visual-operations/prototype/component-implementation-handoff.md
+++ b/examples/visual-operations/prototype/component-implementation-handoff.md
@@ -108,7 +108,7 @@ Evidence Ledger cards, Resource Observatory signals and source-record adapters s
 | 2. Evidence Ledger — implemented | Read-only lanes, cards, filters and inspector using typed mock input. | Derived states and source refs match the accepted prototype; focus returns to the initiating card. |
 | 3. Resource Observatory — implemented | Grouped signals and signal inspector using typed mock input. | Nine candidates preserve availability, provenance, and no-authority semantics. |
 | 4. Projection adapter — first checkpoint implemented | A pure adapter maps the versioned PR #201 and PR #207 Visual Operations outputs into Evidence Ledger records. Live delivery and additional projector types remain deferred. | Source refs, evidence posture, confidence and trace remain attributable; non-read-only input is rejected. |
-| 5. Product QA | Responsive, keyboard, contrast and visual-regression pass. | Critical interaction paths and boundary states are covered. |
+| 5. Product QA — first checkpoint implemented | Browser QA covers desktop and narrow geometry, filters, route navigation, inspectors, Escape close, focus return, console health and contrast-token review. The stale fixture-only authority copy was corrected. Screenshot automation remains a follow-up because the in-app capture command timed out. | Critical interaction paths preserve source authority, responsive containment and keyboard orientation without console errors. |
 
 ## Decisions required before slice 1
 


### PR DESCRIPTION
## What changed
- corrected the global authority note to describe versioned snapshots plus synthetic fixtures
- added a regression assertion that prevents the obsolete fixture-only claim from returning
- recorded the first Product QA checkpoint in the component handoff

## Why
The first projection adapter made the previous `static fixtures only` message inaccurate. Product QA identified this as a trust and provenance issue rather than a cosmetic one.

## How to validate
- `pnpm typecheck`
- `pnpm check:governance`
- `pnpm test`
- `pnpm build:mission-control`
- `./scripts/check-visual-ops-snapshots.sh`
- `git diff --check`
- browser QA: filters, route navigation, inspector open/Escape/focus return, desktop and narrow containment, console errors, and contrast-token review

## Risks, assumptions, follow-ups
- no data behavior or authority changed; this corrects interface truthfulness only
- screenshot capture in the integrated browser timed out, so visual evidence used local Chrome headless as a fallback
- deeper visual-regression automation remains a separate follow-up
- `plans/` remains untouched and untracked