### PR TITLE
docs(context): add minimum surface registry

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -16,6 +16,7 @@ If you need conceptual background, see [`concepts/`](../concepts/README.md). If 
 | [delivery-tooling-boundaries.md](delivery-tooling-boundaries.md) | What delivery tooling may and may not do |
 | [readiness-gates-spec.md](readiness-gates-spec.md) | When a slice is ready to continue, review, hand off, or stop |
 | [context-resource-telemetry-spec.md](context-resource-telemetry-spec.md) | Telemetry surface for resource-aware operations |
+| [context-surface-registry.md](context-surface-registry.md) | Minimum metadata, loading boundaries, freshness and evidence for surfaces that influence agent behavior |
 | [slice-telemetry-model.md](slice-telemetry-model.md) | Minimal model for recording slice-level telemetry |
 | [visual-operations-event-model.md](visual-operations-event-model.md) | Normalized, source-referenced events for read-only visual projection |
 | [work-slice-visual-state-contract.md](work-slice-visual-state-contract.md) | Presentation lanes and derived Work Slice card state without a new lifecycle |

--- a/docs/contracts/context-surface-registry.md
+++ b/docs/contracts/context-surface-registry.md
@@ -1,0 +1,118 @@
+# Context Surface Registry — Minimum Contract
+
+## Purpose
+
+Define the minimum metadata required to govern an artifact that can influence agent behavior. The registry answers where a surface lives, who owns it, when it may be loaded, what should be extracted, and when it must stay out of context.
+
+This contract extends existing [context-rot controls](../concepts/context-rot-controls.md) and [Knowledge Governance](../concepts/knowledge-governance-layer.md). It does not centralize source content or create an automatic context router.
+
+## Boundary
+
+A context surface may be a persistent manifest, role contract, skill/provider declaration, project document, tool configuration, runtime policy, Work Slice artifact or evidence record.
+
+The registry stores metadata about the surface. It must not copy prompts, secrets, restricted source content or full skill methods into the registry.
+
+## Minimum registry
+
+```yaml
+context_surface_registry:
+  version: "0.1"
+  owner: <registry owner>
+  reviewed_at: YYYY-MM-DD
+  surfaces:
+    - id: <stable id>
+      title: <human-readable title>
+      type: persistent_manifest | agent_role_contract | skill_provider | project_doc | tool_config | runtime_policy | work_artifact | evidence_artifact
+      path: <repository path or authorized reference>
+      owner: <person, team, or project role>
+      provider: aletheia | adaptive_skills | project_local | runtime_native | external | user_defined
+      scope: repository | package | feature | agent_role | capability | work_slice | evidence
+      load_mode: always | on_demand | role_scoped | capability_scoped | work_slice_scoped | evidence_only | never_directly
+      priority: critical | high | medium | low
+      activation_conditions:
+        - condition: <when this surface becomes relevant>
+          rationale: <why loading is justified>
+          expected_extraction: <minimum information to retrieve>
+      freshness:
+        last_reviewed: YYYY-MM-DD
+        review_interval_days: <positive integer>
+      budget:
+        max_lines: <positive integer or unavailable>
+        max_tokens: <positive integer or unavailable>
+        origin: reported | estimated | unavailable
+      allowed_content:
+        - <content class allowed in this surface>
+      must_not_contain:
+        - <content class prohibited in this surface>
+      evidence_required:
+        - <proof that use complied with the contract>
+```
+
+## Required rules
+
+1. Every surface has a stable ID, path/reference, owner, provider, scope and load mode.
+2. Every surface except `always` has at least one activation condition with an expected extraction.
+3. Every surface has freshness metadata and an explicit budget. Unknown budget data is `unavailable`, never invented.
+4. `always` is reserved for the smallest persistent identity and critical safety constraints.
+5. `evidence_only` surfaces may support review but may not become instructions.
+6. `never_directly` surfaces require an authorized summary, capsule, retrieval result or adapter.
+7. Skill providers are loaded by capability need; an entire skill library must not become persistent context.
+8. Deterministic rules belong in tools, tests, linters, scanners or CI. Prompts request evidence from those tools instead of repeating their rules.
+9. Restricted content follows the [restricted knowledge usage policy](restricted-knowledge-usage-policy.md) and privacy metadata remains separate from content.
+10. Missing, stale or conflicting context must be visible in the Work Slice; it must not be silently replaced by agent inference.
+
+## Precedence
+
+When active surfaces conflict, resolve them in this order:
+
+1. safe explicit user instruction for the current Work Slice;
+2. safety, legal and restricted-use policy;
+3. current Work Slice constraints and accepted decisions;
+4. project-local architecture, security, design and ADR contracts;
+5. active agent-role contract;
+6. activated skill/provider method;
+7. persistent manifest;
+8. general documentation.
+
+The resolution must cite the conflicting surfaces and record the chosen authority. Knowledge-source conflicts continue to use the [source precedence policy](source-precedence-policy.md).
+
+## Work Slice evidence
+
+A closure or handoff should be able to report:
+
+```yaml
+context_surface_usage:
+  work_slice_id: <id>
+  loaded:
+    - surface_id: <id>
+      reason: <activation condition met>
+      extracted: <minimum relevant context>
+      evidence_ref: <reference>
+  intentionally_not_loaded:
+    - surface_id: <id>
+      reason: <why it was outside scope>
+  delegated_to_tools:
+    - rule_class: <class>
+      tool: <tool or command>
+      evidence_ref: <reference>
+  conflicts: []
+```
+
+## Validation
+
+- All required fields are present.
+- Local paths resolve.
+- Non-`always` surfaces have activation conditions.
+- Budgets state their origin.
+- Allowed and prohibited content do not conflict.
+- No secret, prompt body or restricted source content is embedded.
+- Loaded and intentionally-not-loaded surfaces are recorded for the example Work Slice.
+
+## Non-goals
+
+- No runtime router, loader or policy engine.
+- No universal inventory of every repository document.
+- No automatic prompt refactoring.
+- No requirement to use Adaptive Skills.
+- No Visual Operations metric until source-backed usage evidence exists.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,7 @@ Reading map organized by intent. Each entry links to the most useful starting po
 8. [Runtime adapter contract](contracts/runtime-adapter-contract.md) — what any adapter must honor
 9. [Agent role catalog](reference/agent-role-catalog.md) — portable roles across runtimes
 10. [Agent runtime decision guide](guides/agent-runtime-decision-guide.md) — choosing between runtimes
