### PR TITLE
docs(observations): define recoverable records

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -17,6 +17,7 @@ If you need conceptual background, see [`concepts/`](../concepts/README.md). If 
 | [readiness-gates-spec.md](readiness-gates-spec.md) | When a slice is ready to continue, review, hand off, or stop |
 | [context-resource-telemetry-spec.md](context-resource-telemetry-spec.md) | Telemetry surface for resource-aware operations |
 | [context-surface-registry.md](context-surface-registry.md) | Minimum metadata, loading boundaries, freshness and evidence for surfaces that influence agent behavior |
+| [observation-governance-contract.md](observation-governance-contract.md) | Minimum structured, source-backed and recoverable observation record |
 | [slice-telemetry-model.md](slice-telemetry-model.md) | Minimal model for recording slice-level telemetry |
 | [visual-operations-event-model.md](visual-operations-event-model.md) | Normalized, source-referenced events for read-only visual projection |
 | [work-slice-visual-state-contract.md](work-slice-visual-state-contract.md) | Presentation lanes and derived Work Slice card state without a new lifecycle |

--- a/docs/contracts/observation-governance-contract.md
+++ b/docs/contracts/observation-governance-contract.md
@@ -1,0 +1,156 @@
+# Observation Governance Contract
+
+## Goal
+
+Define the minimum record for turning a verbose tool, runtime, validation, document, or skill return into a compact observation without losing the evidence needed for a decision.
+
+This is a docs-first contract. It does not require an automatic normalizer, evidence database, terminal proxy, schema, or runtime integration.
+
+## Authority boundary
+
+- Source records and raw evidence remain authoritative.
+- An observation summarizes evidence; it does not replace, validate, approve, or execute it.
+- AletheIA governs the record shape and recovery invariant.
+- Runtimes, tools, and skills may produce records that conform to this contract.
+- Visual Operations may project the record read-only, but must not infer missing values.
+
+## Minimum record
+
+Each observation must declare:
+
+| Field | Meaning |
+|---|---|
+| `observation_id` | Stable identifier for the observation. |
+| `work_slice_id` | Work Slice that receives the observation. |
+| `source` | Source type, name, outcome, and source references. |
+| `summary` | Compact statement of what matters for the next decision. |
+| `evidence_items` | Decision-relevant facts preserved from the source. |
+| `hygiene` | Strategies used, lossiness, and signal-loss risk. |
+| `recovery` | Whether recovery is required and the governed pointer when available. |
+| `decision_support` | Relevance, escalation posture, and suggested next review. |
+| `visibility` | Default presentation depth and whether technical detail is available. |
+| `metrics` | Optional measurements with explicit provenance. |
+
+`source.refs` must point to the records that support the observation. The observation itself is not new evidence merely because it is structured.
+
+## Recovery invariant
+
+Allowed lossiness values are:
+
+- `lossless`
+- `lossy_with_recovery`
+- `unavailable`
+
+The invariant is:
+
+```text
+if hygiene.lossiness = lossy_with_recovery
+then recovery.required = true
+and recovery.pointer must be present
+```
+
+`lossy_without_recovery` is invalid. If a producer cannot retain or reference the raw source, it must either emit a lossless observation or declare the observation unavailable for governed use.
+
+A recovery pointer may reference a governed local artifact, CI artifact, runtime trace, source record, or another authorized evidence surface. It must carry sensitivity and retention metadata; it must not embed secrets, prompts, personal data, or restricted source content.
+
+## Evidence preservation
+
+A compact observation should preserve only decision-relevant details, including when applicable:
+
+- outcome and exit code;
+- failure or warning counts;
+- affected files or records;
+- assertion or policy conflict;
+- reproduction or validation reference;
+- handoff or escalation signal.
+
+Omitted detail must be classified. Repeated lines, successful dependency noise, or duplicated traces may be omitted, but critical failures and conflicting evidence may not be silently removed.
+
+## Unavailable-first metrics
+
+Size, token, cost, compression, and avoided-output metrics are optional. Every reported metric must include one provenance value:
+
+- `reported`
+- `estimated`
+- `unavailable`
+
+When no reliable measurement exists, use `value: null` with `provenance: unavailable`. Do not derive exact ratios or savings from size classes.
+
+## Progressive visibility
+
+Visibility modes are rendering depths over the same record, not different sources of truth:
+
+- `guided`: plain summary, impact, next review, and whether human attention is needed;
+- `practitioner`: compact evidence, source refs, risks, and validation posture;
+- `engineer`: recovery pointer, strategy, omitted detail classes, and available runtime metadata.
+
+The modes must not hide an active escalation requirement or make an unavailable value appear healthy.
+
+## Minimum example shape
+
+```yaml
+version: "0.1"
+observation_id: obs-test-001
+work_slice_id: slice-validation-001
+source:
+  type: test_result
+  name: pnpm test
+  outcome: failed
+  refs:
+    - artifact://ci/run-42/test-output
+summary: Two validation tests failed in the authorization boundary.
+evidence_items:
+  - kind: failed_test
+    ref: tests/authorization-boundary.test.ts
+    detail: Expected deny; received allow.
+hygiene:
+  strategies: [failure_focus, dedupe_repeated_lines]
+  lossiness: lossy_with_recovery
+  signal_loss_risk: medium
+  omitted_detail_classes: [repeated_stack_trace]
+recovery:
+  required: true
+  pointer: artifact://ci/run-42/test-output
+  sensitivity: internal
+  retention: project
+decision_support:
+  relevance: blocks_validation
+  escalation_required: true
+  next_review: Resolve the policy conflict before closure.
+visibility:
+  default: practitioner
+  engineer_details_available: true
+metrics:
+  raw_output_size:
+    value: null
+    provenance: unavailable
+```
+
+## Validation rules
+
+1. Required fields are present and identifiers are stable.
+2. Every evidence item is source-backed.
+3. `lossy_with_recovery` always has a non-empty governed pointer.
+4. Missing measurements remain unavailable; they are not invented.
+5. Restricted content is represented by metadata or authorized summary only.
+6. Escalation and failed outcomes remain visible at every presentation depth.
+7. The record does not claim authority to approve, execute, or close a Work Slice.
+
+## Non-goals
+
+This contract does not introduce:
+
+- automatic output interception or normalization;
+- an evidence store or retention service;
+- a mandatory transport or JSON Schema;
+- RTK or provider-specific dependencies;
+- automatic telemetry, scoring, routing, or policy decisions;
+- Resource Observatory metrics before reliable sources exist.
+
+## Related contracts
+
+- [Context Surface Registry](context-surface-registry.md)
+- [Runtime Adapter Contract](runtime-adapter-contract.md)
+- [Slice Telemetry Model](slice-telemetry-model.md)
+- [Agent Harness Governance Extension](agent-harness-governance-extension.md)
+- [Visual Operations Event Model](visual-operations-event-model.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,8 @@ Reading map organized by intent. Each entry links to the most useful starting po
 13. [Orchestration Contract](contracts/orchestration-contract.md) — stage-level declaration for orchestrated work
 14. [Objective Gate Policy](contracts/objective-gate-policy.md) — loop gates, budgets, state, and human review requirements
 15. [Context Surface Registry](contracts/context-surface-registry.md) — minimum metadata and load-mode boundaries for context that influences agent behavior
-16. [All contracts →](contracts/README.md)
+16. [Observation Governance Contract](contracts/observation-governance-contract.md) — compact tool, validation, runtime, document, or skill returns with recoverable evidence
+17. [All contracts →](contracts/README.md)
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,7 +54,7 @@ Se os schemas explicam **a estrutura** e os docs explicam **a lógica**, os exem
 - `context-surface-governance/`
   - registro mínimo de superfícies que distingue contexto persistente, carregamento sob demanda, provider de skill e evidência que não deve virar instrução
 - `resource-aware-operations/`
-  - exemplos da trilha 1.2 para runtime fit, policy signals, pilotos bounded, restart/finalization e adapters
+  - exemplos da trilha 1.2 para runtime fit, policy signals, pilotos bounded, restart/finalization, adapters e observações recuperáveis
 - `visual-operations/`
   - projeção sintética e somente leitura de duas Work Slices, com eventos normalizados, evidência, revisão humana, telemetria opcional e fonte restrita representada apenas por metadados
   - entrada e saídas reproduzíveis do projetor GitHub PR → Visual Operations, incluindo distinção entre evidência observada por CI e validação reportada pelo autor

--- a/examples/resource-aware-operations/README.md
+++ b/examples/resource-aware-operations/README.md
@@ -17,6 +17,7 @@ The first examples stay docs-first and intentionally small.
 - `clean-restart-command-adapter-example.md`
 - `runtime-effort-contract-example.md`
 - `harness-governance-example.md`
+- `test-output-observation-example.yaml` — lossy validation summary with a required recovery pointer and unavailable metrics
 
 ## Related pilot support
 

--- a/examples/resource-aware-operations/test-output-observation-example.yaml
+++ b/examples/resource-aware-operations/test-output-observation-example.yaml
@@ -1,0 +1,57 @@
+version: "0.1"
+observation_id: obs-auth-validation-002
+work_slice_id: slice-auth-002
+
+source:
+  type: test_result
+  name: focused authorization boundary test
+  outcome: failed
+  refs:
+    - synthetic://slice-auth-002/test-run-02
+
+summary: The focused authorization validation failed after the first bounded fix attempt.
+
+evidence_items:
+  - kind: failed_test
+    ref: synthetic://slice-auth-002/test-run-02#authorization-boundary
+    detail: The proposed fixture change did not preserve the expected authorization boundary.
+  - kind: pending_review
+    ref: synthetic://slice-auth-002/human-review-request
+    detail: Repository-maintainer confirmation is required before changing the fixture.
+
+hygiene:
+  strategies:
+    - failure_focus
+    - dedupe_repeated_lines
+    - preserve_source_refs
+  lossiness: lossy_with_recovery
+  signal_loss_risk: medium
+  omitted_detail_classes:
+    - repeated_stack_trace
+    - passing_test_output
+
+recovery:
+  required: true
+  pointer: synthetic://slice-auth-002/test-run-02/raw-output
+  sensitivity: restricted
+  retention: project
+
+decision_support:
+  relevance: blocks_closure
+  escalation_required: true
+  next_review: Resolve the authorization-boundary assumption and rerun the focused validation.
+
+visibility:
+  default: practitioner
+  engineer_details_available: true
+
+metrics:
+  raw_output_size:
+    value: null
+    provenance: unavailable
+  compact_output_size:
+    value: null
+    provenance: unavailable
+  compression_ratio:
+    value: null
+    provenance: unavailable

--- a/starter-pack/README.md
+++ b/starter-pack/README.md
@@ -132,6 +132,12 @@ For a normative, manual registry of context surfaces and their load boundaries, 
 - `starter-pack/templates/context-surface-registry.yaml`
 - `examples/context-surface-governance/minimum-registry.yaml`
 
+For compact, source-backed observations that retain a governed path to lossy raw output, use:
+
+- `docs/contracts/observation-governance-contract.md`
+- `starter-pack/templates/observation-record-template.yaml`
+- `examples/resource-aware-operations/test-output-observation-example.yaml`
+
 
 ## 1.1 constrained adoption guidance
 

--- a/starter-pack/templates/observation-record-template.yaml
+++ b/starter-pack/templates/observation-record-template.yaml
@@ -1,0 +1,50 @@
+version: "0.1"
+observation_id: <stable-observation-id>
+work_slice_id: <work-slice-id>
+
+source:
+  type: <test_result|lint_result|git_diff|runtime_trace|api_response|document_read|skill_output|validation_report|other>
+  name: <source-name>
+  outcome: <passed|failed|partial|unknown|unavailable>
+  refs:
+    - <authoritative-source-ref>
+
+summary: <what-matters-for-the-next-decision>
+
+evidence_items:
+  - kind: <evidence-kind>
+    ref: <source-backed-reference>
+    detail: <authorized-decision-relevant-detail>
+
+hygiene:
+  strategies:
+    - <failure_focus|status_summary|dedupe_repeated_lines|group_by_file|preserve_counts|other>
+  lossiness: <lossless|lossy_with_recovery|unavailable>
+  signal_loss_risk: <low|medium|high|unknown>
+  omitted_detail_classes: []
+
+recovery:
+  required: <true|false>
+  pointer: <governed-pointer-or-null>
+  sensitivity: <public|internal|confidential|restricted>
+  retention: <session|project|release|audit|unknown>
+
+decision_support:
+  relevance: <decision-relevance>
+  escalation_required: <true|false>
+  next_review: <review-prompt-or-none>
+
+visibility:
+  default: <guided|practitioner|engineer>
+  engineer_details_available: <true|false>
+
+metrics:
+  raw_output_size:
+    value: null
+    provenance: unavailable
+  compact_output_size:
+    value: null
+    provenance: unavailable
+  compression_ratio:
+    value: null
+    provenance: unavailable


### PR DESCRIPTION
## What changed
- add the minimum AletheIA observation governance contract
- add a reusable observation record template
- add a lossy test-output example with a governed recovery pointer
- link the contract and example from documentation indexes

## Why
P3/S5 needs a source-backed way to compact verbose operational output without losing access to authoritative evidence or inventing unavailable metrics.

## How to validate
- YAML shape and recovery invariant check
- local Markdown link check
- `pnpm check:governance`
- `pnpm test` (196 core + 23 Mission Control tests)
- `./scripts/check-visual-ops-snapshots.sh`
- `git diff --check`

## Risks, assumptions, follow-ups
- docs-first only: no normalizer, evidence store, schema, runtime dependency, telemetry, or UI change
- Adaptive Skills return pattern remains the second half of S5
- untracked `plans/` remains untouched