### PR TITLE
feat(observatory): project sourced pattern context

### DIFF
--- a/apps/mission-control/src/adapters/patternContextProjectionAdapter.test.ts
+++ b/apps/mission-control/src/adapters/patternContextProjectionAdapter.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import debuggingDeclarationJson from "../../../../examples/execution-patterns/fixtures/skill-execution-patterns-debugging.json";
+import featureValueDeclarationJson from "../../../../examples/execution-patterns/fixtures/skill-execution-patterns-feature-value.json";
+import debuggingSelectionJson from "../../../../examples/execution-patterns/fixtures/execution-pattern-selection-debugging-loop.json";
+import {
+  projectPatternContext,
+  type ExecutionPatternSelectionRecord,
+  type SkillPatternCompatibilityDeclaration,
+} from "./patternContextProjectionAdapter";
+
+const debuggingDeclaration = debuggingDeclarationJson as SkillPatternCompatibilityDeclaration;
+const featureValueDeclaration = featureValueDeclarationJson as SkillPatternCompatibilityDeclaration;
+const debuggingSelection = debuggingSelectionJson as ExecutionPatternSelectionRecord;
+const selectionRef = "examples/execution-patterns/fixtures/execution-pattern-selection-debugging-loop.json";
+const debuggingCompatibilityRef = "https://github.com/nevitonsantana/adaptive-skills/blob/60de75d/examples/execution-patterns/debugging-patterns.yaml";
+
+function loopSelection(overrides: Partial<ExecutionPatternSelectionRecord> = {}): ExecutionPatternSelectionRecord {
+  return {
+    ...debuggingSelection,
+    ...overrides,
+  };
+}
+
+describe("pattern context projection adapter", () => {
+  it("projects compatible debugging context from both canonical sources", () => {
+    const context = projectPatternContext({
+      skillId: "debugging",
+      selection: loopSelection(),
+      selectionRef,
+      compatibilityDeclaration: debuggingDeclaration,
+      compatibilityRef: debuggingCompatibilityRef,
+    });
+
+    expect(context).toMatchObject({
+      pattern: { id: "loop_until_done", vehicle: "loop" },
+      selection: {
+        verdict: "approved_with_constraints",
+        selectedBy: "aletheia",
+        decisionRef: selectionRef,
+      },
+      compatibility: {
+        status: "compatible",
+        declaredBy: "adaptive_skills",
+        conditions: "Only when tests or repro commands provide objective stop condition.",
+        requiredEvidence: ["failing_test", "passing_run", "iteration_count"],
+        declarationRef: debuggingCompatibilityRef,
+      },
+    });
+    expect(context.controls?.requiredControls).toEqual(expect.arrayContaining([
+      "objective_gate_required",
+      "max_iterations",
+      "human_review_before_merge",
+    ]));
+  });
+
+  it("projects a canonical incompatibility without suggesting loop use", () => {
+    const context = projectPatternContext({
+      skillId: "feature-value-governance",
+      selection: loopSelection(),
+      selectionRef,
+      compatibilityDeclaration: featureValueDeclaration,
+      compatibilityRef: "https://github.com/nevitonsantana/adaptive-skills/blob/60de75d/examples/execution-patterns/feature-value-governance-patterns.yaml",
+    });
+
+    expect(context.compatibility).toMatchObject({
+      status: "incompatible",
+      rationale: "Feature judgment does not have objective stop condition.",
+    });
+  });
+
+  it("keeps absent compatibility unavailable instead of inferring it", () => {
+    const context = projectPatternContext({
+      skillId: "feature-planning",
+      selection: loopSelection(),
+      selectionRef,
+    });
+
+    expect(context.compatibility).toEqual({
+      status: "unavailable",
+      message: "loop candidacy not assessed",
+      declaredBy: "unavailable",
+      skillId: "feature-planning",
+    });
+  });
+
+  it("projects explicit missing-gate and bounded-run evidence without inventing success rates", () => {
+    const context = projectPatternContext({
+      skillId: "debugging",
+      selection: loopSelection(),
+      selectionRef,
+      compatibilityDeclaration: debuggingDeclaration,
+      compatibilityRef: debuggingCompatibilityRef,
+      loopRun: {
+        sourceRef: "runtime://loop-runs/debugging-loop-s6",
+        maxIterations: 3,
+        currentIterations: 0,
+        budget: { timeMinutes: 45, tokenBudget: 12000 },
+        missingPreconditions: ["objective_gate"],
+        humanReviewBoundary: "Human-led review required before continuation.",
+        outcome: {
+          result: "escalated",
+          rationale: "The objective gate was not recorded.",
+          evidenceRefs: ["audit://debugging-loop-s6/missing-gate"],
+          escalationRef: "review://debugging-loop-s6",
+          comparableCaseCount: 1,
+        },
+      },
+    });
+
+    expect(context.controls).toMatchObject({
+      maxIterations: 3,
+      currentIterations: 0,
+      missingPreconditions: ["objective_gate"],
+    });
+    expect(context.outcome).toMatchObject({
+      result: "escalated",
+      comparableCaseCount: 1,
+      showSuccessPercentage: false,
+    });
+    expect(context.refs.loopRunRef).toBe("runtime://loop-runs/debugging-loop-s6");
+  });
+
+  it("keeps percentages hidden without both comparable volume and objective criteria", () => {
+    const context = projectPatternContext({
+      skillId: "debugging",
+      selection: loopSelection(),
+      selectionRef,
+      compatibilityDeclaration: debuggingDeclaration,
+      compatibilityRef: debuggingCompatibilityRef,
+      loopRun: {
+        sourceRef: "runtime://loop-runs/debugging-loop-s6/sample-set",
+        outcome: {
+          result: "reinforced",
+          rationale: "Six records exist, but no objective metric definition was attached.",
+          evidenceRefs: ["audit://debugging-loop-s6/sample-set"],
+          comparableCaseCount: 6,
+        },
+      },
+    });
+
+    expect(context.outcome?.showSuccessPercentage).toBe(false);
+  });
+
+  it("rejects mismatched declarations and missing source references", () => {
+    expect(() => projectPatternContext({
+      skillId: "testing",
+      selection: loopSelection(),
+      selectionRef,
+      compatibilityDeclaration: debuggingDeclaration,
+      compatibilityRef: debuggingCompatibilityRef,
+    })).toThrow("must match the projected skill");
+
+    expect(() => projectPatternContext({
+      skillId: "debugging",
+      selection: loopSelection(),
+      selectionRef: "",
+      compatibilityDeclaration: debuggingDeclaration,
+      compatibilityRef: debuggingCompatibilityRef,
+    })).toThrow("Pattern selection requires a durable source reference");
+  });
+});