+11. [Context Surface Registry](contracts/context-surface-registry.md) — what context may load, when, why, and with what evidence
 
 ---
 
@@ -93,7 +94,8 @@ Reading map organized by intent. Each entry links to the most useful starting po
 12. [Execution Pattern Selection](contracts/execution-pattern-selection.md) — selected topology and required controls before execution
 13. [Orchestration Contract](contracts/orchestration-contract.md) — stage-level declaration for orchestrated work
 14. [Objective Gate Policy](contracts/objective-gate-policy.md) — loop gates, budgets, state, and human review requirements
-15. [All contracts →](contracts/README.md)
+15. [Context Surface Registry](contracts/context-surface-registry.md) — minimum metadata and load-mode boundaries for context that influences agent behavior
+16. [All contracts →](contracts/README.md)
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -51,6 +51,8 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
   - fluxo de **policy/verdict por ação** (allow/deny/require_approval) + audit record, contrastando skill operacional (debugging) vs consultiva (feature-value-governance)
 - `execution-patterns/`
   - Execution Pattern Selections trabalhadas (topologia antes da execução): CI triage (scheduled stateful loop), síntese de entrevistas (fan-out + filter), review adversarial de PRD (maker-checker) e feature value review (loops explicitamente inadmissíveis)
+- `context-surface-governance/`
+  - registro mínimo de superfícies que distingue contexto persistente, carregamento sob demanda, provider de skill e evidência que não deve virar instrução
 - `resource-aware-operations/`
   - exemplos da trilha 1.2 para runtime fit, policy signals, pilotos bounded, restart/finalization e adapters
 - `visual-operations/`

