### PR TITLE
feat(visual-ops): show unavailable pattern context

### DIFF
--- a/apps/mission-control/src/adapters/adaptiveSkillExecutionRecordAdapter.test.ts
+++ b/apps/mission-control/src/adapters/adaptiveSkillExecutionRecordAdapter.test.ts
@@ -23,6 +23,18 @@ describe("Adaptive Skills execution record adapter", () => {
         { label: "Modules", value: "dependencies-map, risk-review, traceability-and-anti-overengineering, scope-boundaries" },
         { label: "Handoff", value: "required" },
       ],
+      patternContext: {
+        pattern: null,
+        selection: { verdict: "unavailable", selectedBy: "unavailable" },
+        compatibility: {
+          status: "unavailable",
+          message: "loop candidacy not assessed",
+          declaredBy: "unavailable",
+          skillId: "feature-planning",
+          skillVersion: "0.1.0",
+        },
+        refs: {},
+      },
     });
     expect(adaptAdaptiveSkillExecutionRecord(executionRecord).evidenceRefs).toContain("https://github.com/nevitonsantana/AletheIA/pull/248");
   });

--- a/apps/mission-control/src/adapters/adaptiveSkillExecutionRecordAdapter.ts
+++ b/apps/mission-control/src/adapters/adaptiveSkillExecutionRecordAdapter.ts
@@ -53,5 +53,21 @@ export function adaptAdaptiveSkillExecutionRecord(record: AdaptiveSkillExecution
       { label: "Handoff", value: record.handoff_required ? "required" : "not required" },
     ],
     evidenceRefs: record.evidence_refs,
+    patternContext: {
+      pattern: null,
+      selection: {
+        verdict: "unavailable",
+        selectedBy: "unavailable",
+        rationale: "No source-backed execution pattern selection record is attached to this skill usage.",
+      },
+      compatibility: {
+        status: "unavailable",
+        message: "loop candidacy not assessed",
+        declaredBy: "unavailable",
+        skillId: record.skill.skill_id,
+        skillVersion: record.skill.version,
+      },
+      refs: {},
+    },
   };
 }