--- a/apps/mission-control/src/adapters/patternContextProjectionAdapter.ts
+++ b/apps/mission-control/src/adapters/patternContextProjectionAdapter.ts
@@ -1,0 +1,179 @@
+import type { PatternContext } from "../features/resource-observatory/resourceSignalTypes";
+
+export type ExecutionPatternSelectionRecord = {
+  task_id: string;
+  recommended_vehicle: {
+    type: "manual_prompt" | "single_agent" | "orchestrated_workflow" | "loop" | "human_led_workflow";
+    rationale: string;
+  };
+  recommended_pattern: {
+    type: string;
+    rationale: string;
+  };
+  required_controls: Record<string, boolean>;
+  decision: {
+    verdict: "approved" | "approved_with_constraints" | "rejected" | "human_led_required";
+    notes?: string;
+  };
+};
+
+export type SkillPatternCompatibilityDeclaration = {
+  skill_id: string;
+  version: string;
+  compatible_patterns: Array<{
+    pattern: string;
+    conditions: string;
+    required_controls: string[];
+  }>;
+  incompatible_patterns: Array<{
+    pattern: string;
+    rationale: string;
+  }>;
+  required_evidence_by_pattern?: Record<string, { evidence: string[] }>;
+};
+
+export type LoopRunProjectionRecord = {
+  sourceRef: string;
+  stopCondition?: string;
+  objectiveGate?: string;
+  maxIterations?: number;
+  currentIterations?: number;
+  budget?: {
+    timeMinutes?: number;
+    tokenBudget?: number;
+  };
+  presentControls?: string[];
+  missingPreconditions?: string[];
+  humanReviewBoundary?: string;
+  outcome?: {
+    result: "reinforced" | "no-change" | "proposal-created" | "escalated";
+    rationale: string;
+    evidenceRefs: string[];
+    proposalRef?: string;
+    escalationRef?: string;
+    comparableCaseCount: number;
+    objectiveSuccessCriteriaRef?: string;
+  };
+};
+
+type ProjectionInput = {
+  skillId: string;
+  selection: ExecutionPatternSelectionRecord;
+  selectionRef: string;
+  compatibilityDeclaration?: SkillPatternCompatibilityDeclaration | null;
+  compatibilityRef?: string;
+  loopRun?: LoopRunProjectionRecord | null;
+};
+
+function requireRef(value: string | undefined, label: string) {
+  if (!value?.trim()) throw new Error(`${label} requires a durable source reference`);
+  return value;
+}
+
+function requiredSelectionControls(controls: Record<string, boolean>) {
+  return Object.entries(controls)
+    .filter(([, required]) => required)
+    .map(([control]) => control);
+}
+
+export function projectPatternContext({
+  skillId,
+  selection,
+  selectionRef,
+  compatibilityDeclaration,
+  compatibilityRef,
+  loopRun,
+}: ProjectionInput): PatternContext {
+  const durableSelectionRef = requireRef(selectionRef, "Pattern selection");
+  const patternId = selection.recommended_pattern.type;
+  const compatiblePattern = compatibilityDeclaration?.compatible_patterns.find((item) => item.pattern === patternId);
+  const incompatiblePattern = compatibilityDeclaration?.incompatible_patterns.find((item) => item.pattern === patternId);
+
+  if (compatibilityDeclaration && compatibilityDeclaration.skill_id !== skillId) {
+    throw new Error("Pattern compatibility declaration must match the projected skill");
+  }
+
+  let compatibility: PatternContext["compatibility"];
+  let durableCompatibilityRef: string | undefined;
+
+  if (!compatibilityDeclaration) {
+    compatibility = {
+      status: "unavailable",
+      message: "loop candidacy not assessed",
+      declaredBy: "unavailable",
+      skillId,
+    };
+  } else {
+    durableCompatibilityRef = requireRef(compatibilityRef, "Pattern compatibility");
+    if (compatiblePattern) {
+      compatibility = {
+        status: "compatible",
+        declaredBy: "adaptive_skills",
+        skillId,
+        skillVersion: compatibilityDeclaration.version,
+        conditions: compatiblePattern.conditions,
+        requiredEvidence: compatibilityDeclaration.required_evidence_by_pattern?.[patternId]?.evidence,
+        declarationRef: durableCompatibilityRef,
+      };
+    } else if (incompatiblePattern) {
+      compatibility = {
+        status: "incompatible",
+        declaredBy: "adaptive_skills",
+        skillId,
+        skillVersion: compatibilityDeclaration.version,
+        rationale: incompatiblePattern.rationale,
+        declarationRef: durableCompatibilityRef,
+      };
+    } else {
+      compatibility = {
+        status: "unavailable",
+        message: "loop candidacy not assessed",
+        declaredBy: "adaptive_skills",
+        skillId,
+        skillVersion: compatibilityDeclaration.version,
+        declarationRef: durableCompatibilityRef,
+      };
+    }
+  }
+
+  const requiredControls = [
+    ...requiredSelectionControls(selection.required_controls),
+    ...(compatiblePattern?.required_controls ?? []),
+  ].filter((control, index, all) => all.indexOf(control) === index);
+
+  return {
+    pattern: {
+      id: patternId,
+      vehicle: selection.recommended_vehicle.type,
+      description: selection.recommended_pattern.rationale,
+    },
+    selection: {
+      verdict: selection.decision.verdict,
+      selectedBy: "aletheia",
+      rationale: selection.decision.notes ?? selection.recommended_pattern.rationale,
+      decisionRef: durableSelectionRef,
+    },
+    compatibility,
+    controls: requiredControls.length || loopRun ? {
+      stopCondition: loopRun?.stopCondition,
+      objectiveGate: loopRun?.objectiveGate,
+      maxIterations: loopRun?.maxIterations,
+      currentIterations: loopRun?.currentIterations,
+      budget: loopRun?.budget,
+      requiredControls,
+      presentControls: loopRun?.presentControls,
+      missingPreconditions: loopRun?.missingPreconditions,
+      humanReviewBoundary: loopRun?.humanReviewBoundary,
+    } : null,
+    outcome: loopRun?.outcome ? {
+      ...loopRun.outcome,
+      showSuccessPercentage: loopRun.outcome.comparableCaseCount >= 5 && Boolean(loopRun.outcome.objectiveSuccessCriteriaRef),
+    } : null,
+    refs: {
+      selectionRef: durableSelectionRef,
+      compatibilityRef: durableCompatibilityRef,
+      loopRunRef: loopRun?.sourceRef,
+      auditRefs: loopRun?.outcome?.evidenceRefs,
+    },
+  };
+}