--- a/examples/context-surface-governance/README.md
+++ b/examples/context-surface-governance/README.md
@@ -1,0 +1,13 @@
+# Minimum Context Surface Registry Example
+
+This example applies the [minimum registry contract](../../docs/contracts/context-surface-registry.md) to the Work Slice that introduced unavailable-first execution-pattern context in Mission Control.
+
+It demonstrates four distinctions:
+
+- the repository manifest is minimal and always loaded;
+- the accepted execution-pattern contract is loaded on demand;
+- the Adaptive Skills debugging declaration is capability-scoped and intentionally not loaded for a `feature-planning` observation;
+- test output is evidence, not instruction.
+
+The example is metadata-only. It does not copy prompts or skill content, and it does not implement a context router.
+

--- a/examples/context-surface-governance/minimum-registry.yaml
+++ b/examples/context-surface-governance/minimum-registry.yaml
@@ -1,0 +1,138 @@
+context_surface_registry:
+  version: "0.1"
+  owner: AletheIA maintainers
+  reviewed_at: 2026-06-22
+  surfaces:
+    - id: aletheia-repository-agents
+      title: Repository operating instructions
+      type: persistent_manifest
+      path: runtime:active-agent-instructions
+      owner: AletheIA maintainers
+      provider: project_local
+      scope: repository
+      load_mode: always
+      priority: critical
+      activation_conditions: []
+      freshness:
+        last_reviewed: 2026-06-22
+        review_interval_days: 90
+      budget:
+        max_lines: unavailable
+        max_tokens: unavailable
+        origin: unavailable
+      allowed_content:
+        - minimum operating boundaries
+        - safety and validation expectations
+      must_not_contain:
+        - full skill methods
+        - secrets
+        - restricted source content
+      evidence_required:
+        - changed files and validation reported at closure
+
+    - id: aletheia-execution-pattern-governance
+      title: Execution Pattern Governance
+      type: project_doc
+      path: docs/adr/ADR-015-execution-pattern-governance-pack.md
+      owner: AletheIA maintainers
+      provider: aletheia
+      scope: capability
+      load_mode: on_demand
+      priority: high
+      activation_conditions:
+        - condition: a Work Slice selects, reviews, or projects an execution pattern
+          rationale: pattern, mode, autonomy, controls, and result must remain separate
+          expected_extraction: selected pattern authority, objective-gate rule, required controls, and review boundary
+      freshness:
+        last_reviewed: 2026-06-22
+        review_interval_days: 180
+      budget:
+        max_lines: unavailable
+        max_tokens: unavailable
+        origin: unavailable
+      allowed_content:
+        - accepted architecture decision
+        - pattern governance boundaries
+      must_not_contain:
+        - runtime-specific execution instructions
+        - skill method content
+      evidence_required:
+        - decision reference on projected pattern context
+
+    - id: adaptive-skills-debugging-patterns
+      title: Debugging execution-pattern compatibility
+      type: skill_provider
+      path: ../adaptative-skills/examples/execution-patterns/debugging-patterns.yaml
+      owner: Adaptive Skills maintainers
+      provider: adaptive_skills
+      scope: capability
+      load_mode: capability_scoped
+      priority: high
+      activation_conditions:
+        - condition: debugging is selected for a reproducible failure and pattern compatibility must be assessed
+          rationale: Adaptive Skills owns the canonical compatibility declaration
+          expected_extraction: compatible patterns, required controls, evidence, and escalation triggers
+      freshness:
+        last_reviewed: 2026-06-22
+        review_interval_days: 90
+      budget:
+        max_lines: unavailable
+        max_tokens: unavailable
+        origin: unavailable
+      allowed_content:
+        - compatibility declaration
+        - evidence and control hints
+      must_not_contain:
+        - AletheIA pattern selection decision
+        - approval authority
+      evidence_required:
+        - skill version and declaration reference
+
+    - id: mission-control-test-output
+      title: Mission Control test results
+      type: evidence_artifact
+      path: runtime:test-output
+      owner: runtime harness
+      provider: runtime_native
+      scope: evidence
+      load_mode: evidence_only
+      priority: medium
+      activation_conditions:
+        - condition: implementation claims require test evidence
+          rationale: tests prove behavior but do not define governance
+          expected_extraction: command, pass/fail result, failures, and evidence timestamp
+      freshness:
+        last_reviewed: 2026-06-22
+        review_interval_days: 1
+      budget:
+        max_lines: unavailable
+        max_tokens: unavailable
+        origin: unavailable
+      allowed_content:
+        - test summary
+        - failure references
+      must_not_contain:
+        - new task instructions
+        - inferred approval
+      evidence_required:
+        - command and result
+
+context_surface_usage:
+  work_slice_id: mission-control-pattern-context-unavailable
+  loaded:
+    - surface_id: aletheia-repository-agents
+      reason: persistent repository boundary
+      extracted: scope, validation, safety, and communication constraints
+      evidence_ref: runtime:active-agent-instructions
+    - surface_id: aletheia-execution-pattern-governance
+      reason: the Work Slice projected execution-pattern metadata
+      extracted: pattern authority and no-inference boundary
+      evidence_ref: docs/adr/ADR-015-execution-pattern-governance-pack.md
+  intentionally_not_loaded:
+    - surface_id: adaptive-skills-debugging-patterns
+      reason: the observed skill was feature-planning and no debugging compatibility assessment was authorized
+  delegated_to_tools:
+    - rule_class: type and test correctness
+      tool: pnpm typecheck && pnpm test
+      evidence_ref: PR #252 CI
+  conflicts: []

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -126,6 +126,12 @@ If you want to test a filesystem-based context-routing pattern as a local experi
 
 - `starter-pack/experiments/workspace-context-routing/README.md`
 
