### PR TITLE
feat(visual-ops): dogfood Adaptive Skills signal

### DIFF
--- a/apps/mission-control/README.md
+++ b/apps/mission-control/README.md
@@ -12,7 +12,8 @@ The implementation currently contains:
 - the global operational header;
 - a functional Evidence Ledger with derived filters, Work Slice cards, and an evidence inspector;
 - a narrow read-only adapter that renders the versioned PR #201 and PR #207 projector snapshots beside typed synthetic records;
-- a functional Resource Observatory with nine typed local signal fixtures, three presentation groups, and a provenance inspector;
+- a functional Resource Observatory with nine typed signals, three presentation groups, and a provenance inspector;
+- a first Adaptive Skills dogfood signal reconstructed from a durable `feature-planning` execution record;
 - navigation, persistence, focus, and responsive tests.
 
 The accepted static prototypes remain the visual and content reference. The first
@@ -40,10 +41,10 @@ pnpm build:mission-control
 ## Boundary
 
 - read-only presentation state only;
-- versioned projection snapshots and explicit synthetic fixtures only;
+- versioned source records, projection snapshots, and explicit synthetic fixtures only;
 - no write API, persistence, collection, backend, runtime, or event bus;
 - no new schema, lifecycle, policy, gate, or decision authority;
-- no Adaptive Skills integration;
+- no Adaptive Skills runtime, collector, write-back, or governance authority;
 - Pulso is currently represented through local semantic tokens, not a package dependency.
 
 See the [frontend host decision](../../examples/visual-operations/prototype/frontend-host-decision.md)

--- a/apps/mission-control/src/adapters/README.md
+++ b/apps/mission-control/src/adapters/README.md
@@ -11,6 +11,8 @@ The current checkpoint:
 - preserves historical closure when a later alert creates review follow-up;
 - exposes absent references as `unavailable` rather than inventing provenance;
 - maps the versioned PR #201 and PR #207 snapshots into Evidence Ledger records.
+- maps a durable `feature-planning` execution record from Adaptive Skills into
+  the Resource Observatory while rejecting any governance-authority claim.
 
 It does not fetch, collect, mutate, persist, authorize, or recalculate source state.
 Additional projector types and live delivery are separate future slices.

--- a/apps/mission-control/src/adapters/adaptiveSkillExecutionRecordAdapter.test.ts
+++ b/apps/mission-control/src/adapters/adaptiveSkillExecutionRecordAdapter.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import executionRecordJson from "../../../../examples/visual-operations/adaptive-skills-feature-planning-dogfood-record.json";
+import {
+  adaptAdaptiveSkillExecutionRecord,
+  type AdaptiveSkillExecutionRecord,
+} from "./adaptiveSkillExecutionRecordAdapter";
+
+const executionRecord = executionRecordJson as AdaptiveSkillExecutionRecord;
+
+describe("Adaptive Skills execution record adapter", () => {
+  it("maps a durable skill activation into a sourced Observatory signal", () => {
+    expect(adaptAdaptiveSkillExecutionRecord(executionRecord)).toMatchObject({
+      id: "skill-usage",
+      groupId: "quality",
+      value: "feature-planning",
+      sourceRef: "as-exec-2026-06-22-mission-control-001",
+      origin: "reported",
+      availability: "available",
+      tone: "stable",
+    });
+  });
+
+  it("keeps Adaptive Skills advisory by rejecting governance authority claims", () => {
+    const invalidRecord = {
+      ...executionRecord,
+      governance_authority: true,
+    } as unknown as AdaptiveSkillExecutionRecord;
+
+    expect(() => adaptAdaptiveSkillExecutionRecord(invalidRecord)).toThrow("cannot claim Mission Control governance authority");
+  });
+
+  it("requires durable record and canonical skill references", () => {
+    const invalidRecord = {
+      ...executionRecord,
+      skill: { ...executionRecord.skill, source_ref: "" },
+    };
+
+    expect(() => adaptAdaptiveSkillExecutionRecord(invalidRecord)).toThrow("require durable record and skill source references");
+  });
+});

