### PR TITLE
feat(visual-ops): expose skill execution context

### DIFF
--- a/apps/mission-control/src/adapters/adaptiveSkillExecutionRecordAdapter.test.ts
+++ b/apps/mission-control/src/adapters/adaptiveSkillExecutionRecordAdapter.test.ts
@@ -17,7 +17,14 @@ describe("Adaptive Skills execution record adapter", () => {
       origin: "reported",
       availability: "available",
       tone: "stable",
+      executionContext: [
+        { label: "Mode", value: "workflow/extended" },
+        { label: "Result", value: "usable" },
+        { label: "Modules", value: "dependencies-map, risk-review, traceability-and-anti-overengineering, scope-boundaries" },
+        { label: "Handoff", value: "required" },
+      ],
     });
+    expect(adaptAdaptiveSkillExecutionRecord(executionRecord).evidenceRefs).toContain("https://github.com/nevitonsantana/AletheIA/pull/248");
   });
 
   it("keeps Adaptive Skills advisory by rejecting governance authority claims", () => {

--- a/apps/mission-control/src/adapters/adaptiveSkillExecutionRecordAdapter.ts
+++ b/apps/mission-control/src/adapters/adaptiveSkillExecutionRecordAdapter.ts
@@ -46,5 +46,12 @@ export function adaptAdaptiveSkillExecutionRecord(record: AdaptiveSkillExecution
     tone: "stable",
     kicker: `Adaptive Skills · ${record.result}`,
     interpretation: `Execution record references ${record.skill.skill_id}@${record.skill.version} (${shortRevision}). The activation is trace evidence only; AletheIA retains gate and decision authority.`,
+    executionContext: [
+      { label: "Mode", value: record.mode },
+      { label: "Result", value: record.result },
+      { label: "Modules", value: record.modules_activated.join(", ") || "unavailable" },
+      { label: "Handoff", value: record.handoff_required ? "required" : "not required" },
+    ],
+    evidenceRefs: record.evidence_refs,
   };
 }

--- a/apps/mission-control/src/features/resource-observatory/ResourceObservatory.test.tsx
+++ b/apps/mission-control/src/features/resource-observatory/ResourceObservatory.test.tsx
@@ -50,6 +50,10 @@ describe("Resource Observatory", () => {
 
     expect(within(inspector).getByText("as-exec-2026-06-22-mission-control-001")).toBeInTheDocument();
     expect(within(inspector).getByText(/AletheIA retains gate and decision authority/)).toBeInTheDocument();
+    expect(within(inspector).getByText("workflow/extended")).toBeInTheDocument();
+    expect(within(inspector).getByText(/dependencies-map, risk-review/)).toBeInTheDocument();
+    expect(within(inspector).getByText("required")).toBeInTheDocument();
+    expect(within(inspector).getByText("https://github.com/nevitonsantana/AletheIA/pull/248")).toBeInTheDocument();
     expect(within(inspector).getByRole("button", { name: "Close signal inspector" })).toHaveFocus();
     await user.keyboard("{Escape}");
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();

--- a/apps/mission-control/src/features/resource-observatory/ResourceSignalInspector.tsx
+++ b/apps/mission-control/src/features/resource-observatory/ResourceSignalInspector.tsx
@@ -45,6 +45,27 @@ export function ResourceSignalInspector({ signal, onClose }: ResourceSignalInspe
                 <h3>Interpretation</h3>
                 <p className="signal-interpretation">{signal.interpretation}</p>
               </section>
+              {signal.executionContext?.length ? (
+                <section className="inspector-section">
+                  <h3>Execution context</h3>
+                  <dl className="signal-detail-list">
+                    {signal.executionContext.map((detail) => <div key={detail.label}><dt>{detail.label}</dt><dd>{detail.value}</dd></div>)}
+                  </dl>
+                </section>
+              ) : null}
+              {signal.evidenceRefs?.length ? (
+                <section className="inspector-section">
+                  <h3>Evidence refs</h3>
+                  <div className="source-list">
+                    {signal.evidenceRefs.map((sourceRef) => (
+                      <div className="source-item" key={sourceRef}>
+                        <span className="source-main"><span className="source-name" title={sourceRef}>{sourceRef}</span><span className="source-type">Execution evidence</span></span>
+                        <span className="source-origin reported">reported</span>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
               <section className="inspector-section">
                 <h3>Boundary</h3>
                 <p className="boundary-note">The Resource Observatory displays sourced metadata only. Source records remain authoritative; this interface does not collect, calculate, govern, or execute.</p>

--- a/apps/mission-control/src/features/resource-observatory/resourceSignalTypes.ts
+++ b/apps/mission-control/src/features/resource-observatory/resourceSignalTypes.ts
@@ -15,6 +15,11 @@ export type ResourceSignal = {
   tone: SignalTone;
   kicker: string;
   interpretation: string;
+  executionContext?: Array<{
+    label: string;
+    value: string;
+  }>;
+  evidenceRefs?: string[];
 };
 
 export type ResourceSignalGroup = {

--- a/docs/pilots/visual-operations-adaptive-skills-dogfood.md
+++ b/docs/pilots/visual-operations-adaptive-skills-dogfood.md
@@ -45,6 +45,10 @@ the execution record:
 - source: `as-exec-2026-06-22-mission-control-001`;
 - interpretation: activation evidence does not control gates or decisions.
 
+The contextual inspector progressively reveals the execution mode, result, activated
+modules, handoff posture, and evidence references. These fields explain the activation;
+they are not converted into a score, recommendation, or gate outcome.
+
 ## Boundary and follow-up
 
 This is a versioned snapshot integration, not automatic telemetry. The next useful


### PR DESCRIPTION
## What changed
- extends Resource Observatory signals with optional execution context and evidence references
- renders mode, result, activated modules, handoff and evidence inside the existing skill inspector
- keeps cards compact and uses progressive disclosure

## Why it changed
This makes actual Adaptive Skills usage auditable without turning the Observatory into an execution or governance authority.

## How to validate
- `pnpm check:governance`
- `pnpm test`
- `pnpm --dir apps/mission-control test`
- `pnpm --dir apps/mission-control build`
- `./scripts/check-visual-ops-snapshots.sh`
- `git diff --check main...HEAD`

## Risks, assumptions or follow-ups
- fields are optional and source-backed
- no runtime, collector or backend is introduced
- governed pattern context remains a separate follow-up