--- a/apps/mission-control/src/features/resource-observatory/ResourceSignalInspector.test.tsx
+++ b/apps/mission-control/src/features/resource-observatory/ResourceSignalInspector.test.tsx
@@ -2,6 +2,13 @@ import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ResourceSignalInspector } from "./ResourceSignalInspector";
 import { resourceSignals } from "./resourceSignalFixtures";
+import debuggingDeclarationJson from "../../../../../examples/execution-patterns/fixtures/skill-execution-patterns-debugging.json";
+import debuggingSelectionJson from "../../../../../examples/execution-patterns/fixtures/execution-pattern-selection-debugging-loop.json";
+import {
+  projectPatternContext,
+  type ExecutionPatternSelectionRecord,
+  type SkillPatternCompatibilityDeclaration,
+} from "../../adapters/patternContextProjectionAdapter";
 
 const skillSignal = resourceSignals.find((signal) => signal.id === "skill-usage");
 
@@ -42,5 +49,46 @@ describe("ResourceSignalInspector pattern context", () => {
     expect(within(controls!).getByText("Loop cannot be approved:")).toBeInTheDocument();
     expect(within(controls!).getByText(/objective gate missing/)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /run loop|approve loop/i })).not.toBeInTheDocument();
+  });
+
+  it("renders source-backed compatibility, controls and outcome without adding authority actions", () => {
+    const patternContext = projectPatternContext({
+      skillId: "debugging",
+      selection: debuggingSelectionJson as ExecutionPatternSelectionRecord,
+      selectionRef: "examples/execution-patterns/fixtures/execution-pattern-selection-debugging-loop.json",
+      compatibilityDeclaration: debuggingDeclarationJson as SkillPatternCompatibilityDeclaration,
+      compatibilityRef: "https://github.com/nevitonsantana/adaptive-skills/blob/60de75d/examples/execution-patterns/debugging-patterns.yaml",
+      loopRun: {
+        sourceRef: "runtime://loop-runs/debugging-loop-s6",
+        stopCondition: "Focused test passes.",
+        objectiveGate: "pnpm test -- focused-debugging-spec",
+        maxIterations: 3,
+        currentIterations: 2,
+        budget: { timeMinutes: 45, tokenBudget: 12000 },
+        presentControls: ["objective_gate_required", "token_budget_required", "human_review_required"],
+        missingPreconditions: [],
+        humanReviewBoundary: "Merge requires human review.",
+        outcome: {
+          result: "reinforced",
+          rationale: "Objective evidence supported the declared compatibility.",
+          evidenceRefs: ["test://debugging-loop-s6/passing-run"],
+          comparableCaseCount: 1,
+        },
+      },
+    });
+
+    render(<ResourceSignalInspector signal={{ ...skillSignal, value: "debugging", patternContext }} onClose={vi.fn()} />);
+
+    const inspector = screen.getByRole("dialog");
+    expect(within(inspector).getByText("loop_until_done")).toBeInTheDocument();
+    expect(within(inspector).getByText("compatible")).toBeInTheDocument();
+    expect(within(inspector).getByText(/Only when tests or repro commands/)).toBeInTheDocument();
+    expect(within(inspector).getByText("45 min")).toBeInTheDocument();
+    expect(within(inspector).getByRole("heading", { name: "Outcome & learning" })).toBeInTheDocument();
+    expect(within(inspector).getByText("reinforced")).toBeInTheDocument();
+    expect(within(inspector).getByText("hidden")).toBeInTheDocument();
+    expect(within(inspector).getAllByText(/execution-pattern-selection-debugging-loop.json/).length).toBeGreaterThan(0);
+    expect(within(inspector).getAllByText(/debugging-patterns.yaml/).length).toBeGreaterThan(0);
+    expect(within(inspector).queryByRole("button", { name: /run loop|approve loop/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/mission-control/src/features/resource-observatory/ResourceSignalInspector.tsx
+++ b/apps/mission-control/src/features/resource-observatory/ResourceSignalInspector.tsx
@@ -95,6 +95,9 @@ export function ResourceSignalInspector({ signal, onClose }: ResourceSignalInspe
                       <div><dt>Status</dt><dd>{signal.patternContext.compatibility.status}</dd></div>
                       <div><dt>Declared by</dt><dd>{signal.patternContext.compatibility.declaredBy ?? "unavailable"}</dd></div>
                       {signal.patternContext.compatibility.skillVersion ? <div><dt>Skill version</dt><dd>{signal.patternContext.compatibility.skillVersion}</dd></div> : null}
+                      {signal.patternContext.compatibility.conditions ? <div><dt>Conditions</dt><dd>{signal.patternContext.compatibility.conditions}</dd></div> : null}
+                      {signal.patternContext.compatibility.requiredEvidence ? <div><dt>Required evidence</dt><dd>{joinOrUnavailable(signal.patternContext.compatibility.requiredEvidence)}</dd></div> : null}
+                      {signal.patternContext.compatibility.rationale ? <div><dt>Rationale</dt><dd>{signal.patternContext.compatibility.rationale}</dd></div> : null}
                       {signal.patternContext.compatibility.declarationRef ? <div><dt>Declaration</dt><dd>{signal.patternContext.compatibility.declarationRef}</dd></div> : null}
                     </dl>
                     {signal.patternContext.compatibility.message ? <p className="pattern-state-note"><strong>Unavailable</strong> — {signal.patternContext.compatibility.message}.</p> : null}
@@ -106,11 +109,34 @@ export function ResourceSignalInspector({ signal, onClose }: ResourceSignalInspe
                         <div><dt>Stop condition</dt><dd>{signal.patternContext.controls.stopCondition ?? "unavailable"}</dd></div>
                         <div><dt>Objective gate</dt><dd>{signal.patternContext.controls.objectiveGate ?? "unavailable"}</dd></div>
                         <div><dt>Iterations</dt><dd>{signal.patternContext.controls.currentIterations ?? 0} / {signal.patternContext.controls.maxIterations ?? "unavailable"}</dd></div>
+                        <div><dt>Time budget</dt><dd>{signal.patternContext.controls.budget?.timeMinutes != null ? `${signal.patternContext.controls.budget.timeMinutes} min` : "unavailable"}</dd></div>
+                        <div><dt>Token budget</dt><dd>{signal.patternContext.controls.budget?.tokenBudget ?? "unavailable"}</dd></div>
                         <div><dt>Required</dt><dd>{joinOrUnavailable(signal.patternContext.controls.requiredControls)}</dd></div>
                         <div><dt>Missing</dt><dd>{joinOrUnavailable(signal.patternContext.controls.missingPreconditions)}</dd></div>
                         <div><dt>Human review</dt><dd>{signal.patternContext.controls.humanReviewBoundary ?? "unavailable"}</dd></div>
+                        <div><dt>Source refs</dt><dd>{joinOrUnavailable([
+                          signal.patternContext.refs.selectionRef,
+                          signal.patternContext.refs.compatibilityRef,
+                          signal.patternContext.refs.loopRunRef,
+                        ].filter((ref): ref is string => Boolean(ref)))}</dd></div>
                       </dl>
                       {signal.patternContext.controls.missingPreconditions?.includes("objective_gate") ? <p className="pattern-state-note is-warning"><strong>Loop cannot be approved:</strong> objective gate missing.</p> : null}
+                    </section>
+                  ) : null}
+                  {signal.patternContext.outcome ? (
+                    <section className="inspector-section">
+                      <h3>Outcome &amp; learning</h3>
+                      <dl className="signal-detail-list">
+                        <div><dt>Outcome</dt><dd>{signal.patternContext.outcome.result}</dd></div>
+                        {signal.patternContext.outcome.rationale ? <div><dt>Rationale</dt><dd>{signal.patternContext.outcome.rationale}</dd></div> : null}
+                        <div><dt>Comparable cases</dt><dd>{signal.patternContext.outcome.comparableCaseCount ?? "unavailable"}</dd></div>
+                        {signal.patternContext.outcome.objectiveSuccessCriteriaRef ? <div><dt>Success criteria</dt><dd>{signal.patternContext.outcome.objectiveSuccessCriteriaRef}</dd></div> : null}
+                        {!signal.patternContext.outcome.showSuccessPercentage ? <div><dt>Success percentage</dt><dd>hidden</dd></div> : null}
+                        {signal.patternContext.refs.loopRunRef ? <div><dt>Run source</dt><dd>{signal.patternContext.refs.loopRunRef}</dd></div> : null}
+                        {signal.patternContext.outcome.proposalRef ? <div><dt>Proposal ref</dt><dd>{signal.patternContext.outcome.proposalRef}</dd></div> : null}
+                        {signal.patternContext.outcome.escalationRef ? <div><dt>Escalation ref</dt><dd>{signal.patternContext.outcome.escalationRef}</dd></div> : null}
+                      </dl>
+                      {signal.patternContext.outcome.evidenceRefs?.length ? <p className="pattern-state-note"><strong>Evidence:</strong> {joinOrUnavailable(signal.patternContext.outcome.evidenceRefs)}</p> : null}
                     </section>
                   ) : null}
                 </>

--- a/apps/mission-control/src/features/resource-observatory/resourceSignalTypes.ts
+++ b/apps/mission-control/src/features/resource-observatory/resourceSignalTypes.ts
@@ -6,12 +6,12 @@ export type SignalGroupId = "capacity" | "efficiency" | "quality";
 export type PatternContext = {
   pattern?: {
     id: string;
-    label: string;
-    vehicle: "skill_execution" | "subagent_execution" | "tool_sequence" | "human_led_required" | "unavailable";
+    label?: string;
+    vehicle: "manual_prompt" | "single_agent" | "orchestrated_workflow" | "loop" | "human_led_workflow" | "unavailable";
     description?: string;
   } | null;
   selection?: {
-    verdict: "selected" | "not_selected" | "unavailable";
+    verdict: "approved" | "approved_with_constraints" | "rejected" | "human_led_required" | "unavailable";
     selectedBy: "aletheia" | "unavailable";
     rationale?: string;
     decisionRef?: string;
@@ -22,6 +22,8 @@ export type PatternContext = {
     declaredBy?: "adaptive_skills" | "project_local_skill_provider" | "runtime_native_skill_provider" | "unavailable";
     skillId?: string;
     skillVersion?: string;
+    conditions?: string;
+    requiredEvidence?: string[];
     rationale?: string;
     declarationRef?: string;
   };
@@ -46,6 +48,7 @@ export type PatternContext = {
     proposalRef?: string;
     escalationRef?: string;
     comparableCaseCount?: number;
+    objectiveSuccessCriteriaRef?: string;
     showSuccessPercentage?: boolean;
   } | null;
   refs: {

--- a/examples/execution-patterns/fixtures/execution-pattern-selection-debugging-loop.json
+++ b/examples/execution-patterns/fixtures/execution-pattern-selection-debugging-loop.json
@@ -1,0 +1,40 @@
+{
+  "task_id": "debugging-loop-s6-fixture",
+  "task": "project source-backed debugging loop context into the read-only Resource Observatory inspector",
+  "work_type": "engineering",
+  "task_shape": {
+    "repeated": true,
+    "decomposable": false,
+    "independent_units": false,
+    "stages_depend_on_previous_output": true,
+    "requires_judgment": "medium",
+    "objective_verification_available": true,
+    "state_required": false
+  },
+  "risk": {
+    "risk_level": "medium",
+    "touches_sensitive_context": false,
+    "external_side_effect": false,
+    "irreversible_action_possible": false
+  },
+  "recommended_vehicle": {
+    "type": "loop",
+    "rationale": "A bounded corrective loop is proportional when a small reproducible failure and focused test are present."
+  },
+  "recommended_pattern": {
+    "type": "loop_until_done",
+    "rationale": "The focused test is the objective stop condition; iteration and budget limits remain mandatory."
+  },
+  "required_controls": {
+    "state_required": false,
+    "objective_gate_required": true,
+    "maker_checker_required": false,
+    "human_review_required": true,
+    "token_budget_required": true,
+    "audit_record_required": true
+  },
+  "decision": {
+    "verdict": "approved_with_constraints",
+    "notes": "Fixture-only selection: maximum three iterations, explicit budget, evidence per iteration and human review before merge."
+  }
+}

--- a/tests/contracts/test-execution-pattern-selection.test.ts
+++ b/tests/contracts/test-execution-pattern-selection.test.ts
@@ -5,18 +5,20 @@ import { validateAgainstSchema, SchemaValidationError } from "../../engine";
 
 const schemasDir = path.resolve(process.cwd(), "schemas");
 const schemaPath = path.join(schemasDir, "execution-pattern-selection.schema.json");
-const fixturePath = path.resolve(
-  process.cwd(),
-  "examples/execution-patterns/fixtures/execution-pattern-selection-ci-triage.json",
-);
+const fixturesDir = path.resolve(process.cwd(), "examples/execution-patterns/fixtures");
 
-function loadFixture(): Record<string, unknown> {
-  return JSON.parse(fs.readFileSync(fixturePath, "utf-8")) as Record<string, unknown>;
+function loadFixture(name = "execution-pattern-selection-ci-triage.json"): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(path.join(fixturesDir, name), "utf-8")) as Record<string, unknown>;
 }
 
 describe("Execution Pattern Selection (per-task declaration)", () => {
   it("validates the realistic CI triage selection against the schema", () => {
     const data = loadFixture();
+    expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
+  });
+
+  it("validates the bounded debugging loop projection fixture", () => {
+    const data = loadFixture("execution-pattern-selection-debugging-loop.json");
     expect(() => validateAgainstSchema(data, schemaPath)).not.toThrow();
   });
 


### PR DESCRIPTION
## What changed
- add a read-only adapter that combines AletheIA pattern selections with Adaptive Skills compatibility declarations
- preserve canonical vehicle and selection-verdict vocabulary
- extend the inspector with compatibility conditions, required evidence, budgets, source refs, and source-backed outcome context
- add compatible, incompatible, unavailable, missing-gate, and analytics-gating tests
- add a schema-valid bounded debugging selection fixture

## Why
S6 needs the Resource Observatory to explain governed execution topology from authoritative records without inferring compatibility or becoming a selection/execution authority.

## How to validate
- `pnpm check:governance`
- `pnpm test` (197 core + 30 Mission Control tests)
- `pnpm --filter @aletheia/mission-control typecheck`
- `pnpm --filter @aletheia/mission-control build`
- `./scripts/check-visual-ops-snapshots.sh`
- `git diff --check`

## Risks, assumptions, follow-ups
- the default feature-planning signal remains honestly unavailable because no canonical compatibility declaration exists
- no new card, page, persistent schema, action, runtime, or loop execution was introduced
- success percentages remain hidden without both five comparable cases and objective criteria
- S7 remains the separate real bounded debugging pilot
- untracked `plans/` remains untouched