--- a/apps/mission-control/src/adapters/adaptiveSkillExecutionRecordAdapter.ts
+++ b/apps/mission-control/src/adapters/adaptiveSkillExecutionRecordAdapter.ts
@@ -1,0 +1,50 @@
+import type { ResourceSignal } from "../features/resource-observatory/resourceSignalTypes";
+
+export type AdaptiveSkillExecutionRecord = {
+  record_id: string;
+  recorded_at: string;
+  consumer_project: string;
+  work_slice_id: string;
+  skill: {
+    skill_id: string;
+    version: string;
+    source_ref: string;
+  };
+  mode: string;
+  context: string;
+  modules_activated: string[];
+  trigger_matches: string[];
+  result: string;
+  handoff_required: boolean;
+  failure_type: string | null;
+  improvement_note: string;
+  evidence_refs: string[];
+  attribution_guess: string;
+  result_mode: string;
+  governance_authority: false;
+};
+
+export function adaptAdaptiveSkillExecutionRecord(record: AdaptiveSkillExecutionRecord): ResourceSignal {
+  if (record.governance_authority !== false) {
+    throw new Error("Adaptive Skills records cannot claim Mission Control governance authority");
+  }
+  if (!record.record_id.trim() || !record.skill.skill_id.trim() || !record.skill.source_ref.trim()) {
+    throw new Error("Adaptive Skills records require durable record and skill source references");
+  }
+
+  const shortRevision = record.skill.source_ref.match(/\/blob\/([a-f0-9]{7,40})\//)?.[1]?.slice(0, 8) ?? "versioned";
+
+  return {
+    id: "skill-usage",
+    groupId: "quality",
+    label: "Skill usage",
+    value: record.skill.skill_id,
+    note: `${record.skill.skill_id} produced a ${record.result} execution record for this Observatory slice.`,
+    sourceRef: record.record_id,
+    origin: "reported",
+    availability: "available",
+    tone: "stable",
+    kicker: `Adaptive Skills · ${record.result}`,
+    interpretation: `Execution record references ${record.skill.skill_id}@${record.skill.version} (${shortRevision}). The activation is trace evidence only; AletheIA retains gate and decision authority.`,
+  };
+}

--- a/apps/mission-control/src/adapters/adaptiveSkillUsageSignal.ts
+++ b/apps/mission-control/src/adapters/adaptiveSkillUsageSignal.ts
@@ -1,0 +1,9 @@
+import executionRecordJson from "../../../../examples/visual-operations/adaptive-skills-feature-planning-dogfood-record.json";
+import {
+  adaptAdaptiveSkillExecutionRecord,
+  type AdaptiveSkillExecutionRecord,
+} from "./adaptiveSkillExecutionRecordAdapter";
+
+export const adaptiveSkillUsageSignal = adaptAdaptiveSkillExecutionRecord(
+  executionRecordJson as AdaptiveSkillExecutionRecord,
+);

--- a/apps/mission-control/src/features/resource-observatory/ResourceObservatory.test.tsx
+++ b/apps/mission-control/src/features/resource-observatory/ResourceObservatory.test.tsx
@@ -46,9 +46,10 @@ describe("Resource Observatory", () => {
     renderObservatory();
     const trigger = screen.getByRole("button", { name: "Inspect Skill usage provenance" });
     await user.click(trigger);
-    const inspector = screen.getByRole("dialog", { name: "Skill usage · traced" });
+    const inspector = screen.getByRole("dialog", { name: "Skill usage · feature-planning" });
 
-    expect(within(inspector).getByText(/not authority over gates, decisions, or lifecycle state/)).toBeInTheDocument();
+    expect(within(inspector).getByText("as-exec-2026-06-22-mission-control-001")).toBeInTheDocument();
+    expect(within(inspector).getByText(/AletheIA retains gate and decision authority/)).toBeInTheDocument();
     expect(within(inspector).getByRole("button", { name: "Close signal inspector" })).toHaveFocus();
     await user.keyboard("{Escape}");
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();

--- a/apps/mission-control/src/features/resource-observatory/resourceSignalFixtures.ts
+++ b/apps/mission-control/src/features/resource-observatory/resourceSignalFixtures.ts
@@ -1,26 +1,13 @@
-export type SignalOrigin = "reported" | "estimated" | "unavailable";
-export type SignalAvailability = "available" | "unavailable";
-export type SignalTone = "evidence" | "review" | "stable" | "neutral";
-export type SignalGroupId = "capacity" | "efficiency" | "quality";
-
-export type ResourceSignal = {
-  id: string;
-  groupId: SignalGroupId;
-  label: string;
-  value: string;
-  note: string;
-  sourceRef: string;
-  origin: SignalOrigin;
-  availability: SignalAvailability;
-  tone: SignalTone;
-  kicker: string;
-  interpretation: string;
-};
-
-export type ResourceSignalGroup = {
-  id: SignalGroupId;
-  label: string;
-};
+import { adaptiveSkillUsageSignal } from "../../adapters/adaptiveSkillUsageSignal";
+import type { ResourceSignal, ResourceSignalGroup } from "./resourceSignalTypes";
+export type {
+  ResourceSignal,
+  ResourceSignalGroup,
+  SignalAvailability,
+  SignalGroupId,
+  SignalOrigin,
+  SignalTone,
+} from "./resourceSignalTypes";
 
 export const resourceSignalGroups: ResourceSignalGroup[] = [
   { id: "capacity", label: "Capacity & spend" },
@@ -120,19 +107,7 @@ export const resourceSignals: ResourceSignal[] = [
     kicker: "Reported signal",
     interpretation: "Quality remains tied to its evaluation source and cannot independently close a readiness gate.",
   },
-  {
-    id: "skill-usage",
-    groupId: "quality",
-    label: "Skill usage",
-    value: "traced",
-    note: "Skill activation appears as trace context only.",
-    sourceRef: "ACT-552",
-    origin: "reported",
-    availability: "available",
-    tone: "stable",
-    kicker: "Traced activation",
-    interpretation: "A skill activation is observable evidence, not authority over gates, decisions, or lifecycle state.",
-  },
+  adaptiveSkillUsageSignal,
   {
     id: "agent-usage",
     groupId: "quality",

--- a/apps/mission-control/src/features/resource-observatory/resourceSignalTypes.ts
+++ b/apps/mission-control/src/features/resource-observatory/resourceSignalTypes.ts
@@ -1,0 +1,23 @@
+export type SignalOrigin = "reported" | "estimated" | "unavailable";
+export type SignalAvailability = "available" | "unavailable";
+export type SignalTone = "evidence" | "review" | "stable" | "neutral";
+export type SignalGroupId = "capacity" | "efficiency" | "quality";
+
+export type ResourceSignal = {
+  id: string;
+  groupId: SignalGroupId;
+  label: string;
+  value: string;
+  note: string;
+  sourceRef: string;
+  origin: SignalOrigin;
+  availability: SignalAvailability;
+  tone: SignalTone;
+  kicker: string;
+  interpretation: string;
+};
+
+export type ResourceSignalGroup = {
+  id: SignalGroupId;
+  label: string;
+};

--- a/docs/pilots/README.md
+++ b/docs/pilots/README.md
@@ -22,6 +22,7 @@ Operation closeouts (session/task records from Hermes and other runtimes) live i
 | [visual-operations-usage-pr-200-dogfood.md](visual-operations-usage-pr-200-dogfood.md) | First dogfood usage record: PR #200 snapshot supported a post-merge no-new-infrastructure decision |
 | [visual-operations-usage-pr-201-dogfood.md](visual-operations-usage-pr-201-dogfood.md) | Second dogfood usage record: PR #201 snapshot confirmed static closeout utility and no activation threshold met |
 | [visual-operations-usage-pr-207-dogfood.md](visual-operations-usage-pr-207-dogfood.md) | Third dogfood usage record: PR #207 confirmed human-review unavailable is a source-bound design signal, not a UI failure |
+| [visual-operations-adaptive-skills-dogfood.md](visual-operations-adaptive-skills-dogfood.md) | First full-pipeline checkpoint: a real Adaptive Skills execution record becomes a read-only Resource Observatory signal |
 | [Visual Operations phase closeout](closeouts/2026-06-15-visual-operations-phase-closeout.md) | Closure evidence and activation gates after PRs #193–#197 |
 
 ## Cycle records

--- a/docs/pilots/visual-operations-adaptive-skills-dogfood.md
+++ b/docs/pilots/visual-operations-adaptive-skills-dogfood.md
@@ -1,0 +1,53 @@
+# Visual Operations + Adaptive Skills dogfood
+
+## Status
+
+First bounded cross-repository observability checkpoint, recorded on 2026-06-22.
+
+This pilot uses an existing Adaptive Skills capability while evolving AletheIA's
+Resource Observatory. It does not add a runtime, collector, telemetry service, or
+write-back path.
+
+## What was exercised
+
+| Layer | Role in this slice |
+|---|---|
+| AletheIA | Defines the read-only projection boundary and remains the macro-governance layer. |
+| Adaptive Skills | Supplies the versioned `feature-planning` capability used to define the smallest useful integration slice. |
+| Mission Control | Adapts the execution record into a sourced Resource Observatory signal. |
+
+The canonical capability source is
+[`feature-planning@0.1.0`](https://github.com/nevitonsantana/adaptive-skills/blob/9064ec8e7bef7f3c9b649232d736f079164dfcb8/skills/feature-planning/SKILL.md).
+The consumer-owned execution record is
+[`adaptive-skills-feature-planning-dogfood-record.json`](../../examples/visual-operations/adaptive-skills-feature-planning-dogfood-record.json).
+
+## Why the activation gate is satisfied
+
+The Visual Operations phase closeout required a durable, non-sensitive activation
+record plus a reviewed mapping that preserves AletheIA authority. This checkpoint
+provides both:
+
+- the checked-in record identifies skill, version, source revision, context,
+  activated modules, result, evidence references, and attribution guess;
+- `governance_authority` is explicitly `false`;
+- the adapter rejects records that claim governance authority;
+- the Resource Observatory labels the signal as reported trace evidence;
+- no prompt, secret, personal data, or restricted source body is stored.
+
+## Observable result
+
+The previous synthetic `ACT-552` card is replaced by a signal reconstructed from
+the execution record:
+
+- label: `Skill usage`;
+- value: `feature-planning`;
+- provenance: `reported`;
+- source: `as-exec-2026-06-22-mission-control-001`;
+- interpretation: activation evidence does not control gates or decisions.
+
+## Boundary and follow-up
+
+This is a versioned snapshot integration, not automatic telemetry. The next useful
+cross-repository step should be another real execution record only when a distinct
+skill or outcome adds evidence. Repeated records may later justify a collector, but
+this single checkpoint does not.

--- a/examples/README.md
+++ b/examples/README.md
@@ -58,6 +58,7 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
   - entrada e saídas reproduzíveis do projetor GitHub PR → Visual Operations, incluindo distinção entre evidência observada por CI e validação reportada pelo autor
   - snapshot dogfood do PR #200 usado para registrar a primeira evidência real de uso da Visual Operations no próprio AletheIA
   - snapshot dogfood do PR #201 usado como segunda evidência real e confirmação de que não há threshold para nova infraestrutura
+  - registro real e não sensível de `feature-planning` usado para provar a primeira esteira AletheIA + Adaptive Skills no Resource Observatory
   - segundo piloto real da PR #195, gerado e verificável pelo CLI local com `--check`
   - exemplos estáticos de cards do cockpit para revisar estados visuais antes de qualquer UI
   - composição estática de board com lanes, contagens e exceções antes de wireframe/UI

--- a/examples/visual-operations/adaptive-skills-feature-planning-dogfood-record.json
+++ b/examples/visual-operations/adaptive-skills-feature-planning-dogfood-record.json
@@ -1,0 +1,35 @@
+{
+  "record_id": "as-exec-2026-06-22-mission-control-001",
+  "recorded_at": "2026-06-22T01:27:40Z",
+  "consumer_project": "aletheia",
+  "work_slice_id": "mission-control-adaptive-skills-dogfood-001",
+  "skill": {
+    "skill_id": "feature-planning",
+    "version": "0.1.0",
+    "source_ref": "https://github.com/nevitonsantana/adaptive-skills/blob/9064ec8e7bef7f3c9b649232d736f079164dfcb8/skills/feature-planning/SKILL.md"
+  },
+  "mode": "workflow/extended",
+  "context": "Plan the smallest source-backed Adaptive Skills signal for the read-only AletheIA Resource Observatory.",
+  "modules_activated": [
+    "dependencies-map",
+    "risk-review",
+    "traceability-and-anti-overengineering",
+    "scope-boundaries"
+  ],
+  "trigger_matches": [
+    "new feature work",
+    "cross-repository dependency",
+    "explicit acceptance evidence required"
+  ],
+  "result": "usable",
+  "handoff_required": true,
+  "failure_type": null,
+  "improvement_note": "Keep the first observability layer as a durable execution record; defer runtime telemetry and collectors.",
+  "evidence_refs": [
+    "https://github.com/nevitonsantana/AletheIA/pull/248",
+    "examples/visual-operations/prototype/component-implementation-handoff.md"
+  ],
+  "attribution_guess": "feature-planning made the cross-repository boundary and the smallest useful adapter slice explicit",
+  "result_mode": "reinforced",
+  "governance_authority": false
+}

--- a/examples/visual-operations/prototype/component-implementation-handoff.md
+++ b/examples/visual-operations/prototype/component-implementation-handoff.md
@@ -22,7 +22,7 @@ The implementation objective is to reproduce the accepted experience with reusab
 - no backend, collector, runtime, event bus, or persistence;
 - no new lifecycle, schema, policy engine, or gate authority;
 - no live telemetry or invented operational values;
-- no Adaptive Skills integration;
+- no Adaptive Skills runtime, collector, write-back, or governance authority;
 - no framework or Pulso package commitment before a host decision.
 
 ## Accepted experience baseline
@@ -109,6 +109,7 @@ Evidence Ledger cards, Resource Observatory signals and source-record adapters s
 | 3. Resource Observatory — implemented | Grouped signals and signal inspector using typed mock input. | Nine candidates preserve availability, provenance, and no-authority semantics. |
 | 4. Projection adapter — first checkpoint implemented | A pure adapter maps the versioned PR #201 and PR #207 Visual Operations outputs into Evidence Ledger records. Live delivery and additional projector types remain deferred. | Source refs, evidence posture, confidence and trace remain attributable; non-read-only input is rejected. |
 | 5. Product QA — first checkpoint implemented | Browser QA covers desktop and narrow geometry, filters, route navigation, inspectors, Escape close, focus return, console health and contrast-token review. The stale fixture-only authority copy was corrected. Screenshot automation remains a follow-up because the in-app capture command timed out. | Critical interaction paths preserve source authority, responsive containment and keyboard orientation without console errors. |
+| 6. Adaptive Skills dogfood — first checkpoint implemented | A consumer-owned, non-sensitive `feature-planning` execution record is adapted into the Resource Observatory. Runtime telemetry and collection remain deferred. | The signal cites a canonical versioned skill source, remains read-only, and rejects governance-authority claims. |
 
 ## Decisions required before slice 1
 


### PR DESCRIPTION
## What changed
- added a durable, non-sensitive `feature-planning` execution record tied to Adaptive Skills commit `9064ec8`
- replaced the synthetic `ACT-552` Skill usage card with a Resource Observatory signal adapted from that record
- added a pure adapter that rejects Adaptive Skills records claiming governance authority
- documented the first AletheIA + Adaptive Skills full-pipeline dogfood checkpoint

## Why
The Resource Observatory should exercise the solutions being built. Adaptive Skills already defines an execution record as the first observability layer, so this slice uses that contract without adding runtime telemetry or collection.

## How to validate
- `pnpm typecheck`
- `pnpm check:governance`
- `pnpm test`
- `pnpm build:mission-control`
- `./scripts/check-visual-ops-snapshots.sh`
- JSON parse of the execution record
- local Markdown link audit
- adapter boundary scan and `git diff --check`
- browser QA of card, inspector, focus and console health

## Risks, assumptions, follow-ups
- the execution record is consumer-owned and cites the canonical Adaptive Skills source revision; it is not automated telemetry
- AletheIA retains macro gate and decision authority; Adaptive Skills remains advisory
- no runtime, collector, write-back, backend, schema, or new dependency is introduced
- the installed local feature-planning copy differs from the canonical repository version, so the record deliberately cites the canonical commit
- `plans/` remains untouched and untracked