--- a/apps/mission-control/src/features/resource-observatory/ResourceObservatory.test.tsx
+++ b/apps/mission-control/src/features/resource-observatory/ResourceObservatory.test.tsx
@@ -54,6 +54,11 @@ describe("Resource Observatory", () => {
     expect(within(inspector).getByText(/dependencies-map, risk-review/)).toBeInTheDocument();
     expect(within(inspector).getByText("required")).toBeInTheDocument();
     expect(within(inspector).getByText("https://github.com/nevitonsantana/AletheIA/pull/248")).toBeInTheDocument();
+    expect(within(inspector).getByRole("heading", { name: "Pattern selection" })).toBeInTheDocument();
+    expect(within(inspector).getByText(/No source-backed execution pattern selection record/)).toBeInTheDocument();
+    expect(within(inspector).getByRole("heading", { name: "Skill compatibility" })).toBeInTheDocument();
+    expect(within(inspector).getByText(/loop candidacy not assessed/)).toBeInTheDocument();
+    expect(within(inspector).queryByText("compatible", { exact: true })).not.toBeInTheDocument();
     expect(within(inspector).getByRole("button", { name: "Close signal inspector" })).toHaveFocus();
     await user.keyboard("{Escape}");
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();

--- a/apps/mission-control/src/features/resource-observatory/ResourceSignalInspector.test.tsx
+++ b/apps/mission-control/src/features/resource-observatory/ResourceSignalInspector.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ResourceSignalInspector } from "./ResourceSignalInspector";
+import { resourceSignals } from "./resourceSignalFixtures";
+
+const skillSignal = resourceSignals.find((signal) => signal.id === "skill-usage");
+
+if (!skillSignal) throw new Error("Skill usage fixture is required for inspector tests");
+
+describe("ResourceSignalInspector pattern context", () => {
+  it("describes missing governed context without inferring a pattern", () => {
+    const { patternContext: _patternContext, ...signalWithoutPatternContext } = skillSignal;
+    render(<ResourceSignalInspector signal={signalWithoutPatternContext} onClose={vi.fn()} />);
+
+    const inspector = screen.getByRole("dialog");
+    expect(within(inspector).getByText("No governed pattern context is available for this skill usage.")).toBeInTheDocument();
+    expect(within(inspector).queryByText("loop_until_done")).not.toBeInTheDocument();
+  });
+
+  it("keeps a missing objective gate local to loop controls", () => {
+    render(
+      <ResourceSignalInspector
+        signal={{
+          ...skillSignal,
+          patternContext: {
+            ...skillSignal.patternContext!,
+            controls: {
+              maxIterations: 3,
+              currentIterations: 0,
+              requiredControls: ["objective_gate", "explicit_budget"],
+              missingPreconditions: ["objective_gate"],
+              humanReviewBoundary: "human-led review required before continuation",
+            },
+          },
+        }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const controls = screen.getByRole("heading", { name: "Loop controls" }).closest("section");
+    expect(controls).not.toBeNull();
+    expect(within(controls!).getByText("Loop cannot be approved:")).toBeInTheDocument();
+    expect(within(controls!).getByText(/objective gate missing/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /run loop|approve loop/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/mission-control/src/features/resource-observatory/ResourceSignalInspector.tsx
+++ b/apps/mission-control/src/features/resource-observatory/ResourceSignalInspector.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef } from "react";
 import type { ResourceSignal } from "./resourceSignalFixtures";
 
+function joinOrUnavailable(values?: string[]) {
+  return values?.length ? values.join(", ") : "unavailable";
+}
+
 type ResourceSignalInspectorProps = {
   signal: ResourceSignal | null;
   onClose: () => void;
@@ -65,6 +69,51 @@ export function ResourceSignalInspector({ signal, onClose }: ResourceSignalInspe
                     ))}
                   </div>
                 </section>
+              ) : null}
+              {signal.executionContext && !signal.patternContext ? (
+                <section className="inspector-section">
+                  <h3>Governed pattern context</h3>
+                  <p className="pattern-state-note">No governed pattern context is available for this skill usage.</p>
+                </section>
+              ) : null}
+              {signal.patternContext ? (
+                <>
+                  <section className="inspector-section">
+                    <h3>Pattern selection</h3>
+                    <dl className="signal-detail-list">
+                      <div><dt>Pattern</dt><dd>{signal.patternContext.pattern?.id ?? "unavailable"}</dd></div>
+                      <div><dt>Vehicle</dt><dd>{signal.patternContext.pattern?.vehicle ?? "unavailable"}</dd></div>
+                      <div><dt>Verdict</dt><dd>{signal.patternContext.selection?.verdict ?? "unavailable"}</dd></div>
+                      <div><dt>Selected by</dt><dd>{signal.patternContext.selection?.selectedBy ?? "unavailable"}</dd></div>
+                      {signal.patternContext.selection?.rationale ? <div><dt>Rationale</dt><dd>{signal.patternContext.selection.rationale}</dd></div> : null}
+                      {signal.patternContext.selection?.decisionRef ? <div><dt>Decision ref</dt><dd>{signal.patternContext.selection.decisionRef}</dd></div> : null}
+                    </dl>
+                  </section>
+                  <section className="inspector-section">
+                    <h3>Skill compatibility</h3>
+                    <dl className="signal-detail-list">
+                      <div><dt>Status</dt><dd>{signal.patternContext.compatibility.status}</dd></div>
+                      <div><dt>Declared by</dt><dd>{signal.patternContext.compatibility.declaredBy ?? "unavailable"}</dd></div>
+                      {signal.patternContext.compatibility.skillVersion ? <div><dt>Skill version</dt><dd>{signal.patternContext.compatibility.skillVersion}</dd></div> : null}
+                      {signal.patternContext.compatibility.declarationRef ? <div><dt>Declaration</dt><dd>{signal.patternContext.compatibility.declarationRef}</dd></div> : null}
+                    </dl>
+                    {signal.patternContext.compatibility.message ? <p className="pattern-state-note"><strong>Unavailable</strong> — {signal.patternContext.compatibility.message}.</p> : null}
+                  </section>
+                  {signal.patternContext.controls ? (
+                    <section className="inspector-section">
+                      <h3>Loop controls</h3>
+                      <dl className="signal-detail-list">
+                        <div><dt>Stop condition</dt><dd>{signal.patternContext.controls.stopCondition ?? "unavailable"}</dd></div>
+                        <div><dt>Objective gate</dt><dd>{signal.patternContext.controls.objectiveGate ?? "unavailable"}</dd></div>
+                        <div><dt>Iterations</dt><dd>{signal.patternContext.controls.currentIterations ?? 0} / {signal.patternContext.controls.maxIterations ?? "unavailable"}</dd></div>
+                        <div><dt>Required</dt><dd>{joinOrUnavailable(signal.patternContext.controls.requiredControls)}</dd></div>
+                        <div><dt>Missing</dt><dd>{joinOrUnavailable(signal.patternContext.controls.missingPreconditions)}</dd></div>
+                        <div><dt>Human review</dt><dd>{signal.patternContext.controls.humanReviewBoundary ?? "unavailable"}</dd></div>
+                      </dl>
+                      {signal.patternContext.controls.missingPreconditions?.includes("objective_gate") ? <p className="pattern-state-note is-warning"><strong>Loop cannot be approved:</strong> objective gate missing.</p> : null}
+                    </section>
+                  ) : null}
+                </>
               ) : null}
               <section className="inspector-section">
                 <h3>Boundary</h3>

--- a/apps/mission-control/src/features/resource-observatory/resourceSignalFixtures.ts
+++ b/apps/mission-control/src/features/resource-observatory/resourceSignalFixtures.ts
@@ -7,6 +7,7 @@ export type {
   SignalGroupId,
   SignalOrigin,
   SignalTone,
+  PatternContext,
 } from "./resourceSignalTypes";
 
 export const resourceSignalGroups: ResourceSignalGroup[] = [

--- a/apps/mission-control/src/features/resource-observatory/resourceSignalTypes.ts
+++ b/apps/mission-control/src/features/resource-observatory/resourceSignalTypes.ts
@@ -3,6 +3,59 @@ export type SignalAvailability = "available" | "unavailable";
 export type SignalTone = "evidence" | "review" | "stable" | "neutral";
 export type SignalGroupId = "capacity" | "efficiency" | "quality";
 
+export type PatternContext = {
+  pattern?: {
+    id: string;
+    label: string;
+    vehicle: "skill_execution" | "subagent_execution" | "tool_sequence" | "human_led_required" | "unavailable";
+    description?: string;
+  } | null;
+  selection?: {
+    verdict: "selected" | "not_selected" | "unavailable";
+    selectedBy: "aletheia" | "unavailable";
+    rationale?: string;
+    decisionRef?: string;
+  } | null;
+  compatibility: {
+    status: "compatible" | "incompatible" | "unavailable";
+    message?: string;
+    declaredBy?: "adaptive_skills" | "project_local_skill_provider" | "runtime_native_skill_provider" | "unavailable";
+    skillId?: string;
+    skillVersion?: string;
+    rationale?: string;
+    declarationRef?: string;
+  };
+  controls?: {
+    stopCondition?: string;
+    objectiveGate?: string;
+    maxIterations?: number;
+    currentIterations?: number;
+    budget?: {
+      timeMinutes?: number;
+      tokenBudget?: number;
+    };
+    requiredControls?: string[];
+    presentControls?: string[];
+    missingPreconditions?: string[];
+    humanReviewBoundary?: string;
+  } | null;
+  outcome?: {
+    result: "reinforced" | "no-change" | "proposal-created" | "escalated" | "unavailable";
+    rationale?: string;
+    evidenceRefs?: string[];
+    proposalRef?: string;
+    escalationRef?: string;
+    comparableCaseCount?: number;
+    showSuccessPercentage?: boolean;
+  } | null;
+  refs: {
+    selectionRef?: string;
+    compatibilityRef?: string;
+    loopRunRef?: string;
+    auditRefs?: string[];
+  };
+};
+
 export type ResourceSignal = {
   id: string;
   groupId: SignalGroupId;
@@ -20,6 +73,7 @@ export type ResourceSignal = {
     value: string;
   }>;
   evidenceRefs?: string[];
+  patternContext?: PatternContext;
 };
 
 export type ResourceSignalGroup = {

--- a/apps/mission-control/src/styles.css
+++ b/apps/mission-control/src/styles.css
@@ -187,6 +187,9 @@ button, a { font: inherit; }
 .signal-detail-list > div { display: grid; grid-template-columns: 90px minmax(0, 1fr); align-items: center; gap: 12px; }
 .signal-detail-list dt { color: var(--mc-text-muted); font: 720 0.62rem var(--mono); text-transform: uppercase; }
 .signal-detail-list dd { margin: 0; color: var(--mc-text-support); font-size: 0.76rem; font-weight: 620; }
+.pattern-state-note { margin: 12px 0 0; padding-left: 12px; border-left: 2px solid var(--mc-border-strong); color: var(--mc-text-muted); font-size: 0.74rem; line-height: 1.5; }
+.pattern-state-note strong { color: var(--mc-text-support); }
+.pattern-state-note.is-warning { border-left-color: var(--mc-review); color: var(--mc-text-support); }
 .signal-interpretation { margin: 0; padding: 14px; border: 1px solid var(--mc-border); border-radius: 10px; color: var(--mc-text-support); background: #0f0c1a; font-size: 0.76rem; line-height: 1.45; }
 
 @media (max-width: 1080px) { .topbar { grid-template-columns: 1fr auto; } .search-box { display: none; } }


### PR DESCRIPTION
## What changed
- adds optional `patternContext` to the Resource Observatory view model
- projects feature-planning compatibility and pattern selection as explicitly unavailable when canonical declarations are absent
- adds inspector states for no governed context and missing objective gate
- adds adapter and inspector regression tests

## Why it changed
This is the first observe-only slice of Governed Loop Observation. It exposes absence honestly before any compatible or executable loop state is introduced.

## How to validate
- `pnpm test`
- `pnpm typecheck`
- `pnpm --filter @aletheia/mission-control build`
- `pnpm check:governance`
- `./scripts/check-visual-ops-snapshots.sh`
- `git diff --check`
- desktop and 390×844 browser QA of the existing skill inspector

## Risks, assumptions or follow-ups
- no pattern compatibility is inferred
- no new page, card, storage authority, run action or approval action is introduced
- source-backed compatible states and the debugging pilot remain separate follow-ups
- `plans/` remains untouched and untracked