+For a normative, manual registry of context surfaces and their load boundaries, use:
+
+- `docs/contracts/context-surface-registry.md`
+- `starter-pack/templates/context-surface-registry.yaml`
+- `examples/context-surface-governance/minimum-registry.yaml`
+
 
 ## 1.1 constrained adoption guidance
 

--- a/starter-pack/templates/context-surface-registry.yaml
+++ b/starter-pack/templates/context-surface-registry.yaml
@@ -1,0 +1,34 @@
+context_surface_registry:
+  version: "0.1"
+  owner: <registry owner>
+  reviewed_at: YYYY-MM-DD
+  surfaces:
+    - id: <stable surface id>
+      title: <human-readable title>
+      type: persistent_manifest | agent_role_contract | skill_provider | project_doc | tool_config | runtime_policy | work_artifact | evidence_artifact
+      path: <repository path or authorized reference>
+      owner: <person, team, or project role>
+      provider: aletheia | adaptive_skills | project_local | runtime_native | external | user_defined
+      scope: repository | package | feature | agent_role | capability | work_slice | evidence
+      load_mode: always | on_demand | role_scoped | capability_scoped | work_slice_scoped | evidence_only | never_directly
+      priority: critical | high | medium | low
+      activation_conditions:
+        - condition: <when this surface becomes relevant>
+          rationale: <why loading is justified>
+          expected_extraction: <minimum information to retrieve>
+      freshness:
+        last_reviewed: YYYY-MM-DD
+        review_interval_days: <positive integer>
+      budget:
+        max_lines: <positive integer or unavailable>
+        max_tokens: <positive integer or unavailable>
+        origin: reported | estimated | unavailable
+      allowed_content:
+        - <allowed content class>
+      must_not_contain:
+        - prompts
+        - secrets
+        - restricted source content
+      evidence_required:
+        - <required evidence>
+


### PR DESCRIPTION
## What changed
- adds a minimum Context Surface Registry contract
- adds an adopter-ready YAML template
- adds a worked Work Slice example covering persistent, on-demand, capability-scoped and evidence-only surfaces
- updates contract, docs, starter-pack and example indexes

## Why it changed
AletheIA needs to know where influencing context lives, when to load it, what to extract and when to leave it out without creating an automatic context router.

## How to validate
- `pnpm check:governance`
- `pnpm test`
- YAML parsing and registry invariant validation
- local Markdown link validation
- `git diff --check`

## Risks, assumptions or follow-ups
- registry content is metadata-only; prompts, secrets and restricted source content remain excluded
- no runtime router, loader, policy engine or Visual Operations metric is introduced
- Adaptive Skills provider-loading evidence remains a separate cross-repository follow-up
- `plans/` remains untouched
